### PR TITLE
Improve file handling

### DIFF
--- a/sssom/cli.py
+++ b/sssom/cli.py
@@ -127,14 +127,14 @@ def convert(input: str, output: TextIO, output_format: str):
     required=True,
     help="If True (default), records with unknown prefixes are removed from the SSSOM file.",
 )
-@output_option
+@improved_output_option
 def parse(
     input: str,
     input_format: str,
     metadata: str,
     curie_map_mode: str,
     clean_prefixes: bool,
-    output: str,
+    output: TextIO,
 ):
     """Parses a file in one of the supported formats (such as obographs) into an SSSOM TSV file.
 
@@ -154,7 +154,7 @@ def parse(
 
     parse_file(
         input_path=input,
-        output_path=output,
+        output=output,
         input_format=input_format,
         metadata_path=metadata,
         curie_map_mode=curie_map_mode,

--- a/sssom/cli.py
+++ b/sssom/cli.py
@@ -1,7 +1,8 @@
 import logging
 import re
+import sys
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, TextIO, Tuple
 
 import click
 import pandas as pd
@@ -83,26 +84,21 @@ def main(verbose: int, quiet: bool):
 
 @main.command()
 @input_argument
-@output_option
+@click.option(
+    "-o",
+    "--output",
+    help="Output file, e.g. a SSSOM tsv file.",
+    type=click.File(mode="w"),
+    default=sys.stdout,
+)
 @output_format_option
-def convert(input: str, output: str, output_format: str):
+def convert(input: str, output: TextIO, output_format: str):
     """Convert file (currently only supports conversion to RDF)
 
     Example:
         sssom covert --input my.sssom.tsv --output-format rdfxml --output my.sssom.owl
-
-    Args:
-
-        input (str): The path to the input SSSOM tsv file
-        output (str): The path to the output file.
-        output_format (str): The format to which the the SSSOM TSV should be converted.
-
-    Returns:
-
-        None.
-
     """
-    convert_file(input_path=input, output_path=output, output_format=output_format)
+    convert_file(input_path=input, output=output, output_format=output_format)
 
 
 # Input and metadata would be files (file paths). Check if exists.

--- a/sssom/io.py
+++ b/sssom/io.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Optional, TextIO
 
 from .context import get_default_metadata
 from .parsers import get_parsing_function, read_sssom_table, split_dataframe
@@ -9,22 +9,22 @@ from .writers import get_writer_function, write_table, write_tables
 
 def convert_file(
     input_path: str,
-    output_path: Optional[str] = None,
+    output: TextIO,
     output_format: Optional[str] = None,
 ) -> None:
     """Convert a file.
 
     Args:
         input_path: The path to the input SSSOM tsv file
-        output_path: The path to the output file. If none is given, will default to using stdout.
+        output: The path to the output file. If none is given, will default to using stdout.
         output_format: The format to which the the SSSOM TSV should be converted.
     """
     raise_for_bad_path(input_path)
     doc = read_sssom_table(input_path)
     write_func, fileformat = get_writer_function(
-        output_format=output_format, output=output_path
+        output_format=output_format, output=output
     )
-    write_func(doc, output_path, serialisation=fileformat)
+    write_func(doc, output, serialisation=fileformat)
 
 
 def parse_file(

--- a/sssom/io.py
+++ b/sssom/io.py
@@ -29,7 +29,7 @@ def convert_file(
 
 def parse_file(
     input_path: str,
-    output_path: Optional[str] = None,
+    output: TextIO,
     input_format: Optional[str] = None,
     metadata_path: Optional[str] = None,
     curie_map_mode: Optional[str] = None,
@@ -39,7 +39,7 @@ def parse_file(
 
     Args:
         input_path: The path to the input file in one of the legal formats, eg obographs, aligmentapi-xml
-        output_path: The path to the output file.
+        output: The path to the output file.
         input_format: The string denoting the input format.
         metadata_path: The path to a file containing the sssom metadata (including curie_map)
             to be used during parse.
@@ -56,7 +56,7 @@ def parse_file(
     if clean_prefixes:
         # We do this because we got a lot of prefixes from the default SSSOM prefixes!
         doc.clean_prefix_map()
-    write_table(doc, output_path)
+    write_table(doc, output)
 
 
 def validate_file(input_path: str) -> bool:

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -1,10 +1,8 @@
-import contextlib
 import hashlib
 import json
 import logging
 import os
 import re
-import sys
 from dataclasses import dataclass
 from io import FileIO, StringIO
 from typing import Any, Dict, List, Mapping, Optional, Set, TextIO, Union
@@ -437,21 +435,6 @@ def compare_dataframes(df1: pd.DataFrame, df2: pd.DataFrame) -> MappingSetDiff:
     #    r['other'] = 'synthesized sssom file'
     d.combined_dataframe = pd.DataFrame(rows)
     return d
-
-
-@contextlib.contextmanager
-def smart_open(filename=None):
-    # https://stackoverflow.com/questions/17602878/how-to-handle-both-with-open-and-sys-stdout-nicely
-    if filename and filename != "-":
-        fh = open(filename, "w")
-    else:
-        fh = sys.stdout
-
-    try:
-        yield fh
-    finally:
-        if fh is not sys.stdout:
-            fh.close()
 
 
 def dataframe_to_ptable(df: pd.DataFrame, priors=None, inverse_factor: float = 0.5):

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -7,7 +7,7 @@ import re
 import sys
 from dataclasses import dataclass
 from io import FileIO, StringIO
-from typing import Any, Dict, List, Mapping, Optional, Set, Union
+from typing import Any, Dict, List, Mapping, Optional, Set, TextIO, Union
 from urllib.request import urlopen
 
 import numpy as np
@@ -784,7 +784,8 @@ def inject_metadata_into_df(msdf: MappingSetDataFrame) -> MappingSetDataFrame:
     return msdf
 
 
-def get_file_extension(filename: str) -> str:
+def get_file_extension(file: TextIO) -> str:
+    filename = file.name
     parts = filename.split(".")
     if len(parts) > 0:
         f_format = parts[-1]

--- a/sssom/writers.py
+++ b/sssom/writers.py
@@ -1,8 +1,7 @@
 import json
 import logging
 import os
-import sys
-from typing import Optional
+from typing import Callable, Optional, TextIO, Tuple, Union
 
 import pandas as pd
 import yaml
@@ -38,8 +37,10 @@ SSSOM_NS = SSSOM_URI_PREFIX
 
 # Writers
 
+MSDFWriter = Callable[[MappingSetDataFrame, TextIO], None]
 
-def write_table(msdf: MappingSetDataFrame, filename: str, serialisation="tsv") -> None:
+
+def write_table(msdf: MappingSetDataFrame, file: TextIO, serialisation="tsv") -> None:
     """
     dataframe 2 tsv
     """
@@ -59,23 +60,13 @@ def write_table(msdf: MappingSetDataFrame, filename: str, serialisation="tsv") -
     lines = [f"# {line}" for line in lines if line != ""]
     s = msdf.df.to_csv(sep=sep, index=False)
     lines = lines + [s]
-
-    if filename and filename != "-":
-        if os.path.isfile(filename):
-            os.remove(filename)
-        f = open(filename, "a")
-        for line in lines:
-            f.write(line + "\n")
-        f.close()
-    else:
-        # stdout the result for now
-        for line in lines:
-            sys.stdout.write("#" + line + "\n")
+    for line in lines:
+        print(line, file=file)
 
 
 def write_rdf(
     msdf: MappingSetDataFrame,
-    filename: str,
+    filename: Union[None, str, TextIO],
     serialisation: Optional[str] = None,
 ) -> None:
     """
@@ -94,7 +85,7 @@ def write_rdf(
     graph.serialize(filename, format=serialisation)
 
 
-def write_json(msdf: MappingSetDataFrame, filename: str, serialisation="json") -> None:
+def write_json(msdf: MappingSetDataFrame, output: TextIO, serialisation="json") -> None:
     """
     dataframe 2 tsv
     """
@@ -103,8 +94,7 @@ def write_json(msdf: MappingSetDataFrame, filename: str, serialisation="json") -
         # doc = to_mapping_set_document(msdf)
         # context = prepare_context_from_curie_map(doc.curie_map)
         # data = JSONDumper().dumps(doc.mapping_set, contexts=context)
-        with open(filename, "w") as outfile:
-            json.dump(data, outfile, indent="  ")
+        json.dump(data, output, indent=2)
 
     else:
         raise ValueError(
@@ -114,7 +104,7 @@ def write_json(msdf: MappingSetDataFrame, filename: str, serialisation="json") -
 
 def write_owl(
     msdf: MappingSetDataFrame,
-    filename: str,
+    output: TextIO,
     serialisation=SSSOM_DEFAULT_RDF_SERIALISATION,
 ) -> None:
     if serialisation not in RDF_FORMATS:
@@ -125,7 +115,7 @@ def write_owl(
         serialisation = SSSOM_DEFAULT_RDF_SERIALISATION
 
     graph = to_owl_graph(msdf)
-    graph.serialize(destination=filename, format=serialisation)
+    graph.serialize(destination=output, format=serialisation)
 
 
 # Converters
@@ -328,7 +318,9 @@ def to_json(msdf: MappingSetDataFrame) -> JsonObj:
 # Support methods
 
 
-def get_writer_function(*, output_format: Optional[str] = None, output: str):
+def get_writer_function(
+    *, output_format: Optional[str] = None, output: TextIO
+) -> Tuple[MSDFWriter, str]:
     if output_format is None:
         output_format = get_file_extension(output)
 

--- a/sssom/writers.py
+++ b/sssom/writers.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from typing import Callable, Optional, TextIO, Tuple, Union
+from typing import BinaryIO, Callable, Optional, TextIO, Tuple, Union
 
 import pandas as pd
 import yaml
@@ -34,7 +34,6 @@ OWL_EQUIV_CLASS = "http://www.w3.org/2002/07/owl#equivalentClass"
 OWL_EQUIV_OBJECTPROPERTY = "http://www.w3.org/2002/07/owl#equivalentProperty"
 SSSOM_NS = SSSOM_URI_PREFIX
 
-
 # Writers
 
 MSDFWriter = Callable[[MappingSetDataFrame, TextIO], None]
@@ -66,7 +65,7 @@ def write_table(msdf: MappingSetDataFrame, file: TextIO, serialisation="tsv") ->
 
 def write_rdf(
     msdf: MappingSetDataFrame,
-    filename: Union[None, str, TextIO],
+    file: TextIO,
     serialisation: Optional[str] = None,
 ) -> None:
     """
@@ -82,7 +81,8 @@ def write_rdf(
         serialisation = SSSOM_DEFAULT_RDF_SERIALISATION
 
     graph = to_rdf_graph(msdf=msdf)
-    graph.serialize(filename, format=serialisation)
+    t = graph.serialize(format=serialisation, encoding="utf-8")
+    print(t.decode("utf-8"), file=file)
 
 
 def write_json(msdf: MappingSetDataFrame, output: TextIO, serialisation="json") -> None:
@@ -104,7 +104,7 @@ def write_json(msdf: MappingSetDataFrame, output: TextIO, serialisation="json") 
 
 def write_owl(
     msdf: MappingSetDataFrame,
-    output: TextIO,
+    file: TextIO,
     serialisation=SSSOM_DEFAULT_RDF_SERIALISATION,
 ) -> None:
     if serialisation not in RDF_FORMATS:
@@ -115,7 +115,8 @@ def write_owl(
         serialisation = SSSOM_DEFAULT_RDF_SERIALISATION
 
     graph = to_owl_graph(msdf)
-    graph.serialize(destination=output, format=serialisation)
+    t = graph.serialize(format=serialisation, encoding="utf-8")
+    print(t.decode("utf-8"), file=file)
 
 
 # Converters
@@ -291,7 +292,6 @@ def _temporary_as_rdf_graph(element, contexts, namespaces=None) -> Graph:
 
 
 def _tmp_as_rdf_graph(graph, jsonobj):
-
     return graph
 
     # for m in doc.mapping_set.mappings:

--- a/sssom/writers.py
+++ b/sssom/writers.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from typing import BinaryIO, Callable, Optional, TextIO, Tuple, Union
+from typing import Callable, Optional, TextIO, Tuple
 
 import pandas as pd
 import yaml
@@ -339,11 +339,11 @@ def get_writer_function(
 
 
 def write_tables(sssom_dict, output_dir) -> None:
-    for split_id in sssom_dict:
-        sssom_file = os.path.join(output_dir, f"{split_id}.sssom.tsv")
-        msdf = sssom_dict[split_id]
-        write_table(msdf=msdf, filename=sssom_file)
-        logging.info(f"Writing {sssom_file} complete!")
+    for split_id, msdf in sssom_dict.items():
+        path = os.path.join(output_dir, f"{split_id}.sssom.tsv")
+        with open(path, "w") as file:
+            write_table(msdf, file)
+        logging.info(f"Writing {path} complete!")
 
 
 def _inject_annotation_properties(graph: Graph, elements) -> None:

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -53,9 +53,11 @@ class SSSOMReadWriteTestSuite(unittest.TestCase):
         g = to_owl_graph(msdf)
         file_format = "owl"
         self._test_graph_roundtrip(g, test, file_format)
-        write_owl(msdf, test.get_out_file(file_format), test.graph_serialisation)
+        path = test.get_out_file(file_format)
+        with open(path, "w") as file:
+            write_owl(msdf, file, test.graph_serialisation)
         self._test_load_graph_size(
-            test.get_out_file(file_format),
+            path,
             test.graph_serialisation,
             test.ct_graph_queries_owl,
         )
@@ -72,9 +74,11 @@ class SSSOMReadWriteTestSuite(unittest.TestCase):
         g = to_rdf_graph(msdf)
         file_format = "rdf"
         self._test_graph_roundtrip(g, test, file_format)
-        write_rdf(msdf, test.get_out_file(file_format), test.graph_serialisation)
+        path = test.get_out_file(file_format)
+        with open(path, "w") as file:
+            write_rdf(msdf, file, test.graph_serialisation)
         self._test_load_graph_size(
-            test.get_out_file(file_format),
+            path,
             test.graph_serialisation,
             test.ct_graph_queries_rdf,
         )
@@ -124,9 +128,11 @@ class SSSOMReadWriteTestSuite(unittest.TestCase):
             test.ct_data_frame_rows,
             f"The re-serialised pandas data frame has less elements than the orginal one for {test.filename}",
         )
-        write_table(msdf, test.get_out_file("tsv"))
+        path = test.get_out_file("tsv")
+        with open(path, "w") as file:
+            write_table(msdf, file)
         # self._test_files_equal(test.get_out_file("tsv"), test.get_validate_file("tsv"))
-        df = read_pandas(test.get_out_file("tsv"))
+        df = read_pandas(path)
         self.assertEqual(
             len(df),
             test.ct_data_frame_rows,
@@ -161,8 +167,10 @@ class SSSOMReadWriteTestSuite(unittest.TestCase):
             test.ct_json_elements,
             f"The re-serialised JSON file has less elements than the orginal one for {test.filename}",
         )
-        write_json(msdf, test.get_out_file("jsonld"))
-        with open(test.get_out_file("jsonld")) as json_file:
+        path = test.get_out_file("jsonld")
+        with open(path, "w") as file:
+            write_json(msdf, file)
+        with open(path) as json_file:
             data = json.load(json_file)
         # self._test_files_equal(test.get_out_file("json"), test.get_validate_file("json"))
         self.assertEqual(

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -68,9 +68,9 @@ class TestParse(unittest.TestCase):
 
     def test_parse_sssom_dataframe_url(self):
         msdf = read_sssom_table(self.df_url)
-        write_table(
-            msdf, os.path.join(test_out_dir, "test_parse_sssom_dataframe_url.tsv")
-        )
+        output_path = os.path.join(test_out_dir, "test_parse_sssom_dataframe_url.tsv")
+        with open(output_path, "w") as file:
+            write_table(msdf, file)
         self.assertEqual(
             len(msdf.df),
             141,
@@ -81,7 +81,9 @@ class TestParse(unittest.TestCase):
         msdf = from_obographs(
             jsondoc=self.obographs, curie_map=self.curie_map, meta=self.metadata
         )
-        write_table(msdf, os.path.join(test_out_dir, "test_parse_obographs.tsv"))
+        path = os.path.join(test_out_dir, "test_parse_obographs.tsv")
+        with open(path, "w") as file:
+            write_table(msdf, file)
         self.assertEqual(
             len(msdf.df),
             9941,
@@ -92,7 +94,9 @@ class TestParse(unittest.TestCase):
         msdf = from_sssom_dataframe(
             df=self.df, curie_map=self.df_curie_map, meta=self.df_meta
         )
-        write_table(msdf, os.path.join(test_out_dir, "test_parse_tsv.tsv"))
+        path = os.path.join(test_out_dir, "test_parse_tsv.tsv")
+        with open(path, "w") as file:
+            write_table(msdf, file)
         self.assertEqual(
             len(msdf.df),
             141,
@@ -103,9 +107,9 @@ class TestParse(unittest.TestCase):
         msdf = from_alignment_minidom(
             dom=self.alignmentxml, curie_map=self.curie_map, meta=self.metadata
         )
-        write_table(
-            msdf, os.path.join(test_out_dir, "test_parse_alignment_minidom.tsv")
-        )
+        path = os.path.join(test_out_dir, "test_parse_alignment_minidom.tsv")
+        with open(path, "w") as file:
+            write_table(msdf, file)
         self.assertEqual(
             len(msdf.df),
             646,
@@ -116,7 +120,9 @@ class TestParse(unittest.TestCase):
         msdf = from_sssom_rdf(
             g=self.rdf_graph, curie_map=self.df_curie_map, meta=self.metadata
         )
-        write_table(msdf, os.path.join(test_out_dir, "test_parse_sssom_rdf.tsv"))
+        path = os.path.join(test_out_dir, "test_parse_sssom_rdf.tsv")
+        with open(path, "w") as file:
+            write_table(msdf, file)
         self.assertEqual(
             len(msdf.df),
             136,
@@ -127,7 +133,9 @@ class TestParse(unittest.TestCase):
         msdf = from_sssom_json(
             jsondoc=self.json, curie_map=self.df_curie_map, meta=self.metadata
         )
-        write_table(msdf, os.path.join(test_out_dir, "test_parse_sssom_json.tsv"))
+        path = os.path.join(test_out_dir, "test_parse_sssom_json.tsv")
+        with open(path, "w") as file:
+            write_table(msdf, file)
         self.assertEqual(
             len(msdf.df),
             141,

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -55,13 +55,15 @@ class TestParse(unittest.TestCase):
         self.metadata, self.curie_map = get_default_metadata()
 
     def test_parse_sssom_dataframe(self):
-        file = f"{test_data_dir}/basic.tsv"
-        msdf = read_sssom_table(file)
-        write_table(msdf, os.path.join(test_out_dir, "test_parse_sssom_dataframe.tsv"))
+        input_path = f"{test_data_dir}/basic.tsv"
+        msdf = read_sssom_table(input_path)
+        output_path = os.path.join(test_out_dir, "test_parse_sssom_dataframe.tsv")
+        with open(output_path, "w") as file:
+            write_table(msdf, file)
         self.assertEqual(
             len(msdf.df),
             141,
-            f"{file} has the wrong number of mappings.",
+            f"{input_path} has the wrong number of mappings.",
         )
 
     def test_parse_sssom_dataframe_url(self):

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -3,11 +3,7 @@ import unittest
 
 from sssom.parsers import read_sssom_json, read_sssom_rdf, read_sssom_table
 from sssom.writers import write_json, write_owl, write_rdf, write_table
-
-# from pandasql import sqldf
 from tests.test_data import test_data_dir, test_out_dir
-
-cwd = os.path.abspath(os.path.dirname(__file__))
 
 
 class TestWrite(unittest.TestCase):
@@ -19,9 +15,10 @@ class TestWrite(unittest.TestCase):
         self.mapping_count = 141  # 141 for basic.tsv
 
     def test_write_sssom_dataframe(self):
-        tmp_file = os.path.join(test_out_dir, "test_write_sssom_dataframe.tsv")
-        write_table(self.msdf, tmp_file)
-        msdf = read_sssom_table(tmp_file)
+        tmp_path = os.path.join(test_out_dir, "test_write_sssom_dataframe.tsv")
+        with open(tmp_path, "w") as tmp_file:
+            write_table(self.msdf, tmp_file)
+        msdf = read_sssom_table(tmp_path)
         self.assertEqual(
             len(msdf.df),
             self.mapping_count,
@@ -29,29 +26,36 @@ class TestWrite(unittest.TestCase):
         )
 
     def test_write_sssom_rdf(self):
-        tmp_file = os.path.join(test_out_dir, "test_write_sssom_rdf.rdf")
-        write_rdf(self.msdf, tmp_file)
-        msdf = read_sssom_rdf(tmp_file, self.msdf.prefixmap)
-        write_table(
-            self.msdf, os.path.join(test_out_dir, "test_write_sssom_rdf.rdf.tsv")
-        )
+        path_1 = os.path.join(test_out_dir, "test_write_sssom_rdf.rdf")
+        with open(path_1, "w") as file:
+            write_rdf(self.msdf, file)
+        msdf = read_sssom_rdf(path_1, self.msdf.prefixmap)
         self.assertEqual(
             len(msdf.df),
             self.mapping_count,
-            f"{tmp_file} has the wrong number of mappings.",
+            f"{path_1} has the wrong number of mappings.",
         )
 
+        # TODO this test doesn't make sense
+        path_2 = os.path.join(test_out_dir, "test_write_sssom_rdf.rdf.tsv")
+        with open(path_2, "w") as file:
+            write_table(self.msdf, file)
+
     def test_write_sssom_json(self):
-        tmp_file = os.path.join(test_out_dir, "test_write_sssom_json.json")
-        write_json(self.msdf, tmp_file)
-        msdf = read_sssom_json(tmp_file)
+        path = os.path.join(test_out_dir, "test_write_sssom_json.json")
+        with open(path, "w") as file:
+            write_json(self.msdf, file)
+        msdf = read_sssom_json(path)
         self.assertEqual(
             len(msdf.df),
             self.mapping_count,
-            f"{tmp_file} has the wrong number of mappings.",
+            f"{path} has the wrong number of mappings.",
         )
 
     def test_write_sssom_owl(self):
         tmp_file = os.path.join(test_out_dir, "test_write_sssom_owl.owl")
-        write_owl(self.msdf, tmp_file)
+        with open(tmp_file, "w") as file:
+            write_owl(self.msdf, file)
+        # FIXME this test doesn't test anything
+        # TODO implement "read_owl" function
         self.assertEqual(1, 1)


### PR DESCRIPTION
The lesson learned for this PR is that you should split the functionality of opening files from the functionality that reads/writes them. Now, the CLI takes care of opening files for read and write, and the functions in the package are only responsible for interacting with files (and not paths).

This is better because click already gives you tools for making nice unix-like CLIs (e.g., give dash and it sends to standard out). It's also better because it makes the code generic to people who might have file-like objects or other sneaky files that are gzipped.

I'm not sure if RDFlib is supporting this out of the box, so I hope there are tests for the code that I touched.