### PR TITLE
Fix RDF bugs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ##########################
 [metadata]
 name = sssom
-version = 0.2
+version = 0.3.1
 description = Operations on SSSOM mapping tables
 long_description = file: README.rst
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -13,6 +13,7 @@ data_dir = os.path.join(cwd, "data")
 class TestConvert(unittest.TestCase):
     def setUp(self) -> None:
         self.msdf = read_sssom_table(f"{data_dir}/basic.tsv")
+        self.cob = read_sssom_table(f"{data_dir}/cob-to-external.tsv")
 
     def test_df(self):
         df = self.msdf.df
@@ -32,6 +33,18 @@ class TestConvert(unittest.TestCase):
         )
         size = len(results)
         self.assertEqual(size, 90)
+
+    def test_cob_to_owl(self):
+        g = to_owl_graph(self.cob)
+        results = g.query(
+            """SELECT DISTINCT ?e1 ?e2
+                WHERE {
+                  ?e1 <http://www.w3.org/2002/07/owl#equivalentClass> ?e2 .
+                }"""
+        )
+        # g.serialize(destination="tmp/cob-external-test.owl", format="turtle")
+        size = len(results)
+        self.assertEqual(size, 61)
 
     def test_to_rdf(self):
         g = to_rdf_graph(self.msdf)


### PR DESCRIPTION
The context is ignored by the RDFDumper().as_rdf_graph() method - moving back to the as_json_obj() method in the yaml utils.