### PR TITLE
Bugfix: Missing 'validators' install

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ networkx = ">=0.0"
 pandasql = ">=0.0"
 PyYAML = ">=0.0"
 Sphinx = ">=2.3.1"
+validators = ">=0.0"
 
 [dev-packages]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ install_requires =
     pandas
     linkml
     scipy
+    validators
 
 # Random options
 zip_safe = false


### PR DESCRIPTION
Added missing dependency 'validators' to pipfile and setup.cfg. This is currently in requirements.txt and being imported.