### PR TITLE
Keep imports properly sorted with isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+# line-length = 100
+target-version = ['py36', 'py37', 'py38', 'py39']
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3

--- a/sssom/__init__.py
+++ b/sssom/__init__.py
@@ -1,10 +1,10 @@
-from .sssom_datamodel import Mapping, MappingSet  # noqa:401
 from .sssom_datamodel import slots  # noqa:401
+from .sssom_datamodel import Mapping, MappingSet  # noqa:401
 from .util import (  # noqa:401
-    parse,
     collapse,
+    compare_dataframes,
     dataframe_to_ptable,
     filter_redundant_rows,
     group_mappings,
-    compare_dataframes,
+    parse,
 )

--- a/sssom/cli.py
+++ b/sssom/cli.py
@@ -7,9 +7,8 @@ import click
 import pandas as pd
 import yaml
 from pandasql import sqldf
-from scipy.stats import chi2_contingency
-
 from rdflib import Graph
+from scipy.stats import chi2_contingency
 
 from sssom.rdf_util import rewire_graph
 from sssom.sparql_util import EndpointConfig, query_mappings
@@ -20,6 +19,7 @@ from sssom.util import (
     to_mapping_set_dataframe,
 )
 from sssom.writers import write_table
+
 from .cliques import split_into_cliques, summarize_cliques
 from .io import convert_file, parse_file, split_file, validate_file
 from .parsers import read_sssom_table

--- a/sssom/cliques.py
+++ b/sssom/cliques.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from sssom.parsers import to_mapping_set_document
 from sssom.util import MappingSetDataFrame
+
 from .sssom_datamodel import MappingSet
 from .sssom_document import MappingSetDocument
 

--- a/sssom/cliquesummary.py
+++ b/sssom/cliquesummary.py
@@ -7,44 +7,46 @@
 # license: https://creativecommons.org/publicdomain/zero/1.0/
 
 import dataclasses
-import sys
 import re
-from jsonasobj2 import JsonObj, as_dict
-from typing import Optional, List, Union, Dict, ClassVar, Any
+import sys
 from dataclasses import dataclass
+from typing import Any, ClassVar, Dict, List, Optional, Union
+
+from jsonasobj2 import JsonObj, as_dict
 from linkml_runtime.linkml_model.meta import (
     EnumDefinition,
     PermissibleValue,
     PvFormulaOptions,
 )
-
-from linkml_runtime.utils.slot import Slot
-from linkml_runtime.utils.metamodelcore import empty_list, empty_dict, bnode
-from linkml_runtime.utils.yamlutils import (
-    YAMLRoot,
-    extended_str,
-    extended_float,
-    extended_int,
-)
+from linkml_runtime.utils.curienamespace import CurieNamespace
 from linkml_runtime.utils.dataclass_extensions_376 import (
     dataclasses_init_fn_with_kwargs,
 )
-from linkml_runtime.utils.formatutils import camelcase, underscore, sfx
 from linkml_runtime.utils.enumerations import EnumDefinitionImpl
-from rdflib import Namespace, URIRef
-from linkml_runtime.utils.curienamespace import CurieNamespace
+from linkml_runtime.utils.formatutils import camelcase, sfx, underscore
 from linkml_runtime.utils.metamodelcore import (
+    URI,
     Bool,
     Decimal,
     ElementIdentifier,
     NCName,
     NodeIdentifier,
-    URI,
     URIorCURIE,
     XSDDate,
     XSDDateTime,
     XSDTime,
+    bnode,
+    empty_dict,
+    empty_list,
 )
+from linkml_runtime.utils.slot import Slot
+from linkml_runtime.utils.yamlutils import (
+    YAMLRoot,
+    extended_float,
+    extended_int,
+    extended_str,
+)
+from rdflib import Namespace, URIRef
 
 metamodel_version = "1.7.0"
 

--- a/sssom/io.py
+++ b/sssom/io.py
@@ -4,6 +4,7 @@ import os
 import validators
 
 from sssom.util import read_metadata
+
 from .context import get_default_metadata
 from .parsers import get_parsing_function, read_sssom_table, split_dataframe
 from .writers import get_writer_function, write_table, write_tables

--- a/sssom/parsers.py
+++ b/sssom/parsers.py
@@ -2,9 +2,9 @@ import json
 import logging
 import os
 import re
-from typing import Dict, Set, Union, TextIO
+from typing import Dict, Set, TextIO, Union
 from urllib.request import urlopen
-from xml.dom import minidom, Node
+from xml.dom import Node, minidom
 from xml.dom.minidom import Document
 
 import numpy as np
@@ -15,20 +15,17 @@ from linkml_runtime.loaders.json_loader import JSONLoader
 from rdflib import Graph, URIRef
 
 from sssom.util import (
-    read_pandas,
-    NoCURIEException,
-    curie_from_uri,
     SSSOM_DEFAULT_RDF_SERIALISATION,
     URI_SSSOM_MAPPINGS,
+    NoCURIEException,
+    curie_from_uri,
+    read_pandas,
 )
-from .context import get_default_metadata, add_built_in_prefixes_to_prefix_map
-from .sssom_datamodel import MappingSet, Mapping
+
+from .context import add_built_in_prefixes_to_prefix_map, get_default_metadata
+from .sssom_datamodel import Mapping, MappingSet
 from .sssom_document import MappingSetDocument
-from .util import (
-    MappingSetDataFrame,
-    get_file_extension,
-    to_mapping_set_dataframe,
-)
+from .util import MappingSetDataFrame, get_file_extension, to_mapping_set_dataframe
 
 cwd = os.path.abspath(os.path.dirname(__file__))
 

--- a/sssom/sparql_util.py
+++ b/sssom/sparql_util.py
@@ -3,11 +3,11 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 import pandas as pd
-from SPARQLWrapper import SPARQLWrapper, JSON
 from rdflib import URIRef
 
 # noinspection PyProtectedMember
 from rdflib.namespace import RDFS, SKOS
+from SPARQLWrapper import JSON, SPARQLWrapper
 
 from sssom.util import MappingSetDataFrame
 

--- a/sssom/sssom_datamodel.py
+++ b/sssom/sssom_datamodel.py
@@ -7,33 +7,33 @@
 # license: https://creativecommons.org/publicdomain/zero/1.0/
 
 import dataclasses
-import sys
 import re
-from jsonasobj2 import JsonObj, as_dict
-from typing import Optional, List, Union, Dict, ClassVar, Any
+import sys
 from dataclasses import dataclass
+from typing import Any, ClassVar, Dict, List, Optional, Union
+
+from jsonasobj2 import JsonObj, as_dict
 from linkml_runtime.linkml_model.meta import (
     EnumDefinition,
     PermissibleValue,
     PvFormulaOptions,
 )
-
-from linkml_runtime.utils.slot import Slot
-from linkml_runtime.utils.metamodelcore import empty_list, empty_dict, bnode
-from linkml_runtime.utils.yamlutils import (
-    YAMLRoot,
-    extended_str,
-    extended_float,
-    extended_int,
-)
+from linkml_runtime.linkml_model.types import Double, String
+from linkml_runtime.utils.curienamespace import CurieNamespace
 from linkml_runtime.utils.dataclass_extensions_376 import (
     dataclasses_init_fn_with_kwargs,
 )
-from linkml_runtime.utils.formatutils import camelcase, underscore, sfx
 from linkml_runtime.utils.enumerations import EnumDefinitionImpl
+from linkml_runtime.utils.formatutils import camelcase, sfx, underscore
+from linkml_runtime.utils.metamodelcore import bnode, empty_dict, empty_list
+from linkml_runtime.utils.slot import Slot
+from linkml_runtime.utils.yamlutils import (
+    YAMLRoot,
+    extended_float,
+    extended_int,
+    extended_str,
+)
 from rdflib import Namespace, URIRef
-from linkml_runtime.utils.curienamespace import CurieNamespace
-from linkml_runtime.linkml_model.types import Double, String
 
 metamodel_version = "1.7.0"
 

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -5,7 +5,7 @@ import logging
 import re
 import sys
 from dataclasses import dataclass
-from io import StringIO, FileIO
+from io import FileIO, StringIO
 from typing import Any, Dict, List, Optional, Set, Union
 from urllib.request import urlopen
 
@@ -15,6 +15,7 @@ import validators
 import yaml
 
 from sssom.sssom_datamodel import Entity, slots
+
 from .context import get_default_metadata, get_jsonld_context
 from .sssom_document import MappingSetDocument
 

--- a/sssom/writers.py
+++ b/sssom/writers.py
@@ -13,13 +13,14 @@ from rdflib.namespace import OWL, RDF
 from .parsers import to_mapping_set_document
 from .sssom_datamodel import slots
 from .util import (
-    MappingSetDataFrame,
-    prepare_context_from_curie_map,
-    URI_SSSOM_MAPPINGS,
+    RDF_FORMATS,
+    SSSOM_DEFAULT_RDF_SERIALISATION,
     SSSOM_URI_PREFIX,
+    URI_SSSOM_MAPPINGS,
+    MappingSetDataFrame,
+    get_file_extension,
+    prepare_context_from_curie_map,
 )
-from .util import RDF_FORMATS, SSSOM_DEFAULT_RDF_SERIALISATION
-from .util import get_file_extension
 
 # noinspection PyProtectedMember
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 import unittest
+from typing import Dict
 
 from click.testing import CliRunner
-from typing import Dict
 
 from sssom.cli import (
     cliquesummary,
@@ -10,18 +10,18 @@ from sssom.cli import (
     crosstab,
     dedupe,
     diff,
+    parse,
     partition,
     ptable,
-    validate,
     split,
-    parse,
+    validate,
 )
 from tests.test_data import (
+    SSSOMTestCase,
     ensure_test_dir_exists,
     get_all_test_cases,
-    SSSOMTestCase,
-    test_out_dir,
     get_multiple_input_test_cases,
+    test_out_dir,
 )
 
 

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -4,12 +4,12 @@ import unittest
 from pandasql import sqldf
 
 from sssom import (
-    parse,
     collapse,
+    compare_dataframes,
     dataframe_to_ptable,
     filter_redundant_rows,
     group_mappings,
-    compare_dataframes,
+    parse,
 )
 
 cwd = os.path.abspath(os.path.dirname(__file__))

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -8,9 +8,18 @@ from rdflib import Graph
 from sssom.parsers import get_parsing_function, to_mapping_set_document
 from sssom.sssom_document import MappingSetDocument
 from sssom.util import read_pandas, to_mapping_set_dataframe
-from sssom.writers import to_owl_graph, to_rdf_graph, to_dataframe, to_json
-from sssom.writers import write_json, write_rdf, write_owl, write_table
-from .test_data import ensure_test_dir_exists, SSSOMTestCase, get_all_test_cases
+from sssom.writers import (
+    to_dataframe,
+    to_json,
+    to_owl_graph,
+    to_rdf_graph,
+    write_json,
+    write_owl,
+    write_rdf,
+    write_table,
+)
+
+from .test_data import SSSOMTestCase, ensure_test_dir_exists, get_all_test_cases
 
 
 class SSSOMReadWriteTestSuite(unittest.TestCase):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,4 +1,5 @@
 import os
+
 import yaml
 
 cwd = os.path.abspath(os.path.dirname(__file__))

--- a/tests/test_datamodel_util.py
+++ b/tests/test_datamodel_util.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+
 from sssom.util import MetaTSVConverter
 
 cwd = os.path.abspath(os.path.dirname(__file__))

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -9,15 +9,15 @@ from rdflib import Graph
 
 from sssom.context import get_default_metadata
 from sssom.parsers import (
-    read_sssom_table,
+    from_alignment_minidom,
     from_obographs,
     from_sssom_dataframe,
-    from_alignment_minidom,
-    from_sssom_rdf,
     from_sssom_json,
+    from_sssom_rdf,
+    read_sssom_table,
 )
 from sssom.writers import write_table
-from tests.test_data import test_out_dir, test_data_dir
+from tests.test_data import test_data_dir, test_out_dir
 
 cwd = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,11 +1,9 @@
 import os
 import unittest
 
-from sssom import (
-    filter_redundant_rows,
-)
+from sssom import filter_redundant_rows
 from sssom.parsers import read_sssom_table
-from sssom.util import merge_msdf, deal_with_negation
+from sssom.util import deal_with_negation, merge_msdf
 
 # from pandasql import sqldf
 

--- a/tests/test_rewire.py
+++ b/tests/test_rewire.py
@@ -2,8 +2,9 @@ import os
 import unittest
 
 from rdflib import Graph
-from sssom.rdf_util import rewire_graph
+
 from sssom.parsers import read_sssom_table
+from sssom.rdf_util import rewire_graph
 
 cwd = os.path.abspath(os.path.dirname(__file__))
 data_dir = os.path.join(cwd, "data")

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -1,11 +1,11 @@
 import os
 import unittest
 
-from sssom.parsers import read_sssom_table, read_sssom_json, read_sssom_rdf
-from sssom.writers import write_table, write_json, write_rdf, write_owl
+from sssom.parsers import read_sssom_json, read_sssom_rdf, read_sssom_table
+from sssom.writers import write_json, write_owl, write_rdf, write_table
 
 # from pandasql import sqldf
-from tests.test_data import test_out_dir, test_data_dir
+from tests.test_data import test_data_dir, test_out_dir
 
 cwd = os.path.abspath(os.path.dirname(__file__))
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,9 @@ description = Run unit tests with pytest. This is a special environment that doe
 skip_install = true
 commands =
     black sssom/ tests/ setup.py
+    isort sssom/ tests/ setup.py
 deps =
+    isort
     black
 description = Run code formatters and linters.
 
@@ -32,4 +34,5 @@ commands =
 deps =
     flake8
     flake8-black
+    flake8-isort
 description = Run the flake8 code quality checker.


### PR DESCRIPTION
This PR adds the `isort` utility to the `lint` environment in tox as well as the `flake8-isort` plugin to the flake8 quality assurance testing. Since #127 was merged, this means that this check will be run on all PRs. As you can see by the big diff, there's quite a bit of cleanup it already did!

One thing to consider later (not for accepting this PR) is that there is a mix of absolute and relative imports. While I'm definitely going against the grain here, I think that packages should _only_ be using relative imports, to remind you never to rely on being able to run python files in packages as scripts (instead, the solution is to pip install then use `python -m ...`) 