### PR TITLE
Add better exception when directory does not exist

### DIFF
--- a/sssom/io.py
+++ b/sssom/io.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pathlib
 
 import validators
 
@@ -12,7 +13,7 @@ from .writers import get_writer_function, write_table, write_tables
 cwd = os.path.abspath(os.path.dirname(__file__))
 
 
-def convert_file(input_path: str, output_path: str, output_format: str = None):
+def convert_file(input_path: str, output_path: str = None, output_format: str = None):
     """
 
     Args:
@@ -23,7 +24,9 @@ def convert_file(input_path: str, output_path: str, output_format: str = None):
     Returns:
 
     """
-    if not os.path.exists(os.path.dirname(output_path)):
+    if isinstance(output_path, (str, pathlib.Path)) and not os.path.exists(
+        os.path.dirname(output_path)
+    ):
         raise ValueError(f"Directory for output file does not exist: {output_path}")
     if validators.url(input_path) or os.path.exists(input_path):
         doc = read_sssom_table(input_path)

--- a/sssom/io.py
+++ b/sssom/io.py
@@ -12,7 +12,7 @@ from .writers import get_writer_function, write_table, write_tables
 cwd = os.path.abspath(os.path.dirname(__file__))
 
 
-def convert_file(input_path: str, output_path: str = None, output_format: str = None):
+def convert_file(input_path: str, output_path: str, output_format: str = None):
     """
 
     Args:
@@ -23,6 +23,8 @@ def convert_file(input_path: str, output_path: str = None, output_format: str = 
     Returns:
 
     """
+    if not os.path.exists(os.path.dirname(output_path)):
+        raise ValueError(f"Directory for output file does not exist: {output_path}")
     if validators.url(input_path) or os.path.exists(input_path):
         doc = read_sssom_table(input_path)
         write_func, fileformat = get_writer_function(output_format, output_path)


### PR DESCRIPTION
This PR does two things:

1. It removes the default none value for `convert_file()`. This didn't make any sense, as all usages of it always had strings
2. Gets the directory from the output file path and checks that it exists. If it doesn't, throw a meaningful exception with a more helpful message.

This should provide a more useful error message than what I encountered in https://github.com/OBOFoundry/COB/issues/176#issuecomment-917671960