### PR TITLE
Normalize usage to prefix_map

### DIFF
--- a/sssom/cli.py
+++ b/sssom/cli.py
@@ -58,7 +58,7 @@ metadata_option = click.option(
     "--metadata",
     required=False,
     type=click.Path(),
-    help="The path to a file containing the sssom metadata (including curie_map) to be used.",
+    help="The path to a file containing the sssom metadata (including prefix_map) to be used.",
 )
 transpose_option = click.option("-t", "--transpose/--no-transpose", default=False)
 fields_option = click.option(
@@ -105,15 +105,15 @@ def convert(input: str, output: TextIO, output_format: str):
 @metadata_option
 @click.option(
     "-C",
-    "--curie-map-mode",
+    "--prefix-map-mode",
     default="metadata_only",
     show_default=True,
     required=True,
     type=click.Choice(
         ["metadata_only", "sssom_default_only", "merged"], case_sensitive=False
     ),
-    help="Defines wether the curie map in the metadata should be extended or replaced with "
-    "the SSSOM default curie map. Must be one of metadata_only, sssom_default_only, merged",
+    help="Defines wether the prefix map in the metadata should be extended or replaced with "
+    "the SSSOM default prefix map. Must be one of metadata_only, sssom_default_only, merged",
 )
 @click.option(
     "-p",
@@ -128,7 +128,7 @@ def parse(
     input: str,
     input_format: str,
     metadata: str,
-    curie_map_mode: str,
+    prefix_map_mode: str,
     clean_prefixes: bool,
     output: TextIO,
 ):
@@ -138,8 +138,8 @@ def parse(
 
         input (str): The path to the input file in one of the legal formats, eg obographs, aligmentapi-xml
         input_format (str): The string denoting the input format.
-        metadata (str): The path to a file containing the sssom metadata (including curie_map) to be used during parse.
-        curie_map_mode (str): Curie map mode.
+        metadata (str): The path to a file containing the sssom metadata (including prefix_map) to be used during parse.
+        prefix_map_mode (str): Curie map mode.
         clean_prefixes (bool): If True (default), records with unknown prefixes are removed from the SSSOM file.
         output (str): The path to the SSSOM TSV output file.
 
@@ -153,7 +153,7 @@ def parse(
         output=output,
         input_format=input_format,
         metadata_path=metadata,
-        curie_map_mode=curie_map_mode,
+        prefix_map_mode=prefix_map_mode,
         clean_prefixes=clean_prefixes,
     )
 
@@ -243,7 +243,7 @@ def dedupe(input: str, output: TextIO):
     msdf = read_sssom_table(input)
     df = filter_redundant_rows(msdf.df)
     msdf_out = MappingSetDataFrame(
-        df=df, prefixmap=msdf.prefixmap, metadata=msdf.metadata
+        df=df, prefix_map=msdf.prefix_map, metadata=msdf.metadata
     )
     # df.to_csv(output, sep="\t", index=False)
     write_table(msdf_out, output)
@@ -328,10 +328,10 @@ def sparql(
     if object_labels is not None:
         endpoint.include_object_labels = object_labels
     if prefix is not None:
-        if endpoint.curie_map is None:
-            endpoint.curie_map = {}
+        if endpoint.prefix_map is None:
+            endpoint.prefix_map = {}
         for k, v in prefix:
-            endpoint.curie_map[k] = v
+            endpoint.prefix_map[k] = v
     msdf = query_mappings(endpoint)
     write_table(msdf, output)
 

--- a/sssom/cli.py
+++ b/sssom/cli.py
@@ -105,7 +105,7 @@ def convert(input: str, output: TextIO, output_format: str):
 @metadata_option
 @click.option(
     "-C",
-    "--prefix-map-mode",
+    "--mode",
     default="metadata_only",
     show_default=True,
     required=True,
@@ -128,7 +128,7 @@ def parse(
     input: str,
     input_format: str,
     metadata: str,
-    prefix_map_mode: str,
+    mode: str,
     clean_prefixes: bool,
     output: TextIO,
 ):
@@ -139,7 +139,7 @@ def parse(
         input (str): The path to the input file in one of the legal formats, eg obographs, aligmentapi-xml
         input_format (str): The string denoting the input format.
         metadata (str): The path to a file containing the sssom metadata (including prefix_map) to be used during parse.
-        prefix_map_mode (str): Curie map mode.
+        mode (str): Curie map mode.
         clean_prefixes (bool): If True (default), records with unknown prefixes are removed from the SSSOM file.
         output (str): The path to the SSSOM TSV output file.
 
@@ -153,7 +153,7 @@ def parse(
         output=output,
         input_format=input_format,
         metadata_path=metadata,
-        prefix_map_mode=prefix_map_mode,
+        mode=mode,
         clean_prefixes=clean_prefixes,
     )
 

--- a/sssom/cli.py
+++ b/sssom/cli.py
@@ -105,14 +105,14 @@ def convert(input: str, output: TextIO, output_format: str):
 @metadata_option
 @click.option(
     "-C",
-    "--mode",
+    "--prefix-map-mode",
     default="metadata_only",
     show_default=True,
     required=True,
     type=click.Choice(
         ["metadata_only", "sssom_default_only", "merged"], case_sensitive=False
     ),
-    help="Defines wether the prefix map in the metadata should be extended or replaced with "
+    help="Defines whether the prefix map in the metadata should be extended or replaced with "
     "the SSSOM default prefix map. Must be one of metadata_only, sssom_default_only, merged",
 )
 @click.option(
@@ -128,32 +128,26 @@ def parse(
     input: str,
     input_format: str,
     metadata: str,
-    mode: str,
+    prefix_map_mode: str,
     clean_prefixes: bool,
     output: TextIO,
 ):
-    """Parses a file in one of the supported formats (such as obographs) into an SSSOM TSV file.
+    """Parse a file in one of the supported formats (such as obographs) into an SSSOM TSV file.
 
     Args:
-
-        input (str): The path to the input file in one of the legal formats, eg obographs, aligmentapi-xml
-        input_format (str): The string denoting the input format.
-        metadata (str): The path to a file containing the sssom metadata (including prefix_map) to be used during parse.
-        mode (str): Curie map mode.
-        clean_prefixes (bool): If True (default), records with unknown prefixes are removed from the SSSOM file.
-        output (str): The path to the SSSOM TSV output file.
-
-    Returns:
-
-        None.
+        input: The path to the input file in one of the legal formats, eg obographs, aligmentapi-xml
+        input_format: The string denoting the input format.
+        metadata: The path to a file containing the sssom metadata (including prefix_map) to be used during parse.
+        prefix_map_mode: prefix map mode.
+        clean_prefixes: If True (default), records with unknown prefixes are removed from the SSSOM file.
+        output: The path to the SSSOM TSV output file.
     """
-
     parse_file(
         input_path=input,
         output=output,
         input_format=input_format,
         metadata_path=metadata,
-        mode=mode,
+        prefix_map_mode=prefix_map_mode,
         clean_prefixes=clean_prefixes,
     )
 

--- a/sssom/cliques.py
+++ b/sssom/cliques.py
@@ -6,7 +6,7 @@ import networkx as nx
 import pandas as pd
 
 from .parsers import to_mapping_set_document
-from .sssom_datamodel import Mapping, MappingSet
+from .sssom_datamodel import Mapping
 from .sssom_document import MappingSetDocument
 from .util import MappingSetDataFrame
 
@@ -71,11 +71,7 @@ def split_into_cliques(msdf: MappingSetDataFrame):
         for n in comp:
             node_to_comp[n] = comp_id
         comp_id += 1
-        newdocs.append(
-            MappingSetDocument(
-                curie_map=doc.curie_map, mapping_set=MappingSet(mappings=[])
-            )
-        )
+        newdocs.append(MappingSetDocument.empty(prefix_map=doc.prefix_map))
 
     if not isinstance(doc.mapping_set.mappings, list):
         raise TypeError

--- a/sssom/context.py
+++ b/sssom/context.py
@@ -24,30 +24,30 @@ def get_external_jsonld_context():
 
 def get_built_in_prefix_map() -> PrefixMap:
     contxt = get_jsonld_context()
-    curie_map = {}
+    prefix_map = {}
     for key in contxt["@context"]:
         if key in SSSOM_BUILT_IN_PREFIXES:
             v = contxt["@context"][key]
             if isinstance(v, str):
-                curie_map[key] = v
-    return curie_map
+                prefix_map[key] = v
+    return prefix_map
 
 
 def add_built_in_prefixes_to_prefix_map(
-    prefixmap: Optional[PrefixMap] = None,
+    prefix_map: Optional[PrefixMap] = None,
 ) -> PrefixMap:
     builtinmap = get_built_in_prefix_map()
-    if not prefixmap:
-        prefixmap = builtinmap
+    if not prefix_map:
+        prefix_map = builtinmap
     else:
         for k, v in builtinmap.items():
-            if k not in prefixmap:
-                prefixmap[k] = v
-            elif builtinmap[k] != prefixmap[k]:
+            if k not in prefix_map:
+                prefix_map[k] = v
+            elif builtinmap[k] != prefix_map[k]:
                 logging.warning(
-                    f"Built-in prefix {k} is specified ({prefixmap[k]}) but differs from default ({builtinmap[k]})"
+                    f"Built-in prefix {k} is specified ({prefix_map[k]}) but differs from default ({builtinmap[k]})"
                 )
-    return prefixmap
+    return prefix_map
 
 
 def get_default_metadata() -> Metadata:
@@ -71,6 +71,6 @@ def get_default_metadata() -> Metadata:
             else:
                 if prefix_map[key] != v:
                     logging.warning(
-                        f"{key} is already in curie map ({prefix_map[key]}, but with a different value than {v}"
+                        f"{key} is already in prefix map ({prefix_map[key]}, but with a different value than {v}"
                     )
     return Metadata(prefix_map=prefix_map, metadata=metadata)

--- a/sssom/io.py
+++ b/sssom/io.py
@@ -34,7 +34,7 @@ def parse_file(
     output: TextIO,
     input_format: Optional[str] = None,
     metadata_path: Optional[str] = None,
-    mode: Optional[str] = None,
+    prefix_map_mode: Optional[str] = None,
     clean_prefixes: bool = True,
 ) -> None:
     """
@@ -45,12 +45,14 @@ def parse_file(
         input_format: The string denoting the input format.
         metadata_path: The path to a file containing the sssom metadata (including prefix_map)
             to be used during parse.
-        mode: Defines whether the prefix map in the metadata should be extended or replaced with
+        prefix_map_mode: Defines whether the prefix map in the metadata should be extended or replaced with
             the SSSOM default prefix map. Must be one of metadata_only, sssom_default_only, merged
         clean_prefixes: If True (default), records with unknown prefixes are removed from the SSSOM file.
     """
     raise_for_bad_path(input_path)
-    metadata = get_metadata_and_prefix_map(metadata_path=metadata_path, mode=mode)
+    metadata = get_metadata_and_prefix_map(
+        metadata_path=metadata_path, prefix_map_mode=prefix_map_mode
+    )
     parse_func = get_parsing_function(input_format, input_path)
     doc = parse_func(
         input_path, prefix_map=metadata.prefix_map, meta=metadata.prefix_map
@@ -94,27 +96,27 @@ def split_file(input_path: str, output_directory: str) -> None:
 
 
 def get_metadata_and_prefix_map(
-    metadata_path: Optional[str] = None, mode: Optional[str] = None
+    metadata_path: Optional[str] = None, prefix_map_mode: Optional[str] = None
 ) -> Metadata:
     """
     Load SSSOM metadata from a file, and then augments it with default prefixes.
 
     :param metadata_path: The metadata file in YAML format
-    :param mode: one of metadata_only, sssom_default_only, merged
+    :param prefix_map_mode: one of metadata_only, sssom_default_only, merged
     :return: a prefix map dictionary and a metadata object dictionary
     """
     if metadata_path is None:
         return get_default_metadata()
-    if mode is None:
-        mode = "metadata_only"
+    if prefix_map_mode is None:
+        prefix_map_mode = "metadata_only"
     prefix_map, metadata = read_metadata(metadata_path)
     # TODO reduce complexity by flipping conditionals
     #  and returning eagerly (it's fine if there are multiple returns)
-    if mode != "metadata_only":
+    if prefix_map_mode != "metadata_only":
         meta_sssom, prefix_map_sssom = get_default_metadata()
-        if mode == "sssom_default_only":
+        if prefix_map_mode == "sssom_default_only":
             prefix_map = prefix_map_sssom
-        elif mode == "merged":
+        elif prefix_map_mode == "merged":
             for prefix, uri_prefix in prefix_map_sssom.items():
                 if prefix not in prefix_map:
                     prefix_map[prefix] = uri_prefix

--- a/sssom/io.py
+++ b/sssom/io.py
@@ -34,7 +34,7 @@ def parse_file(
     output: TextIO,
     input_format: Optional[str] = None,
     metadata_path: Optional[str] = None,
-    prefix_map_mode: Optional[str] = None,
+    mode: Optional[str] = None,
     clean_prefixes: bool = True,
 ) -> None:
     """
@@ -45,14 +45,12 @@ def parse_file(
         input_format: The string denoting the input format.
         metadata_path: The path to a file containing the sssom metadata (including prefix_map)
             to be used during parse.
-        prefix_map_mode: Defines whether the prefix map in the metadata should be extended or replaced with
+        mode: Defines whether the prefix map in the metadata should be extended or replaced with
             the SSSOM default prefix map. Must be one of metadata_only, sssom_default_only, merged
         clean_prefixes: If True (default), records with unknown prefixes are removed from the SSSOM file.
     """
     raise_for_bad_path(input_path)
-    metadata = get_metadata_and_prefix_map(
-        metadata_path=metadata_path, prefix_map_mode=prefix_map_mode
-    )
+    metadata = get_metadata_and_prefix_map(metadata_path=metadata_path, mode=mode)
     parse_func = get_parsing_function(input_format, input_path)
     doc = parse_func(
         input_path, prefix_map=metadata.prefix_map, meta=metadata.prefix_map
@@ -96,27 +94,27 @@ def split_file(input_path: str, output_directory: str) -> None:
 
 
 def get_metadata_and_prefix_map(
-    metadata_path: Optional[str] = None, prefix_map_mode: Optional[str] = None
+    metadata_path: Optional[str] = None, mode: Optional[str] = None
 ) -> Metadata:
     """
     Load SSSOM metadata from a file, and then augments it with default prefixes.
 
     :param metadata_path: The metadata file in YAML format
-    :param prefix_map_mode: one of metadata_only, sssom_default_only, merged
+    :param mode: one of metadata_only, sssom_default_only, merged
     :return: a prefix map dictionary and a metadata object dictionary
     """
     if metadata_path is None:
         return get_default_metadata()
-    if prefix_map_mode is None:
-        prefix_map_mode = "metadata_only"
+    if mode is None:
+        mode = "metadata_only"
     prefix_map, metadata = read_metadata(metadata_path)
     # TODO reduce complexity by flipping conditionals
     #  and returning eagerly (it's fine if there are multiple returns)
-    if prefix_map_mode != "metadata_only":
+    if mode != "metadata_only":
         meta_sssom, prefix_map_sssom = get_default_metadata()
-        if prefix_map_mode == "sssom_default_only":
+        if mode == "sssom_default_only":
             prefix_map = prefix_map_sssom
-        elif prefix_map_mode == "merged":
+        elif mode == "merged":
             for prefix, uri_prefix in prefix_map_sssom.items():
                 if prefix not in prefix_map:
                     prefix_map[prefix] = uri_prefix

--- a/sssom/io.py
+++ b/sssom/io.py
@@ -34,7 +34,7 @@ def parse_file(
     output: TextIO,
     input_format: Optional[str] = None,
     metadata_path: Optional[str] = None,
-    curie_map_mode: Optional[str] = None,
+    prefix_map_mode: Optional[str] = None,
     clean_prefixes: bool = True,
 ) -> None:
     """
@@ -43,19 +43,19 @@ def parse_file(
         input_path: The path to the input file in one of the legal formats, eg obographs, aligmentapi-xml
         output: The path to the output file.
         input_format: The string denoting the input format.
-        metadata_path: The path to a file containing the sssom metadata (including curie_map)
+        metadata_path: The path to a file containing the sssom metadata (including prefix_map)
             to be used during parse.
-        curie_map_mode: Defines whether the curie map in the metadata should be extended or replaced with
-            the SSSOM default curie map. Must be one of metadata_only, sssom_default_only, merged
+        prefix_map_mode: Defines whether the prefix map in the metadata should be extended or replaced with
+            the SSSOM default prefix map. Must be one of metadata_only, sssom_default_only, merged
         clean_prefixes: If True (default), records with unknown prefixes are removed from the SSSOM file.
     """
     raise_for_bad_path(input_path)
-    metadata = get_metadata_and_curie_map(
-        metadata_path=metadata_path, curie_map_mode=curie_map_mode
+    metadata = get_metadata_and_prefix_map(
+        metadata_path=metadata_path, prefix_map_mode=prefix_map_mode
     )
     parse_func = get_parsing_function(input_format, input_path)
     doc = parse_func(
-        input_path, curie_map=metadata.prefix_map, meta=metadata.prefix_map
+        input_path, prefix_map=metadata.prefix_map, meta=metadata.prefix_map
     )
     if clean_prefixes:
         # We do this because we got a lot of prefixes from the default SSSOM prefixes!
@@ -95,29 +95,29 @@ def split_file(input_path: str, output_directory: str) -> None:
     write_tables(splitted, output_directory)
 
 
-def get_metadata_and_curie_map(
-    metadata_path: Optional[str] = None, curie_map_mode: Optional[str] = None
+def get_metadata_and_prefix_map(
+    metadata_path: Optional[str] = None, prefix_map_mode: Optional[str] = None
 ) -> Metadata:
     """
     Load SSSOM metadata from a file, and then augments it with default prefixes.
 
     :param metadata_path: The metadata file in YAML format
-    :param curie_map_mode: one of metadata_only, sssom_default_only, merged
-    :return: a curie map dictionary and a metadata object dictionary
+    :param prefix_map_mode: one of metadata_only, sssom_default_only, merged
+    :return: a prefix map dictionary and a metadata object dictionary
     """
     if metadata_path is None:
         return get_default_metadata()
-    if curie_map_mode is None:
-        curie_map_mode = "metadata_only"
+    if prefix_map_mode is None:
+        prefix_map_mode = "metadata_only"
     prefix_map, metadata = read_metadata(metadata_path)
     # TODO reduce complexity by flipping conditionals
     #  and returning eagerly (it's fine if there are multiple returns)
-    if curie_map_mode != "metadata_only":
-        meta_sssom, curie_map_sssom = get_default_metadata()
-        if curie_map_mode == "sssom_default_only":
-            prefix_map = curie_map_sssom
-        elif curie_map_mode == "merged":
-            for prefix, uri_prefix in curie_map_sssom.items():
+    if prefix_map_mode != "metadata_only":
+        meta_sssom, prefix_map_sssom = get_default_metadata()
+        if prefix_map_mode == "sssom_default_only":
+            prefix_map = prefix_map_sssom
+        elif prefix_map_mode == "merged":
+            for prefix, uri_prefix in prefix_map_sssom.items():
                 if prefix not in prefix_map:
                     prefix_map[prefix] = uri_prefix
     return Metadata(prefix_map=prefix_map, metadata=metadata)

--- a/sssom/parsers.py
+++ b/sssom/parsers.py
@@ -251,7 +251,7 @@ def from_sssom_rdf(
     mlist: List[Mapping] = []
 
     for sx, px, ox in g.triples((None, URIRef(URI_SSSOM_MAPPINGS), None)):
-        mdict = {}
+        mdict: Dict[str, Any] = {}
         # TODO replace with g.predicate_objects()
         for _s, p, o in g.triples((ox, None, None)):
             if isinstance(p, URIRef):
@@ -414,7 +414,7 @@ def from_obographs(
                         if "xrefs" in n["meta"]:
                             for xref in n["meta"]["xrefs"]:
                                 xref_id = xref["val"]
-                                mdict = {}
+                                mdict: Dict[str, Any] = {}
                                 try:
                                     mdict["subject_id"] = curie_from_uri(
                                         nid, prefix_map
@@ -427,6 +427,7 @@ def from_obographs(
                                     mdict["match_type"] = "Unspecified"
                                     mlist.append(Mapping(**mdict))
                                 except NoCURIEException as e:
+                                    # FIXME this will cause all sorts of ragged Mappings
                                     logging.warning(e)
                         if "basicPropertyValues" in n["meta"]:
                             for value in n["meta"]["basicPropertyValues"]:
@@ -448,6 +449,7 @@ def from_obographs(
                                         mdict["match_type"] = "Unspecified"
                                         mlist.append(Mapping(**mdict))
                                     except NoCURIEException as e:
+                                        # FIXME this will cause ragged mappings
                                         logging.warning(e)
     else:
         raise Exception("No graphs element in obographs file, wrong format?")
@@ -565,7 +567,7 @@ def _set_metadata_in_mapping_set(
 
 
 def _cell_element_values(cell_node, prefix_map: PrefixMap) -> Optional[Mapping]:
-    mdict = {}
+    mdict: Dict[str, Any] = {}
     for child in cell_node.childNodes:
         if child.nodeType == Node.ELEMENT_NODE:
             try:

--- a/sssom/parsers.py
+++ b/sssom/parsers.py
@@ -20,6 +20,7 @@ from .sssom_datamodel import Mapping, MappingSet
 from .sssom_document import MappingSetDocument
 from .typehints import Metadata, MetadataType, PrefixMap
 from .util import (
+    PREFIX_MAP_KEY,
     SSSOM_DEFAULT_RDF_SERIALISATION,
     URI_SSSOM_MAPPINGS,
     MappingSetDataFrame,
@@ -36,7 +37,7 @@ from .util import (
 
 def read_sssom_table(
     file_path: str,
-    curie_map: Optional[PrefixMap] = None,
+    prefix_map: Optional[PrefixMap] = None,
     meta: Optional[MetadataType] = None,
 ) -> MappingSetDataFrame:
     """
@@ -64,15 +65,15 @@ def read_sssom_table(
                     sssom_metadata[k] = v
         meta = sssom_metadata
 
-    curie_map, meta = _get_curie_map_and_metadata(curie_map=curie_map, meta=meta)
+    prefix_map, meta = _get_prefix_map_and_metadata(prefix_map=prefix_map, meta=meta)
 
-    msdf = from_sssom_dataframe(df, curie_map=curie_map, meta=meta)
+    msdf = from_sssom_dataframe(df, prefix_map=prefix_map, meta=meta)
     return msdf
 
 
 def read_sssom_rdf(
     file_path: str,
-    curie_map: Dict[str, str] = None,
+    prefix_map: Dict[str, str] = None,
     meta: Dict[str, str] = None,
     serialisation=SSSOM_DEFAULT_RDF_SERIALISATION,
 ) -> MappingSetDataFrame:
@@ -80,30 +81,27 @@ def read_sssom_rdf(
     parses a TSV -> MappingSetDocument -> MappingSetDataFrame
     """
     raise_for_bad_path(file_path)
-    metadata = _get_curie_map_and_metadata(curie_map=curie_map, meta=meta)
+    metadata = _get_prefix_map_and_metadata(prefix_map=prefix_map, meta=meta)
 
     g = Graph()
     g.load(file_path, format=serialisation)
-    # json_obj = json.loads(g.serialize(format="json-ld"))
-    # print(json_obj)
-    # msdf = from_sssom_json(json_obj, curie_map=curie_map, meta=meta)
-    msdf = from_sssom_rdf(g, curie_map=metadata.prefix_map, meta=metadata.metadata)
+    msdf = from_sssom_rdf(g, prefix_map=metadata.prefix_map, meta=metadata.metadata)
     return msdf
 
 
 def read_sssom_json(
-    file_path: str, curie_map: Dict[str, str] = None, meta: Dict[str, str] = None
+    file_path: str, prefix_map: Dict[str, str] = None, meta: Dict[str, str] = None
 ) -> MappingSetDataFrame:
     """
     parses a TSV -> MappingSetDocument -> MappingSetDataFrame
     """
     raise_for_bad_path(file_path)
-    metadata = _get_curie_map_and_metadata(curie_map=curie_map, meta=meta)
+    metadata = _get_prefix_map_and_metadata(prefix_map=prefix_map, meta=meta)
 
     with open(file_path) as json_file:
         jsondoc = json.load(json_file)
     msdf = from_sssom_json(
-        jsondoc=jsondoc, curie_map=metadata.prefix_map, meta=metadata.metadata
+        jsondoc=jsondoc, prefix_map=metadata.prefix_map, meta=metadata.metadata
     )
     return msdf
 
@@ -112,64 +110,64 @@ def read_sssom_json(
 
 
 def read_obographs_json(
-    file_path: str, curie_map: Dict[str, str] = None, meta: Dict[str, str] = None
+    file_path: str, prefix_map: Dict[str, str] = None, meta: Dict[str, str] = None
 ) -> MappingSetDataFrame:
-    """
-    parses an obographs file as a JSON object and translates it into a MappingSetDataFrame
+    """Parse an obographs file as a JSON object and translates it into a MappingSetDataFrame.
+
     :param file_path: The path to the obographs file
-    :param curie_map: an optional curie map
+    :param prefix_map: an optional prefix map
     :param meta: an optional dictionary of metadata elements
     :return: A SSSOM MappingSetDataFrame
     """
     raise_for_bad_path(file_path)
 
-    _xmetadata = _get_curie_map_and_metadata(curie_map=curie_map, meta=meta)
+    _xmetadata = _get_prefix_map_and_metadata(prefix_map=prefix_map, meta=meta)
 
     with open(file_path) as json_file:
         jsondoc = json.load(json_file)
 
     return from_obographs(
-        jsondoc, curie_map=_xmetadata.prefix_map, meta=_xmetadata.metadata
+        jsondoc, prefix_map=_xmetadata.prefix_map, meta=_xmetadata.metadata
     )
 
 
-def _get_curie_map_and_metadata(
-    curie_map: Optional[PrefixMap] = None, meta: Optional[MetadataType] = None
+def _get_prefix_map_and_metadata(
+    prefix_map: Optional[PrefixMap] = None, meta: Optional[MetadataType] = None
 ) -> Metadata:
     default_metadata = get_default_metadata()
 
-    if curie_map is None:
+    if prefix_map is None:
         logging.warning(
-            "No curie map provided (not recommended), trying to use defaults.."
+            "No prefix map provided (not recommended), trying to use defaults.."
         )
-        curie_map = default_metadata.prefix_map
+        prefix_map = default_metadata.prefix_map
 
     if meta is None:
         meta = default_metadata.metadata
     else:
-        if curie_map and "curie_map" in meta:
+        if prefix_map and PREFIX_MAP_KEY in meta:
             logging.info(
-                "Curie map provided as parameter, but SSSOM file provides its own CURIE map. "
-                "CURIE map provided externally is disregarded in favour of the curie map in the SSSOM file."
+                "Prefix map provided as parameter, but SSSOM file provides its own prefix map. "
+                "Prefix map provided externally is disregarded in favour of the prefix map in the SSSOM file."
             )
-            curie_map = cast(PrefixMap, meta["curie_map"])
+            prefix_map = cast(PrefixMap, meta[PREFIX_MAP_KEY])
 
-    return Metadata(prefix_map=curie_map, metadata=meta)
+    return Metadata(prefix_map=prefix_map, metadata=meta)
 
 
 def read_alignment_xml(
-    file_path: str, curie_map: Dict[str, str], meta: Dict[str, str]
+    file_path: str, prefix_map: Dict[str, str], meta: Dict[str, str]
 ) -> MappingSetDataFrame:
     """
     parses a TSV -> MappingSetDocument -> MappingSetDataFrame
     """
     raise_for_bad_path(file_path)
 
-    metadata = _get_curie_map_and_metadata(curie_map=curie_map, meta=meta)
+    metadata = _get_prefix_map_and_metadata(prefix_map=prefix_map, meta=meta)
     logging.info("Loading from alignment API")
     xmldoc = minidom.parse(file_path)
     msdf = from_alignment_minidom(
-        xmldoc, curie_map=metadata.prefix_map, meta=metadata.metadata
+        xmldoc, prefix_map=metadata.prefix_map, meta=metadata.metadata
     )
     return msdf
 
@@ -180,17 +178,17 @@ def read_alignment_xml(
 def from_sssom_dataframe(
     df: pd.DataFrame,
     *,
-    curie_map: Optional[PrefixMap] = None,
+    prefix_map: Optional[PrefixMap] = None,
     meta: Optional[MetadataType] = None,
 ) -> MappingSetDataFrame:
     """
     Converts a dataframe to a MappingSetDataFrame
     :param df:
-    :param curie_map:
+    :param prefix_map:
     :param meta:
     :return: MappingSetDataFrame
     """
-    curie_map = _ensure_prefix_map(curie_map)
+    prefix_map = _ensure_prefix_map(prefix_map)
 
     if "confidence" in df.columns:
         df["confidence"].replace(r"^\s*$", np.NaN, regex=True, inplace=True)
@@ -222,13 +220,13 @@ def from_sssom_dataframe(
     # so with a heavy heart we employ type:ignore
     ms.mappings = mlist  # type:ignore
     _set_metadata_in_mapping_set(mapping_set=ms, metadata=meta)
-    doc = MappingSetDocument(mapping_set=ms, curie_map=curie_map)
+    doc = MappingSetDocument(mapping_set=ms, prefix_map=prefix_map)
     return to_mapping_set_dataframe(doc)
 
 
 def from_sssom_rdf(
     g: Graph,
-    curie_map: Optional[PrefixMap] = None,
+    prefix_map: Optional[PrefixMap] = None,
     meta: Optional[MetadataType] = None,
     mapping_predicates: Optional[Set[str]] = None,
 ) -> MappingSetDataFrame:
@@ -236,14 +234,14 @@ def from_sssom_rdf(
     Converts an SSSOM RDF graph into a SSSOM data table
     Args:
         g: the Graph (rdflib)
-        curie_map: A dictionary conatining the prefix map
+        prefix_map: A dictionary containing the prefix map
         meta: Potentially additional metadata
         mapping_predicates: A set of predicates that should be extracted from the RDF graph
 
     Returns:
 
     """
-    curie_map = _ensure_prefix_map(curie_map)
+    prefix_map = _ensure_prefix_map(prefix_map)
 
     if mapping_predicates is None:
         # FIXME unused
@@ -258,7 +256,7 @@ def from_sssom_rdf(
         for _s, p, o in g.triples((ox, None, None)):
             if isinstance(p, URIRef):
                 try:
-                    p_id = curie_from_uri(p, curie_map)
+                    p_id = curie_from_uri(p, prefix_map)
                     k = None
 
                     if p_id.startswith("sssom:"):
@@ -271,7 +269,7 @@ def from_sssom_rdf(
                         k = "subject_id"
 
                     if isinstance(o, URIRef):
-                        v = curie_from_uri(o, curie_map)
+                        v = curie_from_uri(o, prefix_map)
                     else:
                         v = o.toPython()
 
@@ -292,43 +290,44 @@ def from_sssom_rdf(
         else:
             logging.warning(
                 f"While trying to prepare a mapping for {sx},{px}, {ox}, something went wrong. "
-                f"This usually happens when a critical curie_map entry is missing."
+                f"This usually happens when a critical prefix_map entry is missing."
             )
 
     ms.mappings = mlist  # type: ignore
     _set_metadata_in_mapping_set(mapping_set=ms, metadata=meta)
-    mdoc = MappingSetDocument(mapping_set=ms, curie_map=curie_map)
+    mdoc = MappingSetDocument(mapping_set=ms, prefix_map=prefix_map)
     return to_mapping_set_dataframe(mdoc)
 
 
 def from_sssom_json(
     jsondoc: Union[str, dict, TextIO],
     *,
-    curie_map: Dict[str, str],
+    prefix_map: Dict[str, str],
     meta: Dict[str, str] = None,
 ) -> MappingSetDataFrame:
-    _ensure_prefix_map(curie_map)
-
-    # noinspection PyTypeChecker
-    ms = JSONLoader().load(source=jsondoc, target_class=MappingSet)
-
-    _set_metadata_in_mapping_set(ms, metadata=meta)
-    mdoc = MappingSetDocument(mapping_set=ms, curie_map=curie_map)
-    return to_mapping_set_dataframe(mdoc)
+    prefix_map = _ensure_prefix_map(prefix_map)
+    mapping_set = cast(
+        MappingSet, JSONLoader().load(source=jsondoc, target_class=MappingSet)
+    )
+    _set_metadata_in_mapping_set(mapping_set, metadata=meta)
+    mapping_set_document = MappingSetDocument(
+        mapping_set=mapping_set, prefix_map=prefix_map
+    )
+    return to_mapping_set_dataframe(mapping_set_document)
 
 
 def from_alignment_minidom(
-    dom: Document, *, curie_map: PrefixMap, meta: MetadataType
+    dom: Document, *, prefix_map: PrefixMap, meta: MetadataType
 ) -> MappingSetDataFrame:
     """
     Reads a minidom Document object
     :param dom: XML (minidom) object
-    :param curie_map:
+    :param prefix_map:
     :param meta: Optional meta data
     :return: MappingSetDocument
     """
-    # FIXME: should be curie_map =  _check_curie_map(curie_map)
-    _ensure_prefix_map(curie_map)
+    # FIXME: should be prefix_map =  _check_prefix_map(prefix_map)
+    _ensure_prefix_map(prefix_map)
 
     ms = MappingSet()
     mlist: List[Mapping] = []
@@ -342,14 +341,14 @@ def from_alignment_minidom(
                 if node_name == "map":
                     cell = e.getElementsByTagName("Cell")
                     for c_node in cell:
-                        mdict = _cell_element_values(c_node, curie_map)
+                        mdict = _cell_element_values(c_node, prefix_map)
                         if mdict:
                             m = _prepare_mapping(mdict)
                             mlist.append(m)
                         else:
                             logging.warning(
                                 f"While trying to prepare a mapping for {c_node}, something went wrong. "
-                                f"This usually happens when a critical curie_map entry is missing."
+                                f"This usually happens when a critical prefix_map entry is missing."
                             )
 
                 elif node_name == "xml":
@@ -368,26 +367,26 @@ def from_alignment_minidom(
 
     ms.mappings = mlist  # type: ignore
     _set_metadata_in_mapping_set(mapping_set=ms, metadata=meta)
-    mdoc = MappingSetDocument(mapping_set=ms, curie_map=curie_map)
-    return to_mapping_set_dataframe(mdoc)
+    mapping_set_document = MappingSetDocument(mapping_set=ms, prefix_map=prefix_map)
+    return to_mapping_set_dataframe(mapping_set_document)
 
 
 def from_obographs(
-    jsondoc: Dict, *, curie_map: PrefixMap, meta: Optional[MetadataType] = None
+    jsondoc: Dict, *, prefix_map: PrefixMap, meta: Optional[MetadataType] = None
 ) -> MappingSetDataFrame:
     """
     Converts a obographs json object to an SSSOM data frame
 
     Args:
         jsondoc: The JSON object representing the ontology in obographs format
-        curie_map: The curie map to be used
+        prefix_map: The prefix map to be used
         meta: Any additional metadata that needs to be added to the resulting SSSOM data frame
 
     Returns:
         An SSSOM data frame (MappingSetDataFrame)
 
     """
-    _ensure_prefix_map(curie_map)
+    _ensure_prefix_map(prefix_map)
 
     ms = MappingSet()
     mlist: List[Mapping] = []
@@ -417,9 +416,11 @@ def from_obographs(
                                 xref_id = xref["val"]
                                 mdict = {}
                                 try:
-                                    mdict["subject_id"] = curie_from_uri(nid, curie_map)
+                                    mdict["subject_id"] = curie_from_uri(
+                                        nid, prefix_map
+                                    )
                                     mdict["object_id"] = curie_from_uri(
-                                        xref_id, curie_map
+                                        xref_id, prefix_map
                                     )
                                     mdict["subject_label"] = label
                                     mdict["predicate_id"] = "oboInOwl:hasDbXref"
@@ -435,14 +436,14 @@ def from_obographs(
                                     mdict = {}
                                     try:
                                         mdict["subject_id"] = curie_from_uri(
-                                            nid, curie_map
+                                            nid, prefix_map
                                         )
                                         mdict["object_id"] = curie_from_uri(
-                                            xref_id, curie_map
+                                            xref_id, prefix_map
                                         )
                                         mdict["subject_label"] = label
                                         mdict["predicate_id"] = curie_from_uri(
-                                            pred, curie_map
+                                            pred, prefix_map
                                         )
                                         mdict["match_type"] = "Unspecified"
                                         mlist.append(Mapping(**mdict))
@@ -453,7 +454,7 @@ def from_obographs(
 
     ms.mappings = mlist  # type: ignore
     _set_metadata_in_mapping_set(mapping_set=ms, metadata=meta)
-    mdoc = MappingSetDocument(mapping_set=ms, curie_map=curie_map)
+    mdoc = MappingSetDocument(mapping_set=ms, prefix_map=prefix_map)
     return to_mapping_set_dataframe(mdoc)
 
 
@@ -478,11 +479,11 @@ def get_parsing_function(input_format, filename):
         raise Exception(f"Unknown input format: {input_format}")
 
 
-def _ensure_prefix_map(curie_map: Optional[PrefixMap] = None) -> PrefixMap:
-    if not curie_map:
-        raise Exception("No valid curie_map provided")
+def _ensure_prefix_map(prefix_map: Optional[PrefixMap] = None) -> PrefixMap:
+    if not prefix_map:
+        raise Exception("No valid prefix_map provided")
     else:
-        return add_built_in_prefixes_to_prefix_map(curie_map)
+        return add_built_in_prefixes_to_prefix_map(prefix_map)
 
 
 def _get_default_mapping_predicates():
@@ -559,22 +560,22 @@ def _set_metadata_in_mapping_set(
         logging.info("Tried setting metadata but none provided.")
     else:
         for k, v in metadata.items():
-            if k != "curie_map":
+            if k != PREFIX_MAP_KEY:
                 mapping_set[k] = v
 
 
-def _cell_element_values(cell_node, curie_map: PrefixMap) -> Optional[Mapping]:
+def _cell_element_values(cell_node, prefix_map: PrefixMap) -> Optional[Mapping]:
     mdict = {}
     for child in cell_node.childNodes:
         if child.nodeType == Node.ELEMENT_NODE:
             try:
                 if child.nodeName == "entity1":
                     mdict["subject_id"] = curie_from_uri(
-                        child.getAttribute("rdf:resource"), curie_map
+                        child.getAttribute("rdf:resource"), prefix_map
                     )
                 elif child.nodeName == "entity2":
                     mdict["object_id"] = curie_from_uri(
-                        child.getAttribute("rdf:resource"), curie_map
+                        child.getAttribute("rdf:resource"), prefix_map
                     )
                 elif child.nodeName == "measure":
                     mdict["confidence"] = child.firstChild.nodeValue
@@ -603,8 +604,8 @@ def _cell_element_values(cell_node, curie_map: PrefixMap) -> Optional[Mapping]:
 
 def to_mapping_set_document(msdf: MappingSetDataFrame) -> MappingSetDocument:
     """Convert a MappingSetDataFrame to a MappingSetDocument."""
-    if not msdf.prefixmap:
-        raise Exception("No valid curie_map provided")
+    if not msdf.prefix_map:
+        raise Exception("No valid prefix_map provided")
 
     mlist: List[Mapping] = []
     ms = MappingSet()
@@ -634,9 +635,9 @@ def to_mapping_set_document(msdf: MappingSetDataFrame) -> MappingSetDocument:
     ms.mappings = mlist  # type: ignore
     if msdf.metadata is not None:
         for k, v in msdf.metadata.items():
-            if k != "curie_map":
+            if k != PREFIX_MAP_KEY:
                 ms[k] = v
-    return MappingSetDocument(mapping_set=ms, curie_map=msdf.prefixmap)
+    return MappingSetDocument(mapping_set=ms, prefix_map=msdf.prefix_map)
 
 
 def split_dataframe(
@@ -667,7 +668,7 @@ def split_dataframe_by_prefix(
     :return: a dict of SSSOM data frame names to MappingSetDataFrame
     """
     df = msdf.df
-    curie_map = msdf.prefixmap
+    prefix_map = msdf.prefix_map
     meta = msdf.metadata
     splitted = {}
     for pre_subj in subject_prefixes:
@@ -682,13 +683,13 @@ def split_dataframe_by_prefix(
                         & (df["predicate_id"] == rel)
                         & (df["object_id"].str.startswith(pre_obj + ":"))
                     ]
-                if pre_subj in curie_map and pre_obj in curie_map and len(dfs) > 0:
+                if pre_subj in prefix_map and pre_obj in prefix_map and len(dfs) > 0:
                     cm = {
-                        pre_subj: curie_map[pre_subj],
-                        pre_obj: curie_map[pre_obj],
-                        relpre: curie_map[relpre],
+                        pre_subj: prefix_map[pre_subj],
+                        pre_obj: prefix_map[pre_obj],
+                        relpre: prefix_map[relpre],
                     }
-                    msdf = from_sssom_dataframe(dfs, curie_map=cm, meta=meta)
+                    msdf = from_sssom_dataframe(dfs, prefix_map=cm, meta=meta)
                     splitted[split_name] = msdf
                 else:
                     logging.warning(

--- a/sssom/rdf_util.py
+++ b/sssom/rdf_util.py
@@ -17,7 +17,7 @@ def rewire_graph(
     """
     rewires an RDF Graph replacing using equivalence mappings
     """
-    pm = mset.prefixmap
+    pm = mset.prefix_map
     mdoc = to_mapping_set_document(mset)
     rewire_map: Dict[EntityId, EntityId] = {}
 

--- a/sssom/sparql_util.py
+++ b/sssom/sparql_util.py
@@ -17,7 +17,7 @@ class EndpointConfig:
     predmap: Dict[str, str]
     predicates: Optional[List[str]]
     limit: Optional[int]
-    curie_map: Optional[Dict[str, str]]
+    prefix_map: Optional[Dict[str, str]]
     include_object_labels: bool = False
 
 
@@ -80,9 +80,9 @@ def query_mappings(config: EndpointConfig) -> MappingSetDataFrame:
         row = {k: v["value"] for k, v in result.items()}
         rows.append(curiefy_row(row, config))
     df = pd.DataFrame(rows)
-    if config.curie_map is None:
+    if config.prefix_map is None:
         raise TypeError
-    return MappingSetDataFrame(df=df, prefixmap=config.curie_map)
+    return MappingSetDataFrame(df=df, prefix_map=config.prefix_map)
 
 
 def curiefy_row(row: Mapping[str, str], config: EndpointConfig) -> Dict[str, str]:
@@ -90,18 +90,18 @@ def curiefy_row(row: Mapping[str, str], config: EndpointConfig) -> Dict[str, str
 
 
 def contract_uri(uristr: str, config: EndpointConfig) -> str:
-    if config.curie_map is None:
+    if config.prefix_map is None:
         return uristr
-    for k, v in config.curie_map.items():
+    for k, v in config.prefix_map.items():
         if uristr.startswith(v):
             return uristr.replace(v, f"{k}:")
     return uristr
 
 
 def expand_curie(curie: str, config: EndpointConfig) -> URIRef:
-    if config.curie_map is None:
+    if config.prefix_map is None:
         return URIRef(curie)
-    for k, v in config.curie_map.items():
+    for k, v in config.prefix_map.items():
         prefix = f"{k}:"
         if curie.startswith(prefix):
             return URIRef(curie.replace(prefix, v))

--- a/sssom/sssom_document.py
+++ b/sssom/sssom_document.py
@@ -17,9 +17,14 @@ class MappingSetDocument:
     The main part of the document: a set of mappings plus metadata
     """
 
-    curie_map: PrefixMap
+    prefix_map: PrefixMap
     """
     Mappings between ID prefixes and URI Bases, used to map CURIEs to URIs.
-    Note that the CURIE map is not part of the core SSSOM model, hence it belongs here in the document
+    Note that the prefix map is not part of the core SSSOM model, hence it belongs here in the document
     object
     """
+
+    @classmethod
+    def empty(cls, prefix_map: PrefixMap) -> "MappingSetDocument":
+        """Get an empty mapping set document with the given prefix map."""
+        return cls(prefix_map=prefix_map, mapping_set=MappingSet(mappings=[]))

--- a/sssom/writers.py
+++ b/sssom/writers.py
@@ -15,13 +15,14 @@ from rdflib.namespace import OWL, RDF
 from .parsers import to_mapping_set_document
 from .sssom_datamodel import slots
 from .util import (
+    PREFIX_MAP_KEY,
     RDF_FORMATS,
     SSSOM_DEFAULT_RDF_SERIALISATION,
     SSSOM_URI_PREFIX,
     URI_SSSOM_MAPPINGS,
     MappingSetDataFrame,
     get_file_extension,
-    prepare_context_from_curie_map,
+    prepare_context_str,
 )
 
 # noinspection PyProtectedMember
@@ -53,8 +54,8 @@ def write_table(msdf: MappingSetDataFrame, file: TextIO, serialisation="tsv") ->
     meta: Dict[str, Any] = {}
     if msdf.metadata is not None:
         meta.update(msdf.metadata)
-    if msdf.prefixmap is not None:
-        meta["curie_map"] = msdf.prefixmap
+    if msdf.prefix_map is not None:
+        meta[PREFIX_MAP_KEY] = msdf.prefix_map
 
     lines = yaml.safe_dump(meta).split("\n")
     lines = [f"# {line}" for line in lines if line != ""]
@@ -92,9 +93,6 @@ def write_json(msdf: MappingSetDataFrame, output: TextIO, serialisation="json") 
     """
     if serialisation == "json":
         data = to_json(msdf)
-        # doc = to_mapping_set_document(msdf)
-        # context = prepare_context_from_curie_map(doc.curie_map)
-        # data = JSONDumper().dumps(doc.mapping_set, contexts=context)
         json.dump(data, output, indent=2)
 
     else:
@@ -252,7 +250,7 @@ def to_rdf_graph(msdf: MappingSetDataFrame) -> Graph:
 
     """
     doc = to_mapping_set_document(msdf)
-    cntxt = prepare_context_from_curie_map(doc.curie_map)
+    cntxt = prepare_context_str(doc.prefix_map)
 
     # json_obj = to_json(msdf)
     # g = Graph()
@@ -260,7 +258,7 @@ def to_rdf_graph(msdf: MappingSetDataFrame) -> Graph:
     # print(g.serialize(format="xml"))
 
     graph = _temporary_as_rdf_graph(
-        element=doc.mapping_set, contexts=cntxt, namespaces=doc.curie_map
+        element=doc.mapping_set, contexts=cntxt, namespaces=doc.prefix_map
     )
     # print(graph.serialize(format="turtle").decode())
     return graph
@@ -310,7 +308,7 @@ def to_json(msdf: MappingSetDataFrame) -> JsonObj:
     """
 
     doc = to_mapping_set_document(msdf)
-    context = prepare_context_from_curie_map(doc.curie_map)
+    context = prepare_context_str(doc.prefix_map)
     data = JSONDumper().dumps(doc.mapping_set, contexts=context)
     json_obj = json.loads(data)
     return json_obj

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,7 +91,7 @@ class SSSOMCLITestSuite(unittest.TestCase):
             test_case.get_out_file("tsv"),
             "--input-format",
             test_case.inputformat,
-            "--curie-map-mode",
+            "--mode",
             "merged",
         ]
         if test_case.metadata_file:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,7 +91,7 @@ class SSSOMCLITestSuite(unittest.TestCase):
             test_case.get_out_file("tsv"),
             "--input-format",
             test_case.inputformat,
-            "--mode",
+            "--prefix-map-mode",
             "merged",
         ]
         if test_case.metadata_file:

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -30,8 +30,7 @@ class SSSOMReadWriteTestSuite(unittest.TestCase):
         for test in test_cases:
             with self.subTest():
                 read_func = get_parsing_function(test.inputformat, test.filepath)
-                # mdoc = read_func(test.filepath, curie_map=test.curie_map)
-                msdf = read_func(test.filepath, curie_map=test.curie_map)
+                msdf = read_func(test.filepath, prefix_map=test.prefix_map)
                 mdoc = to_mapping_set_document(msdf)
                 logging.info(f"Testing {test.filepath}")
                 self.assertEqual(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,6 +2,8 @@ import os
 
 import yaml
 
+from sssom.util import PREFIX_MAP_KEY
+
 cwd = os.path.abspath(os.path.dirname(__file__))
 test_data_dir = os.path.join(cwd, "data")
 test_out_dir = os.path.join(cwd, "tmp")
@@ -70,10 +72,7 @@ class SSSOMTestCase:
         self.ct_graph_queries_rdf = self._query_tuple(
             config, "ct_graph_queries_rdf", queries
         )
-        if "curie_map" in config:
-            self.curie_map = config["curie_map"]
-        else:
-            self.curie_map = None
+        self.prefix_map = config.pop(PREFIX_MAP_KEY, None)
 
     def _query_tuple(self, config, tuple_id, queries_dict):
         queries = []

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -16,6 +16,7 @@ from sssom.parsers import (
     from_sssom_rdf,
     read_sssom_table,
 )
+from sssom.util import PREFIX_MAP_KEY
 from sssom.writers import write_table
 from tests.test_data import test_data_dir, test_out_dir
 
@@ -46,13 +47,12 @@ class TestParse(unittest.TestCase):
 
         with open(f"{test_data_dir}/basic-meta-external.yml") as file:
             df_meta = yaml.safe_load(file)
-            self.df_curie_map = df_meta["curie_map"]
+            self.df_prefix_map = df_meta.pop(PREFIX_MAP_KEY)
             self.df_meta = df_meta
-            self.df_meta.pop("curie_map", None)
 
         self.alignmentxml_file = f"{test_data_dir}/oaei-ordo-hp.rdf"
         self.alignmentxml = minidom.parse(self.alignmentxml_file)
-        self.curie_map, self.metadata = get_default_metadata()
+        self.prefix_map, self.metadata = get_default_metadata()
 
     def test_parse_sssom_dataframe(self):
         input_path = f"{test_data_dir}/basic.tsv"
@@ -79,7 +79,7 @@ class TestParse(unittest.TestCase):
 
     def test_parse_obographs(self):
         msdf = from_obographs(
-            jsondoc=self.obographs, curie_map=self.curie_map, meta=self.metadata
+            jsondoc=self.obographs, prefix_map=self.prefix_map, meta=self.metadata
         )
         path = os.path.join(test_out_dir, "test_parse_obographs.tsv")
         with open(path, "w") as file:
@@ -92,7 +92,7 @@ class TestParse(unittest.TestCase):
 
     def test_parse_tsv(self):
         msdf = from_sssom_dataframe(
-            df=self.df, curie_map=self.df_curie_map, meta=self.df_meta
+            df=self.df, prefix_map=self.df_prefix_map, meta=self.df_meta
         )
         path = os.path.join(test_out_dir, "test_parse_tsv.tsv")
         with open(path, "w") as file:
@@ -105,7 +105,7 @@ class TestParse(unittest.TestCase):
 
     def test_parse_alignment_minidom(self):
         msdf = from_alignment_minidom(
-            dom=self.alignmentxml, curie_map=self.curie_map, meta=self.metadata
+            dom=self.alignmentxml, prefix_map=self.prefix_map, meta=self.metadata
         )
         path = os.path.join(test_out_dir, "test_parse_alignment_minidom.tsv")
         with open(path, "w") as file:
@@ -118,7 +118,7 @@ class TestParse(unittest.TestCase):
 
     def test_parse_sssom_rdf(self):
         msdf = from_sssom_rdf(
-            g=self.rdf_graph, curie_map=self.df_curie_map, meta=self.metadata
+            g=self.rdf_graph, prefix_map=self.df_prefix_map, meta=self.metadata
         )
         path = os.path.join(test_out_dir, "test_parse_sssom_rdf.tsv")
         with open(path, "w") as file:
@@ -131,7 +131,7 @@ class TestParse(unittest.TestCase):
 
     def test_parse_sssom_json(self):
         msdf = from_sssom_json(
-            jsondoc=self.json, curie_map=self.df_curie_map, meta=self.metadata
+            jsondoc=self.json, prefix_map=self.df_prefix_map, meta=self.metadata
         )
         path = os.path.join(test_out_dir, "test_parse_sssom_json.tsv")
         with open(path, "w") as file:

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -29,7 +29,7 @@ class TestWrite(unittest.TestCase):
         path_1 = os.path.join(test_out_dir, "test_write_sssom_rdf.rdf")
         with open(path_1, "w") as file:
             write_rdf(self.msdf, file)
-        msdf = read_sssom_rdf(path_1, self.msdf.prefixmap)
+        msdf = read_sssom_rdf(path_1, self.msdf.prefix_map)
         self.assertEqual(
             len(msdf.df),
             self.mapping_count,

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -9,8 +9,8 @@ INPUT_URL_3='https://raw.githubusercontent.com/mapping-commons/sssom-py/master/t
 OUTPUT_DIR='tests/tmp/'
 QUERY_1="SELECT * FROM df1 WHERE confidence>0.5 ORDER BY confidence"
 
-sssom parse $INPUT_FILE_1 --output $OUTPUT_DIR/parsed_basic_file.tsv --input-format tsv --curie-map-mode merged
-sssom parse $INPUT_URL_1 --output $OUTPUT_DIR/parsed_basic_url.tsv --input-format tsv --curie-map-mode merged
+sssom parse $INPUT_FILE_1 --output $OUTPUT_DIR/parsed_basic_file.tsv --input-format tsv --mode merged
+sssom parse $INPUT_URL_1 --output $OUTPUT_DIR/parsed_basic_url.tsv --input-format tsv --mode merged
 
 sssom split $INPUT_FILE_1 --output-directory $OUTPUT_DIR
 sssom split $INPUT_URL_1 --output-directory $OUTPUT_DIR

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -9,8 +9,8 @@ INPUT_URL_3='https://raw.githubusercontent.com/mapping-commons/sssom-py/master/t
 OUTPUT_DIR='tests/tmp/'
 QUERY_1="SELECT * FROM df1 WHERE confidence>0.5 ORDER BY confidence"
 
-sssom parse $INPUT_FILE_1 --output $OUTPUT_DIR/parsed_basic_file.tsv --input-format tsv --mode merged
-sssom parse $INPUT_URL_1 --output $OUTPUT_DIR/parsed_basic_url.tsv --input-format tsv --mode merged
+sssom parse $INPUT_FILE_1 --output $OUTPUT_DIR/parsed_basic_file.tsv --input-format tsv --prefix-map-mode merged
+sssom parse $INPUT_URL_1 --output $OUTPUT_DIR/parsed_basic_url.tsv --input-format tsv --prefix-map-mode merged
 
 sssom split $INPUT_FILE_1 --output-directory $OUTPUT_DIR
 sssom split $INPUT_URL_1 --output-directory $OUTPUT_DIR


### PR DESCRIPTION
All instances of `curie_map` and `prefixmap` have been normalized to `prefix_map` both in variable names and function names. The notable exception is when interacting with dictionaries coming from SSSOM yaml, where the name is unfortunately `curie_map` - so this is maintained as a constant string called `sssom.util.PREFIX_MAP_KEY` in case it's possible we can ever change it.