### PR TITLE
Add easy flake8 plugins

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -144,6 +144,9 @@ ignore =
 # Line length
     E501
     W503 # Line break before binary operator (flake8 is wrong)
+    S408 # don't worry about unsafe xml
+    S318 # don't worry about unsafe xml
+    S310 # TODO remove this later and switch to using requests
 exclude =
     sssom/sssom_datamodel.py
     sssom/cliquesummary.py

--- a/sssom/cli.py
+++ b/sssom/cli.py
@@ -564,7 +564,7 @@ def correlations(input: str, output: str, transpose: bool, fields: Tuple):
 
     tups = []
     for i, row in corr.iterrows():
-        for j, v in row.iteritems():
+        for j, v in row.items():
             logging.info(f"{i} x {j} = {v}")
             tups.append((v, i, j))
     tups = sorted(tups, key=lambda tx: tx[0])

--- a/sssom/cliques.py
+++ b/sssom/cliques.py
@@ -128,7 +128,7 @@ def summarize_cliques(doc: MappingSetDataFrame):
             confs.append(m.confidence)
         src2ids = invert_dict(id2src)
         mstr = "|".join(members)
-        md5 = hashlib.md5(mstr.encode("utf-8")).hexdigest()
+        md5 = hashlib.md5(mstr.encode("utf-8")).hexdigest()  # noqa:S303
         item = {
             "id": md5,
             "num_mappings": len(ms),

--- a/sssom/parsers.py
+++ b/sssom/parsers.py
@@ -427,10 +427,10 @@ def from_obographs(
                                 except NoCURIEException as e:
                                     logging.warning(e)
                         if "basicPropertyValues" in n["meta"]:
-                            for basicPropertyBalue in n["meta"]["basicPropertyValues"]:
-                                pred = basicPropertyBalue["pred"]
+                            for value in n["meta"]["basicPropertyValues"]:
+                                pred = value["pred"]
                                 if pred in allowed_properties:
-                                    xref_id = basicPropertyBalue["val"]
+                                    xref_id = value["val"]
                                     mdict = {}
                                     try:
                                         mdict["subject_id"] = curie_from_uri(

--- a/sssom/parsers.py
+++ b/sssom/parsers.py
@@ -49,16 +49,16 @@ def read_sssom_table(
             if meta:
                 for k, v in meta.items():
                     if k in sssom_metadata:
-                        if sssom_metadata[k] != meta[k]:
+                        if sssom_metadata[k] != v:
                             logging.warning(
                                 f"SSSOM internal metadata {k} ({sssom_metadata[k]}) "
                                 f"conflicts with provided ({meta[k]})."
                             )
                     else:
                         logging.info(
-                            f"Externally provided metadata {k}:{meta[k]} is added to metadata set."
+                            f"Externally provided metadata {k}:{v} is added to metadata set."
                         )
-                        sssom_metadata[k] = meta[k]
+                        sssom_metadata[k] = v
             meta = sssom_metadata
 
         curie_map, meta = _get_curie_map_and_metadata(curie_map=curie_map, meta=meta)
@@ -254,7 +254,8 @@ def from_sssom_rdf(
 
     for sx, px, ox in g.triples((None, URIRef(URI_SSSOM_MAPPINGS), None)):
         mdict = {}
-        for s, p, o in g.triples((ox, None, None)):
+        # TODO replace with g.predicate_objects()
+        for _s, p, o in g.triples((ox, None, None)):
             if isinstance(p, URIRef):
                 try:
                     p_id = curie_from_uri(p, curie_map)

--- a/sssom/rdf_util.py
+++ b/sssom/rdf_util.py
@@ -46,7 +46,7 @@ def rewire_graph(
                             rewire_map[src] = tgt
                             logging.info(f"{tgt} has precedence, due to {precedence}")
                 else:
-                    raise Exception(f"Ambiguous: {src} -> {tgt} vs {curr_tgt}")
+                    raise ValueError(f"Ambiguous: {src} -> {tgt} vs {curr_tgt}")
             else:
                 rewire_map[src] = tgt
     rewire_map = {expand_curie(k): expand_curie(v) for k, v in rewire_map.items()}

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -876,7 +876,7 @@ def to_mapping_set_dataframe(doc: MappingSetDocument) -> MappingSetDataFrame:
 # to_mapping_set_document is in parser.py in order to avoid circular import errors
 
 
-class NoCURIEException(Exception):
+class NoCURIEException(ValueError):
     pass
 
 

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -311,7 +311,7 @@ def filter_redundant_rows(df: pd.DataFrame, ignore_predicate=False) -> pd.DataFr
     dfmax: pd.DataFrame
     dfmax = df.groupby(key, as_index=False)[CONFIDENCE].apply(max).drop_duplicates()
     max_conf = {}
-    for index, row in dfmax.iterrows():
+    for _, row in dfmax.iterrows():
         if ignore_predicate:
             max_conf[(row[SUBJECT_ID], row[OBJECT_ID])] = row[CONFIDENCE]
         else:
@@ -663,7 +663,7 @@ def deal_with_negation(df: pd.DataFrame) -> pd.DataFrame:
     # If same confidence prefer "HumanCurated".
     reconciled_df_subset: pd.DataFrame
     reconciled_df_subset = pd.DataFrame(columns=combined_normalized_subset.columns)
-    for idx_1, row_1 in max_confidence_df.iterrows():
+    for _, row_1 in max_confidence_df.iterrows():
         match_condition_1 = (
             (combined_normalized_subset[SUBJECT_ID] == row_1[SUBJECT_ID])
             & (combined_normalized_subset[OBJECT_ID] == row_1[OBJECT_ID])
@@ -693,7 +693,7 @@ def deal_with_negation(df: pd.DataFrame) -> pd.DataFrame:
     # Add negations (NOT symbol) back to the PREDICATE_ID
     # NOTE: negative TRUMPS positive if negative and positive with same
     # [SUBJECT_ID, OBJECT_ID, PREDICATE_ID] exist
-    for idx_2, row_2 in negation_df.iterrows():
+    for _, row_2 in negation_df.iterrows():
         match_condition_2 = (
             (reconciled_df_subset[SUBJECT_ID] == row_2[SUBJECT_ID])
             & (reconciled_df_subset[OBJECT_ID] == row_2[OBJECT_ID])
@@ -706,7 +706,7 @@ def deal_with_negation(df: pd.DataFrame) -> pd.DataFrame:
 
     reconciled_df: pd.DataFrame
     reconciled_df = pd.DataFrame(columns=df.columns)
-    for idx_3, row_3 in reconciled_df_subset.iterrows():
+    for _, row_3 in reconciled_df_subset.iterrows():
         match_condition_3 = (
             (df[SUBJECT_ID] == row_3[SUBJECT_ID])
             & (df[OBJECT_ID] == row_3[OBJECT_ID])
@@ -914,7 +914,7 @@ def get_prefixes_used_in_table(df: pd.DataFrame):
 def filter_out_prefixes(df: pd.DataFrame, filter_prefixes) -> pd.DataFrame:
     rows = []
 
-    for index, row in df.iterrows():
+    for _, row in df.iterrows():
         # Get list of CURIEs from the 3 columns (KEY_FEATURES) for the row.
         prefixes = {get_prefix_from_curie(curie) for curie in row[KEY_FEATURES]}
         # Confirm if none of the 3 CURIEs in the list above appear in the filter_prefixes list.

--- a/sssom/writers.py
+++ b/sssom/writers.py
@@ -268,7 +268,8 @@ def _temporary_as_rdf_graph(element, contexts, namespaces=None) -> Graph:
     for k, v in namespaces.items():
         graph.bind(k, v)
 
-    for s, p, o in graph.triples((None, URIRef(URI_SSSOM_MAPPINGS), None)):
+    # TODO replace with graph.objects()
+    for _s, _p, o in graph.triples((None, URIRef(URI_SSSOM_MAPPINGS), None)):
         graph.add((o, URIRef(RDF_TYPE), OWL.Axiom))
 
     for axiom in graph.subjects(RDF.type, OWL.Axiom):

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -42,7 +42,7 @@ class TestCollapse(unittest.TestCase):
         rows = dataframe_to_ptable(self.df)
         for row in rows[0:10]:
             print("\t".join(row))
-        assert len(rows) == 91
+        self.assertEqual(91, len(rows))
 
     def test_groupings(self):
         mappings = group_mappings(self.df)
@@ -50,15 +50,15 @@ class TestCollapse(unittest.TestCase):
 
     def test_diff(self):
         diff = compare_dataframes(self.df, self.df)
-        assert len(diff.unique_tuples1) == 0
-        assert len(diff.unique_tuples2) == 0
-        assert len(diff.common_tuples) == 91
+        self.assertEqual(0, len(diff.unique_tuples1))
+        self.assertEqual(0, len(diff.unique_tuples2))
+        self.assertEqual(91, len(diff.common_tuples))
         diff_df = diff.combined_dataframe
         # print(len(diff_df.index))
         # print(diff_df[0:20])
-        assert len(diff_df.index) > 100
+        self.assertLess(100, len(diff_df.index))
         for c in diff_df["comment"]:
-            assert c.startswith("COMMON_TO_BOTH")
+            self.assertTrue(c.startswith("COMMON_TO_BOTH"))
         output = sqldf("select * from diff_df where comment != ''")
         print(output)
         # print(diff)
@@ -68,11 +68,11 @@ class TestCollapse(unittest.TestCase):
         # print(len(diff.unique_tuples1))
         # print(len(diff.unique_tuples2))
         # print(len(diff.common_tuples))
-        assert len(diff.unique_tuples1) == 15
-        assert len(diff.unique_tuples2) == 3
-        assert len(diff.common_tuples) == 76
+        self.assertEqual(15, len(diff.unique_tuples1))
+        self.assertEqual(3, len(diff.unique_tuples2))
+        self.assertEqual(76, len(diff.common_tuples))
         # totlen = len(diff.unique_tuples1) + len(diff.unique_tuples2) + len(diff.common_tuples)
-        # assert totlen == len(self.df.index) + len(df2.index)
+        # self.assertEqual(totlen, len(self.df.index) + len(df2.index))
         diff_df = diff.combined_dataframe
         print(len(diff_df.index))
         # print(diff_df[0:10])

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -57,7 +57,7 @@ class SSSOMReadWriteTestSuite(unittest.TestCase):
         self._test_load_graph_size(
             test.get_out_file(file_format),
             test.graph_serialisation,
-            getattr(test, "ct_graph_queries_owl"),
+            test.ct_graph_queries_owl,
         )
         # self._test_files_equal(test.get_out_file(file_format), test.get_validate_file(file_format))
 
@@ -76,7 +76,7 @@ class SSSOMReadWriteTestSuite(unittest.TestCase):
         self._test_load_graph_size(
             test.get_out_file(file_format),
             test.graph_serialisation,
-            getattr(test, "ct_graph_queries_rdf"),
+            test.ct_graph_queries_rdf,
         )
         # self._test_files_equal(test.get_out_file(file_format), test.get_validate_file(file_format))
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -22,7 +22,7 @@ def ensure_test_dir_exists():
 
 def load_config():
     with open(TEST_CONFIG) as file:
-        config = yaml.load(file, Loader=yaml.FullLoader)
+        config = yaml.safe_load(file)
     return config
 
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -45,7 +45,7 @@ class TestParse(unittest.TestCase):
             self.json = json.load(json_file)
 
         with open(f"{test_data_dir}/basic-meta-external.yml") as file:
-            df_meta = yaml.load(file, Loader=yaml.FullLoader)
+            df_meta = yaml.safe_load(file)
             self.df_curie_map = df_meta["curie_map"]
             self.df_meta = df_meta
             self.df_meta.pop("curie_map", None)

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -23,11 +23,11 @@ class TestReconcile(unittest.TestCase):
     def test_filter(self):
         df = filter_redundant_rows(self.msdf.df)
         print(df[0:20])
-        assert len(df.index) == 10
+        self.assertEqual(10, len(df.index))
 
     def test_deal_with_negation(self):
         df = deal_with_negation(self.msdf.df)
-        assert len(df.index) == 7
+        self.assertEqual(7, len(df.index))
 
     def test_merge(self):
         msdf1 = read_sssom_table(f"{data_dir}/basic.tsv")
@@ -35,7 +35,7 @@ class TestReconcile(unittest.TestCase):
 
         merged_msdf = merge_msdf(msdf1=msdf1, msdf2=msdf2)
 
-        assert len(merged_msdf.df) == 95
+        self.assertEqual(95, len(merged_msdf.df))
 
     def test_merge_no_reconcile(self):
         msdf1 = read_sssom_table(f"{data_dir}/basic4.tsv")
@@ -43,6 +43,6 @@ class TestReconcile(unittest.TestCase):
 
         merged_msdf = merge_msdf(msdf1=msdf1, msdf2=msdf2, reconcile=False)
 
-        assert len(msdf1.df) == 53
-        assert len(msdf2.df) == 53
-        assert len(merged_msdf.df) == (len(msdf1.df) + len(msdf2.df))
+        self.assertEqual(53, len(msdf1.df))
+        self.assertEqual(53, len(msdf2.df))
+        self.assertEqual(len(merged_msdf.df), (len(msdf1.df) + len(msdf2.df)))

--- a/tests/test_rewire.py
+++ b/tests/test_rewire.py
@@ -23,13 +23,10 @@ class TestRewire(unittest.TestCase):
         self.graph = g
 
     def test_rewire(self):
-        expected_exception = False
-        try:
-            rewire_graph(self.graph, self.mset)
-        except Exception:
+        with self.assertRaises(Exception):
             # we expect this to fail due to PR/CHEBI ambiguity
-            expected_exception = True
-        assert expected_exception
+            rewire_graph(self.graph, self.mset)
+
         n = rewire_graph(self.graph, self.mset, precedence=["PR"])
         print(f"Num changed = {n}")
         with open(f"{test_out_dir}/rewired-cob.ttl", "w") as stream:

--- a/tests/test_rewire.py
+++ b/tests/test_rewire.py
@@ -23,7 +23,7 @@ class TestRewire(unittest.TestCase):
         self.graph = g
 
     def test_rewire(self):
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             # we expect this to fail due to PR/CHEBI ambiguity
             rewire_graph(self.graph, self.mset)
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,4 +32,5 @@ commands =
 deps =
     flake8
     flake8-black
+    pep8-naming
 description = Run the flake8 code quality checker.

--- a/tox.ini
+++ b/tox.ini
@@ -32,5 +32,6 @@ commands =
 deps =
     flake8
     flake8-black
+    flake8-colors
     pep8-naming
 description = Run the flake8 code quality checker.

--- a/tox.ini
+++ b/tox.ini
@@ -37,5 +37,6 @@ deps =
     flake8-colors
     flake8-bandit
     pep8-naming
+    flake8-bugbear
     flake8-isort
 description = Run the flake8 code quality checker.

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ deps =
     flake8
     flake8-black
     flake8-colors
+    flake8-bandit
     pep8-naming
     flake8-isort
 description = Run the flake8 code quality checker.


### PR DESCRIPTION
This PR adds some easy to comply with flake8 plugins.

- [x] pep8-naming (93c773e)
- [x] flake8-colors (d526d10)
- [x] flake8-bugbear (c1f39e4; or common mistakes that could lead to bugs)
- [x] flake8-bandit (9c373b8; for security stuff)