### PR TITLE
fixed #42

### DIFF
--- a/sssom/datamodel_util.py
+++ b/sssom/datamodel_util.py
@@ -77,7 +77,7 @@ class MetaTSVConverter:
         :return:
         """
         #self.df = pd.read_csv(filename, sep="\t", comment="#").fillna("")
-        self.df = read_pandas(filename,sep='\t')
+        self.df = read_pandas(filename)
 
 
     def convert(self) -> Dict[str, Any]:
@@ -196,7 +196,7 @@ def read_csv(filename, comment='#', sep=','):
                     if not line.startswith(comment)])
     return pd.read_csv(StringIO(lines), sep=sep)
 
-def read_pandas(filename: str, sep=None) -> pd.DataFrame:
+def read_pandas(filename: str, sep='\t') -> pd.DataFrame:
     """
     wrapper to pd.read_csv that handles comment lines correctly
     :param filename:

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -28,7 +28,7 @@ def parse(filename) -> pd.DataFrame:
     #return from_tsv(filename)
     logging.info(f'Parsing {filename}')
     return pd.read_csv(filename, sep="\t", comment="#")
-    #return read_pandas(filename, sep="\t")
+    #return read_pandas(filename)
 
 def collapse(df):
     """

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -83,12 +83,12 @@ class SSSOMReadWriteTestSuite(unittest.TestCase):
                          f"The pandas data frame has less elements than the orginal one for {test.filename}")
         df.to_csv(test.get_out_file("roundtrip.tsv"), sep="\t")
         #data = pd.read_csv(test.get_out_file("roundtrip.tsv"), sep="\t")
-        data = read_pandas(test.get_out_file("roundtrip.tsv"), sep="\t")
+        data = read_pandas(test.get_out_file("roundtrip.tsv"))
         self.assertEqual(len(data), test.ct_data_frame_rows,
                          f"The re-serialised pandas data frame has less elements than the orginal one for {test.filename}")
         write_tsv(msdf, test.get_out_file("tsv"))
         # self._test_files_equal(test.get_out_file("tsv"), test.get_validate_file("tsv"))
-        df = read_pandas(test.get_out_file("tsv"), sep="\t")
+        df = read_pandas(test.get_out_file("tsv"))
         self.assertEqual(len(df), test.ct_data_frame_rows,
                          f"The exported pandas data frame has less elements than the orginal one for {test.filename}")
 


### PR DESCRIPTION
Made read_pandas have a default '\t' separator.