### PR TITLE
Flake8 Round 2: We have to go deeper

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -152,7 +152,6 @@ ignore =
     D103
     D104
     D105
-    D107
 exclude =
     sssom/sssom_datamodel.py
     sssom/cliquesummary.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -149,7 +149,6 @@ ignore =
     D100
     D101
     D102
-    D103
 exclude =
     sssom/sssom_datamodel.py
     sssom/cliquesummary.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -146,7 +146,6 @@ ignore =
     S318 # don't worry about unsafe xml
     S310 # TODO remove this later and switch to using requests
     # The following are documentation things (remove one at a time in future PRs)
-    BLK100
     D100
     D101
     D102

--- a/setup.cfg
+++ b/setup.cfg
@@ -146,6 +146,7 @@ ignore =
     S318 # don't worry about unsafe xml
     S310 # TODO remove this later and switch to using requests
     # The following are documentation things (remove one at a time in future PRs)
+    BLK100
     D100
     D101
     D102

--- a/setup.cfg
+++ b/setup.cfg
@@ -151,7 +151,6 @@ ignore =
     D102
     D103
     D104
-    D105
 exclude =
     sssom/sssom_datamodel.py
     sssom/cliquesummary.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -150,7 +150,6 @@ ignore =
     D101
     D102
     D103
-    D104
 exclude =
     sssom/sssom_datamodel.py
     sssom/cliquesummary.py

--- a/sssom/cli.py
+++ b/sssom/cli.py
@@ -164,7 +164,7 @@ def validate(input: str):
 @main.command()
 @input_argument
 @output_directory_option
-def split(input: str, output_directory: TextIO):
+def split(input: str, output_directory: str):
     """Split input file into multiple output broken down by prefixes."""
     split_file(input_path=input, output_directory=output_directory)
 

--- a/sssom/cli.py
+++ b/sssom/cli.py
@@ -164,7 +164,7 @@ def validate(input: str):
 @main.command()
 @input_argument
 @output_directory_option
-def split(input: str, output_directory: str):
+def split(input: str, output_directory: TextIO):
     """Split input file into multiple output broken down by prefixes."""
     split_file(input_path=input, output_directory=output_directory)
 

--- a/sssom/cliques.py
+++ b/sssom/cliques.py
@@ -63,12 +63,10 @@ def split_into_cliques(msdf: MappingSetDataFrame) -> List[MappingSetDocument]:
     """Split MappingSetDataFrames into cliques.
 
     :param msdf: MappingSetDataFrame object
-    :type msdf: MappingSetDataFrame
     :raises TypeError: If Mappings is not of type List
     :raises TypeError: If each mapping is not of type Mapping
     :raises TypeError: If Mappings is not of type List
     :return: List of MappingSetDocument objects
-    :rtype: List[MappingSetDocument]
     """
     doc = to_mapping_set_document(msdf)
     g = to_networkx(msdf)
@@ -100,9 +98,7 @@ def invert_dict(d: Dict[str, str]) -> Dict[str, str]:
     """Invert Dictionary.
 
     :param d: Dictionary
-    :type d: Dict[str, str]
     :return: Dictionary with keys and values interchanged
-    :rtype: Dict[str, str]
     """
     invdict: Dict[str, Any] = {}
     for k, v in d.items():
@@ -116,11 +112,8 @@ def get_src(src: str, cid: str):
     """Get source.
 
     :param src: Source
-    :type src: str
     :param cid: CURIE
-    :type cid: str
     :return: Source
-    :rtype: [type]
     """
     if src is None:
         return cid.split(":")[0]

--- a/sssom/cliques.py
+++ b/sssom/cliques.py
@@ -1,6 +1,6 @@
 import hashlib
 import statistics
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import networkx as nx
 import pandas as pd
@@ -126,23 +126,26 @@ def summarize_cliques(doc: MappingSetDataFrame):
     cliquedocs = split_into_cliques(doc)
     items = []
     for cdoc in cliquedocs:
+        ms: Dict[Any, Any]  # NEEDS CORRECTION
         ms = cdoc.mapping_set.mappings
         members = set()
         members_names = set()
-        confs = []
-        id2src = {}
-        for m in ms:
-            sub = m.subject_id
-            obj = m.object_id
-            subsrc = get_src(m.subject_source, sub)
-            objsrc = get_src(m.object_source, obj)
-            id2src[sub] = subsrc
-            id2src[obj] = objsrc
-            members.add(sub)
-            members.add(obj)
-            members_names.add(str(m.subject_label))
-            members_names.add(str(m.object_label))
-            confs.append(m.confidence)
+        confs: List[float] = []
+        id2src: Dict[Any, str] = {}
+        if ms is not None:
+            for m in ms:
+                sub = str(m.subject_id)
+                obj = str(m.object_id)
+                subsrc = get_src(m.subject_source, sub)
+                objsrc = get_src(m.object_source, obj)
+                id2src[sub] = subsrc
+                id2src[obj] = objsrc
+                members.add(sub)
+                members.add(obj)
+                members_names.add(str(m.subject_label))
+                members_names.add(str(m.object_label))
+                if m.confidence is not None:
+                    confs.append(m.confidence)
         src2ids = invert_dict(id2src)
         mstr = "|".join(members)
         md5 = hashlib.md5(mstr.encode("utf-8")).hexdigest()  # noqa:S303

--- a/sssom/cliques.py
+++ b/sssom/cliques.py
@@ -61,7 +61,7 @@ def to_networkx(msdf: MappingSetDataFrame) -> nx.DiGraph:
 
 
 def split_into_cliques(msdf: MappingSetDataFrame) -> List[MappingSetDocument]:
-    """Split MappingSetDataFrames into a list of MappingSetDocuments.
+    """Split MappingSetDataFrames into a list of MappingSetDocuments consisting of nodes in strongly connected components of graph.
 
     :param msdf: MappingSetDataFrame object
     :raises TypeError: If Mappings is not of type List
@@ -104,7 +104,7 @@ def group_values(d: Dict[str, str]) -> Dict[str, List[str]]:
 
 
 def get_src(src: Optional[str], cid: str):
-    """Get source/CURIE of subject/object in the MappingSetDataFrame.
+    """Get prefix of subject/object in the MappingSetDataFrame.
 
     :param src: Source
     :param cid: CURIE

--- a/sssom/cliques.py
+++ b/sssom/cliques.py
@@ -1,7 +1,7 @@
 import hashlib
 import statistics
 from collections import defaultdict
-from typing import Any, DefaultDict, Dict, List, Optional
+from typing import DefaultDict, Dict, List, Optional, Set
 
 import networkx as nx
 import pandas as pd
@@ -121,32 +121,32 @@ def summarize_cliques(doc: MappingSetDataFrame):
     cliquedocs = split_into_cliques(doc)
     items = []
     for cdoc in cliquedocs:
-        ms: Dict[Any, Any]  # NEEDS CORRECTION
-        ms = cdoc.mapping_set.mappings
-        members = set()
-        members_names = set()
+        mappings = cdoc.mapping_set.mappings
+        if mappings is None:
+            continue
+        members: Set[str] = set()
+        members_names: Set[str] = set()
         confs: List[float] = []
-        id2src: Dict[Any, str] = {}
-        if ms is not None:
-            for m in ms:
-                sub = str(m.subject_id)
-                obj = str(m.object_id)
-                subsrc = get_src(m.subject_source, sub)
-                objsrc = get_src(m.object_source, obj)
-                id2src[sub] = subsrc
-                id2src[obj] = objsrc
-                members.add(sub)
-                members.add(obj)
-                members_names.add(str(m.subject_label))
-                members_names.add(str(m.object_label))
-                if m.confidence is not None:
-                    confs.append(m.confidence)
+        id2src: Dict[str, str] = {}
+        for mapping in mappings:
+            if not isinstance(mapping, Mapping):
+                raise TypeError
+            sub = str(mapping.subject_id)
+            obj = str(mapping.object_id)
+            id2src[sub] = get_src(mapping.subject_source, sub)
+            id2src[obj] = get_src(mapping.object_source, obj)
+            members.add(sub)
+            members.add(obj)
+            members_names.add(str(mapping.subject_label))
+            members_names.add(str(mapping.object_label))
+            if mapping.confidence is not None:
+                confs.append(mapping.confidence)
         src2ids = group_values(id2src)
         mstr = "|".join(members)
         md5 = hashlib.md5(mstr.encode("utf-8")).hexdigest()  # noqa:S303
         item = {
             "id": md5,
-            "num_mappings": len(ms),
+            "num_mappings": len(mappings),
             "num_members": len(members),
             "members": mstr,
             "members_labels": "|".join(members_names),

--- a/sssom/cliques.py
+++ b/sssom/cliques.py
@@ -58,7 +58,7 @@ def to_digraph(msdf: MappingSetDataFrame) -> nx.DiGraph:
 
 
 def split_into_cliques(msdf: MappingSetDataFrame) -> List[MappingSetDocument]:
-    """Split MappingSetDataFrames into a list of MappingSetDocuments consisting of nodes in strongly connected components of graph.
+    """Split a MappingSetDataFrames documents corresponding to a strongly connected components of the associated graph.
 
     :param msdf: MappingSetDataFrame object
     :raises TypeError: If Mappings is not of type List
@@ -100,15 +100,15 @@ def group_values(d: Dict[str, str]) -> Dict[str, List[str]]:
     return dict(rv)
 
 
-def get_src(src: Optional[str], cid: str):
+def get_src(src: Optional[str], curie: str):
     """Get prefix of subject/object in the MappingSetDataFrame.
 
     :param src: Source
-    :param cid: CURIE
+    :param curie: CURIE
     :return: Source
     """
     if src is None:
-        return cid.split(":")[0]
+        return curie.split(":")[0]
     else:
         return src
 

--- a/sssom/cliques.py
+++ b/sssom/cliques.py
@@ -1,6 +1,7 @@
 import hashlib
 import statistics
-from typing import Any, Dict, List, Optional, Union
+from collections import defaultdict
+from typing import Any, DefaultDict, Dict, List, Optional
 
 import networkx as nx
 import pandas as pd
@@ -94,18 +95,12 @@ def split_into_cliques(msdf: MappingSetDataFrame) -> List[MappingSetDocument]:
     return newdocs
 
 
-def invert_dict(d: Dict[str, str]) -> Dict[str, str]:
-    """Invert Dictionary: sxkeys become values and values become keys.
-
-    :param d: Dictionary
-    :return: Dictionary with keys and values interchanged
-    """
-    invdict: Dict[str, Any] = {}
+def group_values(d: Dict[str, str]) -> Dict[str, List[str]]:
+    """Group all keys in the dictionary that share the same value."""
+    rv: DefaultDict[str, List[str]] = defaultdict(list)
     for k, v in d.items():
-        if v not in invdict:
-            invdict[v] = []
-        invdict[v].append(k)
-    return invdict
+        rv[v].append(k)
+    return dict(rv)
 
 
 def get_src(src: Optional[str], cid: str):
@@ -146,7 +141,7 @@ def summarize_cliques(doc: MappingSetDataFrame):
                 members_names.add(str(m.object_label))
                 if m.confidence is not None:
                     confs.append(m.confidence)
-        src2ids = invert_dict(id2src)
+        src2ids = group_values(id2src)
         mstr = "|".join(members)
         md5 = hashlib.md5(mstr.encode("utf-8")).hexdigest()  # noqa:S303
         item = {

--- a/sssom/cliques.py
+++ b/sssom/cliques.py
@@ -1,6 +1,6 @@
 import hashlib
 import statistics
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import networkx as nx
 import pandas as pd
@@ -59,7 +59,17 @@ def to_networkx(msdf: MappingSetDataFrame) -> nx.DiGraph:
     return g
 
 
-def split_into_cliques(msdf: MappingSetDataFrame):
+def split_into_cliques(msdf: MappingSetDataFrame) -> List[MappingSetDocument]:
+    """Split MappingSetDataFrames into cliques.
+
+    :param msdf: MappingSetDataFrame object
+    :type msdf: MappingSetDataFrame
+    :raises TypeError: If Mappings is not of type List
+    :raises TypeError: If each mapping is not of type Mapping
+    :raises TypeError: If Mappings is not of type List
+    :return: List of MappingSetDocument objects
+    :rtype: List[MappingSetDocument]
+    """
     doc = to_mapping_set_document(msdf)
     g = to_networkx(msdf)
     gen = nx.algorithms.components.strongly_connected_components(g)
@@ -87,6 +97,13 @@ def split_into_cliques(msdf: MappingSetDataFrame):
 
 
 def invert_dict(d: Dict[str, str]) -> Dict[str, str]:
+    """Invert Dictionary.
+
+    :param d: Dictionary
+    :type d: Dict[str, str]
+    :return: Dictionary with keys and values interchanged
+    :rtype: Dict[str, str]
+    """
     invdict: Dict[str, Any] = {}
     for k, v in d.items():
         if v not in invdict:
@@ -95,7 +112,16 @@ def invert_dict(d: Dict[str, str]) -> Dict[str, str]:
     return invdict
 
 
-def get_src(src, cid):
+def get_src(src: str, cid: str):
+    """Get source.
+
+    :param src: Source
+    :type src: str
+    :param cid: CURIE
+    :type cid: str
+    :return: Source
+    :rtype: [type]
+    """
     if src is None:
         return cid.split(":")[0]
     else:

--- a/sssom/cliques.py
+++ b/sssom/cliques.py
@@ -60,7 +60,7 @@ def to_networkx(msdf: MappingSetDataFrame) -> nx.DiGraph:
 
 
 def split_into_cliques(msdf: MappingSetDataFrame) -> List[MappingSetDocument]:
-    """Split MappingSetDataFrames into cliques.
+    """Split MappingSetDataFrames into a list of MappingSetDocuments.
 
     :param msdf: MappingSetDataFrame object
     :raises TypeError: If Mappings is not of type List
@@ -109,7 +109,7 @@ def invert_dict(d: Dict[str, str]) -> Dict[str, str]:
 
 
 def get_src(src: str, cid: str):
-    """Get source.
+    """Get source/CURIE of subject/object in the MappingSetDataFrame.
 
     :param src: Source
     :param cid: CURIE

--- a/sssom/cliques.py
+++ b/sssom/cliques.py
@@ -95,7 +95,7 @@ def split_into_cliques(msdf: MappingSetDataFrame) -> List[MappingSetDocument]:
 
 
 def invert_dict(d: Dict[str, str]) -> Dict[str, str]:
-    """Invert Dictionary.
+    """Invert Dictionary: sxkeys become values and values become keys.
 
     :param d: Dictionary
     :return: Dictionary with keys and values interchanged

--- a/sssom/cliques.py
+++ b/sssom/cliques.py
@@ -1,6 +1,6 @@
 import hashlib
 import statistics
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import networkx as nx
 import pandas as pd
@@ -108,7 +108,7 @@ def invert_dict(d: Dict[str, str]) -> Dict[str, str]:
     return invdict
 
 
-def get_src(src: str, cid: str):
+def get_src(src: Optional[str], cid: str):
     """Get source/CURIE of subject/object in the MappingSetDataFrame.
 
     :param src: Source

--- a/sssom/context.py
+++ b/sssom/context.py
@@ -15,14 +15,29 @@ SSSOM_BUILT_IN_PREFIXES = ["sssom", "owl", "rdf", "rdfs", "skos"]
 
 
 def get_jsonld_context():
+    """Get JSON-LD context.
+
+    :return: JSON-LD context
+    :rtype: Any
+    """
     return json.loads(sssom_context, strict=False)
 
 
 def get_external_jsonld_context():
+    """Get JSON-LD context.
+
+    :return: JSON-LD context
+    :rtype: Any
+    """
     return json.loads(sssom_external_context, strict=False)
 
 
 def get_built_in_prefix_map() -> PrefixMap:
+    """Get built-in prefix map.
+
+    :return: Prefix map
+    :rtype: PrefixMap
+    """
     contxt = get_jsonld_context()
     prefix_map = {}
     for key in contxt["@context"]:
@@ -36,6 +51,13 @@ def get_built_in_prefix_map() -> PrefixMap:
 def add_built_in_prefixes_to_prefix_map(
     prefix_map: Optional[PrefixMap] = None,
 ) -> PrefixMap:
+    """Add built-in prefix map.
+
+    :param prefix_map: Prefix map, defaults to None
+    :type prefix_map: Optional[PrefixMap], optional
+    :return: Prefix map
+    :rtype: PrefixMap
+    """
     builtinmap = get_built_in_prefix_map()
     if not prefix_map:
         prefix_map = builtinmap
@@ -51,6 +73,11 @@ def add_built_in_prefixes_to_prefix_map(
 
 
 def get_default_metadata() -> Metadata:
+    """Get Default metadata.
+
+    :return: Metadata
+    :rtype: Metadata
+    """
     contxt = get_jsonld_context()
     contxt_external = get_external_jsonld_context()
     prefix_map = {}

--- a/sssom/context.py
+++ b/sssom/context.py
@@ -18,7 +18,6 @@ def get_jsonld_context():
     """Get JSON-LD context.
 
     :return: JSON-LD context
-    :rtype: Any
     """
     return json.loads(sssom_context, strict=False)
 
@@ -27,7 +26,6 @@ def get_external_jsonld_context():
     """Get JSON-LD context.
 
     :return: JSON-LD context
-    :rtype: Any
     """
     return json.loads(sssom_external_context, strict=False)
 
@@ -36,7 +34,6 @@ def get_built_in_prefix_map() -> PrefixMap:
     """Get built-in prefix map.
 
     :return: Prefix map
-    :rtype: PrefixMap
     """
     contxt = get_jsonld_context()
     prefix_map = {}
@@ -54,9 +51,7 @@ def add_built_in_prefixes_to_prefix_map(
     """Add built-in prefix map.
 
     :param prefix_map: Prefix map, defaults to None
-    :type prefix_map: Optional[PrefixMap], optional
     :return: Prefix map
-    :rtype: PrefixMap
     """
     builtinmap = get_built_in_prefix_map()
     if not prefix_map:
@@ -76,7 +71,6 @@ def get_default_metadata() -> Metadata:
     """Get Default metadata.
 
     :return: Metadata
-    :rtype: Metadata
     """
     contxt = get_jsonld_context()
     contxt_external = get_external_jsonld_context()

--- a/sssom/context.py
+++ b/sssom/context.py
@@ -15,7 +15,9 @@ SSSOM_BUILT_IN_PREFIXES = ["sssom", "owl", "rdf", "rdfs", "skos"]
 
 
 def get_jsonld_context():
-    """Get JSON-LD context.
+    """Get JSON-LD form of sssom_context variable from auto-generated 'internal_context.py' file.
+
+    [Auto generated from sssom.yaml by jsonldcontextgen.py]
 
     :return: JSON-LD context
     """
@@ -23,7 +25,7 @@ def get_jsonld_context():
 
 
 def get_external_jsonld_context():
-    """Get JSON-LD context.
+    """Get JSON-LD form of sssom_external_context variable from auto-generated 'external_context.py' file.
 
     :return: JSON-LD context
     """
@@ -31,7 +33,9 @@ def get_external_jsonld_context():
 
 
 def get_built_in_prefix_map() -> PrefixMap:
-    """Get built-in prefix map.
+    """Get built-in prefix map from the sssom_context variable in the auto-generated 'internal_context.py' file.
+
+    [Auto generated from sssom.yaml by jsonldcontextgen.py]
 
     :return: Prefix map
     """
@@ -48,7 +52,9 @@ def get_built_in_prefix_map() -> PrefixMap:
 def add_built_in_prefixes_to_prefix_map(
     prefix_map: Optional[PrefixMap] = None,
 ) -> PrefixMap:
-    """Add built-in prefix map.
+    """Add built-in prefix map from the sssom_context variable in the auto-generated 'internal_context.py' file.
+
+    [Auto generated from sssom.yaml by jsonldcontextgen.py]
 
     :param prefix_map: Prefix map, defaults to None
     :return: Prefix map
@@ -68,7 +74,9 @@ def add_built_in_prefixes_to_prefix_map(
 
 
 def get_default_metadata() -> Metadata:
-    """Get Default metadata.
+    """Get @context property value from the sssom_context variable in the auto-generated 'internal_context.py' file.
+
+    [Auto generated from sssom.yaml by jsonldcontextgen.py]
 
     :return: Metadata
     """

--- a/sssom/context.py
+++ b/sssom/context.py
@@ -56,8 +56,8 @@ def add_built_in_prefixes_to_prefix_map(
 
     [Auto generated from sssom.yaml by jsonldcontextgen.py]
 
-    :param prefix_map: Prefix map, defaults to None
-    :return: Prefix map
+    :param prefix_map: A custom prefix map
+    :return: A prefix map
     """
     builtinmap = get_built_in_prefix_map()
     if not prefix_map:

--- a/sssom/io.py
+++ b/sssom/io.py
@@ -54,8 +54,6 @@ def parse_file(
     metadata = get_metadata_and_prefix_map(
         metadata_path=metadata_path, prefix_map_mode=prefix_map_mode
     )
-    if input_format is None:
-        raise ValueError("Input format not provided.")
     parse_func = get_parsing_function(input_format, input_path)
     doc = parse_func(
         input_path, prefix_map=metadata.prefix_map, meta=metadata.prefix_map

--- a/sssom/io.py
+++ b/sssom/io.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Optional, TextIO
+from pathlib import Path
+from typing import Optional, TextIO, Union
 
 from .context import get_default_metadata
 from .parsers import get_parsing_function, read_sssom_table, split_dataframe
@@ -83,7 +84,7 @@ def validate_file(input_path: str) -> bool:
         return False
 
 
-def split_file(input_path: str, output_directory: TextIO) -> None:
+def split_file(input_path: str, output_directory: Union[str, Path]) -> None:
     """
     Split an SSSOM TSV by prefixes and relations.
 

--- a/sssom/io.py
+++ b/sssom/io.py
@@ -54,7 +54,7 @@ def parse_file(
         metadata_path=metadata_path, prefix_map_mode=prefix_map_mode
     )
     if input_format is None:
-        raise(ValueError('Input format not provided.'))
+        raise ValueError("Input format not provided.")
     parse_func = get_parsing_function(input_format, input_path)
     doc = parse_func(
         input_path, prefix_map=metadata.prefix_map, meta=metadata.prefix_map

--- a/sssom/io.py
+++ b/sssom/io.py
@@ -53,6 +53,8 @@ def parse_file(
     metadata = get_metadata_and_prefix_map(
         metadata_path=metadata_path, prefix_map_mode=prefix_map_mode
     )
+    if input_format is None:
+        raise(ValueError('Input format not provided.'))
     parse_func = get_parsing_function(input_format, input_path)
     doc = parse_func(
         input_path, prefix_map=metadata.prefix_map, meta=metadata.prefix_map
@@ -81,7 +83,7 @@ def validate_file(input_path: str) -> bool:
         return False
 
 
-def split_file(input_path: str, output_directory: str) -> None:
+def split_file(input_path: str, output_directory: TextIO) -> None:
     """
     Split an SSSOM TSV by prefixes and relations.
 

--- a/sssom/parsers.py
+++ b/sssom/parsers.py
@@ -647,7 +647,7 @@ def split_dataframe(
     """Split DataFrame.
 
     :param msdf: MappingSetDataFrame object
-    :raises RuntimeError: Object is None
+    :raises RuntimeError: DataFrame object within MappingSetDataFrame is None
     :return: Mapping object
     """
     if msdf.df is None:

--- a/sssom/parsers.py
+++ b/sssom/parsers.py
@@ -224,11 +224,11 @@ def from_sssom_rdf(
 ) -> MappingSetDataFrame:
     """Convert an SSSOM RDF graph into a SSSOM data table.
 
-    Args:
-        g: the Graph (rdflib)
-        prefix_map: A dictionary containing the prefix map
-        meta: Potentially additional metadata
-        mapping_predicates: A set of predicates that should be extracted from the RDF graph
+    :param g: the Graph (rdflib)
+    :param prefix_map: A dictionary containing the prefix map, defaults to None
+    :param meta: Potentially additional metadata, defaults to None
+    :param mapping_predicates: A set of predicates that should be extracted from the RDF graph, defaults to None
+    :return: MappingSetDataFrame object
     """
     prefix_map = _ensure_prefix_map(prefix_map)
 
@@ -297,13 +297,9 @@ def from_sssom_json(
     """Get data from JSON.
 
     :param jsondoc: JSON document
-    :type jsondoc: Union[str, dict, TextIO]
     :param prefix_map: Prefix map
-    :type prefix_map: Dict[str, str]
     :param meta: metadata, defaults to None
-    :type meta: Dict[str, str], optional
     :return: MappingSetDataFrame object
-    :rtype: MappingSetDataFrame
     """
     prefix_map = _ensure_prefix_map(prefix_map)
     mapping_set = cast(
@@ -376,14 +372,11 @@ def from_obographs(
 ) -> MappingSetDataFrame:
     """Convert a obographs json object to an SSSOM data frame.
 
-    Args:
-        jsondoc: The JSON object representing the ontology in obographs format
-        prefix_map: The prefix map to be used
-        meta: Any additional metadata that needs to be added to the resulting SSSOM data frame
-
-    Returns:
-        An SSSOM data frame (MappingSetDataFrame)
-
+    :param jsondoc: The JSON object representing the ontology in obographs format
+    :param prefix_map: The prefix map to be used
+    :param meta: Any additional metadata that needs to be added to the resulting SSSOM data frame, defaults to None
+    :raises Exception: When there is no CURIE
+    :return: An SSSOM data frame (MappingSetDataFrame)
     """
     _ensure_prefix_map(prefix_map)
 
@@ -467,12 +460,9 @@ def get_parsing_function(input_format: str, filename: str) -> Callable:
     """Return appropriate function based on input format of file.
 
     :param input_format: File format
-    :type input_format: str
     :param filename: Filename
-    :type filename: str
     :raises Exception: Unknown file format
     :return: Appropriate 'read' function
-    :rtype: function
     """
     if input_format is None:
         input_format = get_file_extension(filename)
@@ -657,10 +647,8 @@ def split_dataframe(
     """Split DataFrame.
 
     :param msdf: MappingSetDataFrame object
-    :type msdf: MappingSetDataFrame
     :raises RuntimeError: Object is None
     :return: Mapping object
-    :rtype: typing.Mapping[str, MappingSetDataFrame]
     """
     if msdf.df is None:
         raise RuntimeError

--- a/sssom/parsers.py
+++ b/sssom/parsers.py
@@ -3,7 +3,7 @@ import logging
 import re
 import typing
 from collections import Counter
-from typing import Any, Dict, List, Optional, Set, TextIO, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Set, TextIO, Union, cast
 from urllib.request import urlopen
 from xml.dom import Node, minidom
 from xml.dom.minidom import Document
@@ -294,6 +294,17 @@ def from_sssom_json(
     prefix_map: Dict[str, str],
     meta: Dict[str, str] = None,
 ) -> MappingSetDataFrame:
+    """Get data from JSON.
+
+    :param jsondoc: JSON document
+    :type jsondoc: Union[str, dict, TextIO]
+    :param prefix_map: Prefix map
+    :type prefix_map: Dict[str, str]
+    :param meta: metadata, defaults to None
+    :type meta: Dict[str, str], optional
+    :return: MappingSetDataFrame object
+    :rtype: MappingSetDataFrame
+    """
     prefix_map = _ensure_prefix_map(prefix_map)
     mapping_set = cast(
         MappingSet, JSONLoader().load(source=jsondoc, target_class=MappingSet)
@@ -452,7 +463,17 @@ def from_obographs(
 # All read_* take as an input a a file handle and return a MappingSetDataFrame (usually wrapping a from_* method)
 
 
-def get_parsing_function(input_format, filename):
+def get_parsing_function(input_format: str, filename: str) -> Callable:
+    """Return appropriate function based on input format of file.
+
+    :param input_format: File format
+    :type input_format: str
+    :param filename: Filename
+    :type filename: str
+    :raises Exception: Unknown file format
+    :return: Appropriate 'read' function
+    :rtype: function
+    """
     if input_format is None:
         input_format = get_file_extension(filename)
     if input_format == "tsv":
@@ -633,6 +654,14 @@ def to_mapping_set_document(msdf: MappingSetDataFrame) -> MappingSetDocument:
 def split_dataframe(
     msdf: MappingSetDataFrame,
 ) -> typing.Mapping[str, MappingSetDataFrame]:
+    """Split DataFrame.
+
+    :param msdf: MappingSetDataFrame object
+    :type msdf: MappingSetDataFrame
+    :raises RuntimeError: Object is None
+    :return: Mapping object
+    :rtype: typing.Mapping[str, MappingSetDataFrame]
+    """
     if msdf.df is None:
         raise RuntimeError
     subject_prefixes = set(msdf.df["subject_id"].str.split(":", 1, expand=True)[0])

--- a/sssom/parsers.py
+++ b/sssom/parsers.py
@@ -294,11 +294,11 @@ def from_sssom_json(
     prefix_map: Dict[str, str],
     meta: Dict[str, str] = None,
 ) -> MappingSetDataFrame:
-    """Get data from JSON.
+    """Load a mapping set dataframe from a JSON object.
 
     :param jsondoc: JSON document
     :param prefix_map: Prefix map
-    :param meta: metadata, defaults to None
+    :param meta: metadata
     :return: MappingSetDataFrame object
     """
     prefix_map = _ensure_prefix_map(prefix_map)
@@ -644,7 +644,7 @@ def to_mapping_set_document(msdf: MappingSetDataFrame) -> MappingSetDocument:
 def split_dataframe(
     msdf: MappingSetDataFrame,
 ) -> Dict[str, MappingSetDataFrame]:
-    """Split DataFrame.
+    """Group the mapping set dataframe into several subdataframes by prefix.
 
     :param msdf: MappingSetDataFrame object
     :raises RuntimeError: DataFrame object within MappingSetDataFrame is None

--- a/sssom/parsers.py
+++ b/sssom/parsers.py
@@ -643,7 +643,7 @@ def to_mapping_set_document(msdf: MappingSetDataFrame) -> MappingSetDocument:
 
 def split_dataframe(
     msdf: MappingSetDataFrame,
-) -> typing.Mapping[str, MappingSetDataFrame]:
+) -> Dict[str, MappingSetDataFrame]:
     """Split DataFrame.
 
     :param msdf: MappingSetDataFrame object
@@ -665,7 +665,7 @@ def split_dataframe(
 
 def split_dataframe_by_prefix(
     msdf: MappingSetDataFrame, subject_prefixes, object_prefixes, relations
-) -> typing.Mapping[str, MappingSetDataFrame]:
+) -> Dict[str, MappingSetDataFrame]:
     """Split a mapping set dataframe by prefix.
 
     :param msdf: An SSSOM MappingSetDataFrame

--- a/sssom/parsers.py
+++ b/sssom/parsers.py
@@ -456,8 +456,8 @@ def from_obographs(
 # All read_* take as an input a a file handle and return a MappingSetDataFrame (usually wrapping a from_* method)
 
 
-def get_parsing_function(input_format: str, filename: str) -> Callable:
-    """Return appropriate function based on input format of file.
+def get_parsing_function(input_format: Optional[str], filename: str) -> Callable:
+    """Return appropriate parser function based on input format of file.
 
     :param input_format: File format
     :param filename: Filename

--- a/sssom/sparql_util.py
+++ b/sssom/sparql_util.py
@@ -84,7 +84,7 @@ def query_mappings(config: EndpointConfig) -> MappingSetDataFrame:
 
 
 def curiefy_row(row: Mapping[str, str], config: EndpointConfig) -> Dict[str, str]:
-    """CURIEfy row.
+    """CURIE-fy row.
 
     :param row: Mapping object row
     :type row: Mapping[str, str]

--- a/sssom/sparql_util.py
+++ b/sssom/sparql_util.py
@@ -87,11 +87,8 @@ def curiefy_row(row: Mapping[str, str], config: EndpointConfig) -> Dict[str, str
     """CURIE-fy row.
 
     :param row: Mapping object row
-    :type row: Mapping[str, str]
     :param config: Configuration
-    :type config: EndpointConfig
     :return: Dictionary of CURIEs
-    :rtype: Dict[str, str]
     """
     return {k: contract_uri(v, config) for k, v in row.items()}
 
@@ -100,11 +97,8 @@ def contract_uri(uristr: str, config: EndpointConfig) -> str:
     """Contract URI.
 
     :param uristr: URI string
-    :type uristr: str
     :param config: Configuration
-    :type config: EndpointConfig
     :return: URI string (contracted)
-    :rtype: str
     """
     if config.prefix_map is None:
         return uristr
@@ -118,11 +112,8 @@ def expand_curie(curie: str, config: EndpointConfig) -> URIRef:
     """Expand CURIE.
 
     :param curie: CURIE
-    :type curie: str
     :param config: Configuration
-    :type config: EndpointConfig
     :return: URI of CURIE
-    :rtype: URIRef
     """
     if config.prefix_map is None:
         return URIRef(curie)

--- a/sssom/sparql_util.py
+++ b/sssom/sparql_util.py
@@ -96,7 +96,7 @@ def curiefy_row(row: Mapping[str, str], config: EndpointConfig) -> Dict[str, str
 def contract_uri(uristr: str, config: EndpointConfig) -> str:
     """Contract URI. For e.g. "http://purl.org/dc/terms/" => "dc".
 
-    :param uristr: URI string
+    :param uristr: Prefix
     :param config: Configuration
     :return: URI string (contracted)
     """
@@ -109,7 +109,7 @@ def contract_uri(uristr: str, config: EndpointConfig) -> str:
 
 
 def expand_curie(curie: str, config: EndpointConfig) -> URIRef:
-    """Expand CURIE. For e.g. "dc" => "http://purl.org/dc/terms/".
+    """Expand prefix. For e.g. "dc" => "http://purl.org/dc/terms/".
 
     :param curie: CURIE
     :param config: Configuration

--- a/sssom/sparql_util.py
+++ b/sssom/sparql_util.py
@@ -84,10 +84,28 @@ def query_mappings(config: EndpointConfig) -> MappingSetDataFrame:
 
 
 def curiefy_row(row: Mapping[str, str], config: EndpointConfig) -> Dict[str, str]:
+    """CURIEfy row.
+
+    :param row: Mapping object row
+    :type row: Mapping[str, str]
+    :param config: Configuration
+    :type config: EndpointConfig
+    :return: Dictionary of CURIEs
+    :rtype: Dict[str, str]
+    """
     return {k: contract_uri(v, config) for k, v in row.items()}
 
 
 def contract_uri(uristr: str, config: EndpointConfig) -> str:
+    """Contract URI.
+
+    :param uristr: URI string
+    :type uristr: str
+    :param config: Configuration
+    :type config: EndpointConfig
+    :return: URI string (contracted)
+    :rtype: str
+    """
     if config.prefix_map is None:
         return uristr
     for k, v in config.prefix_map.items():
@@ -97,6 +115,15 @@ def contract_uri(uristr: str, config: EndpointConfig) -> str:
 
 
 def expand_curie(curie: str, config: EndpointConfig) -> URIRef:
+    """Expand CURIE.
+
+    :param curie: CURIE
+    :type curie: str
+    :param config: Configuration
+    :type config: EndpointConfig
+    :return: URI of CURIE
+    :rtype: URIRef
+    """
     if config.prefix_map is None:
         return URIRef(curie)
     for k, v in config.prefix_map.items():

--- a/sssom/sparql_util.py
+++ b/sssom/sparql_util.py
@@ -94,7 +94,7 @@ def curiefy_row(row: Mapping[str, str], config: EndpointConfig) -> Dict[str, str
 
 
 def contract_uri(uristr: str, config: EndpointConfig) -> str:
-    """Contract URI. For e.g. "http://purl.org/dc/terms/" => "dc".
+    """Replace the URI with a prefix based on the prefix map in the given configuration.
 
     :param uristr: Prefix
     :param config: Configuration

--- a/sssom/sparql_util.py
+++ b/sssom/sparql_util.py
@@ -84,7 +84,7 @@ def query_mappings(config: EndpointConfig) -> MappingSetDataFrame:
 
 
 def curiefy_row(row: Mapping[str, str], config: EndpointConfig) -> Dict[str, str]:
-    """CURIE-fy row.
+    """Assign a contracted URI ("dc") if Mapping object dictionary value is "http://purl.org/dc/terms/".
 
     :param row: Mapping object row
     :param config: Configuration
@@ -94,7 +94,7 @@ def curiefy_row(row: Mapping[str, str], config: EndpointConfig) -> Dict[str, str
 
 
 def contract_uri(uristr: str, config: EndpointConfig) -> str:
-    """Contract URI.
+    """Contract URI. For e.g. "http://purl.org/dc/terms/" => "dc".
 
     :param uristr: URI string
     :param config: Configuration
@@ -109,7 +109,7 @@ def contract_uri(uristr: str, config: EndpointConfig) -> str:
 
 
 def expand_curie(curie: str, config: EndpointConfig) -> URIRef:
-    """Expand CURIE.
+    """Expand CURIE. For e.g. "dc" => "http://purl.org/dc/terms/".
 
     :param curie: CURIE
     :param config: Configuration

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -349,7 +349,7 @@ def compare_dataframes(df1: pd.DataFrame, df2: pd.DataFrame) -> MappingSetDiff:
     return d
 
 
-def dataframe_to_ptable(df: pd.DataFrame, inverse_factor: float = 0.5):
+def dataframe_to_ptable(df: pd.DataFrame, *, inverse_factor: float = 0.5):
     """Export a KBOOM table.
 
     :param df: Pandas DataFrame

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -275,19 +275,18 @@ def remove_unmatched(df: pd.DataFrame) -> pd.DataFrame:
     return df[df[PREDICATE_ID] != "noMatch"]
 
 
-def create_entity(eid: str, mappings: Dict[str, Any]) -> Entity:
+def create_entity(identifier: str, mappings: Dict[str, Any]) -> Entity:
     """Create an Entity object.
 
-    :param row: Row - [UNUSED]
-    :param eid: Entity Id
+    :param identifier: Entity Id
     :param mappings: Mapping dictionary
     :return: An Entity object
     """
-    e = Entity(id=eid)
-    for k, v in mappings.items():
-        if k in e:
-            e[k] = v
-    return e
+    entity = Entity(id=identifier)
+    for key, value in mappings.items():
+        if key in entity:
+            entity[key] = value
+    return entity
 
 
 def group_mappings(df: pd.DataFrame) -> Dict[EntityPair, List[pd.Series]]:
@@ -295,7 +294,7 @@ def group_mappings(df: pd.DataFrame) -> Dict[EntityPair, List[pd.Series]]:
     mappings: DefaultDict[EntityPair, List[pd.Series]] = defaultdict(list)
     for _, row in df.iterrows():
         subject_entity = create_entity(
-            eid=row[SUBJECT_ID],
+            identifier=row[SUBJECT_ID],
             mappings={
                 "label": SUBJECT_LABEL,
                 "category": SUBJECT_CATEGORY,
@@ -303,7 +302,7 @@ def group_mappings(df: pd.DataFrame) -> Dict[EntityPair, List[pd.Series]]:
             },
         )
         object_entity = create_entity(
-            eid=row[OBJECT_ID],
+            identifier=row[OBJECT_ID],
             mappings={
                 "label": OBJECT_LABEL,
                 "category": OBJECT_CATEGORY,

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -273,7 +273,7 @@ def remove_unmatched(df: pd.DataFrame) -> pd.DataFrame:
     return df[df[PREDICATE_ID] != "noMatch"]
 
 
-def create_entity(row, eid: str, mappings: Dict[str, Any]) -> Entity:
+def create_entity(eid: str, mappings: Dict[str, Any]) -> Entity:
     """Create an Entity object.
 
     :param row: Row - [UNUSED]
@@ -281,7 +281,6 @@ def create_entity(row, eid: str, mappings: Dict[str, Any]) -> Entity:
     :param mappings: Mapping dictionary
     :return: An Entity object
     """
-    logging.warning(f"create_entity() has row parameter ({row}), but not used.")
     e = Entity(id=eid)
     for k, v in mappings.items():
         if k in e:
@@ -294,7 +293,6 @@ def group_mappings(df: pd.DataFrame) -> Dict[EntityPair, List[pd.Series]]:
     mappings: DefaultDict[EntityPair, List[pd.Series]] = defaultdict(list)
     for _, row in df.iterrows():
         subject_entity = create_entity(
-            row,
             eid=row[SUBJECT_ID],
             mappings={
                 "label": SUBJECT_LABEL,
@@ -303,7 +301,6 @@ def group_mappings(df: pd.DataFrame) -> Dict[EntityPair, List[pd.Series]]:
             },
         )
         object_entity = create_entity(
-            row,
             eid=row[OBJECT_ID],
             mappings={
                 "label": OBJECT_LABEL,

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -435,19 +435,17 @@ PREDICATE_SIBLING = 3
 RDF_FORMATS = {"ttl", "turtle", "nt", "xml"}
 
 
-def sha256sum(filename: str) -> str:
+def sha256sum(path: str) -> str:
     """Calculate the SHA256 hash over the bytes in a file.
 
-    :param filename: Filename
-    :type filename: str
+    :param path: Filename
     :return: Hashed value
-    :rtype: str
     """
     h = hashlib.sha256()
     b = bytearray(128 * 1024)
     mv = memoryview(b)
-    with open(filename, "rb", buffering=0) as f:
-        for n in iter(lambda: f.readinto(mv), 0):  # type: ignore
+    with open(path, "rb", buffering=0) as file:
+        for n in iter(lambda: file.readinto(mv), 0):  # type: ignore
             h.update(mv[:n])
     return h.hexdigest()
 

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -189,14 +189,26 @@ def collapse(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def sort_sssom_columns(columns: List[str]) -> List[str]:
-    # Ideally, the order of the sssom column names is parsed strictly from sssom.yaml
+    """Sort columns: Ideally, the order of the sssom column names is parsed strictly from sssom.yaml.
 
+    :param columns: Column names
+    :type columns: List[str]
+    :return: Sorted column names
+    :rtype: List[str]
+    """
     logging.warning("SSSOM sort columns not implemented")
     columns.sort()
     return columns
 
 
 def sort_sssom(df: pd.DataFrame) -> pd.DataFrame:
+    """Sort SSSOM by columns.
+
+    :param df: SSSOM DataFrame to be sorted.
+    :type df: pd.DataFrame
+    :return: Sorted SSSOM DataFrame
+    :rtype: pd.DataFrame
+    """
     df.sort_values(
         by=sort_sssom_columns(list(df.columns)), ascending=False, inplace=True
     )
@@ -253,6 +265,13 @@ def filter_redundant_rows(
 
 
 def assign_default_confidence(df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Assign numpy.NaN values to confidence that are blank.
+
+    :param df: SSSOM DataFrame
+    :type df: pd.DataFrame
+    :return: A Tuple consisting of the original DataFrame and dataframe consisting of empty confidence values.
+    :rtype: Tuple[pd.DataFrame, pd.DataFrame]
+    """
     # Get rows having numpy.NaN as confidence
     if df is not None and "confidence" not in df.columns:
         df["confidence"] = np.NaN
@@ -274,6 +293,17 @@ def remove_unmatched(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def create_entity(row, eid: str, mappings: Dict[str, Any]) -> Entity:
+    """Create an Entity object.
+
+    :param row: Row - [UNUSED]
+    :type row: [type]
+    :param eid: Entity Id
+    :type eid: str
+    :param mappings: Mapping dictionary
+    :type mappings: Dict[str, Any]
+    :return: An Entity object
+    :rtype: Entity
+    """
     logging.warning(f"create_entity() has row parameter ({row}), but not used.")
     e = Entity(id=eid)
     for k, v in mappings.items():
@@ -440,7 +470,14 @@ PREDICATE_SIBLING = 3
 RDF_FORMATS = {"ttl", "turtle", "nt", "xml"}
 
 
-def sha256sum(filename):
+def sha256sum(filename: str) -> str:
+    """Hashing function.
+
+    :param filename: Filename
+    :type filename: str
+    :return: Hashed value
+    :rtype: str
+    """
     h = hashlib.sha256()
     b = bytearray(128 * 1024)
     mv = memoryview(b)
@@ -667,6 +704,14 @@ def inject_metadata_into_df(msdf: MappingSetDataFrame) -> MappingSetDataFrame:
 
 
 def get_file_extension(file: Union[str, TextIO]) -> str:
+    """Get file extension.
+
+    :param file: Name of the file
+    :type file: Union[str, TextIO]
+    :raises Exception: Cannot determine extension exception
+    :return: format of the file passed
+    :rtype: str
+    """
     if isinstance(file, str):
         filename = file
     else:
@@ -679,7 +724,18 @@ def get_file_extension(file: Union[str, TextIO]) -> str:
         raise Exception(f"Cannot guess format from {filename}")
 
 
-def read_csv(filename, comment="#", sep=","):
+def read_csv(filename: str, comment: str = "#", sep: str = ",") -> pd.DataFrame:
+    """Read TSV file.
+
+    :param filename: filename
+    :type filename: str
+    :param comment: character that indicates beginning of a comment, defaults to "#"
+    :type comment: str, optional
+    :param sep: separator, defaults to ","
+    :type sep: str, optional
+    :return: Pandas DataFrame
+    :rtype: pd.DataFrame
+    """
     if validators.url(filename):
         response = urlopen(filename)
         lines = "".join(
@@ -724,7 +780,14 @@ def read_pandas(file: Union[str, TextIO], sep: Optional[str] = None) -> pd.DataF
     return read_csv(file, comment="#", sep=sep).fillna("")
 
 
-def extract_global_metadata(msdoc: MappingSetDocument):
+def extract_global_metadata(msdoc: MappingSetDocument) -> Dict[str, PrefixMap]:
+    """Extract metadata.
+
+    :param msdoc: MappingSetDocument object
+    :type msdoc: MappingSetDocument
+    :return: Dictionary containing metadata
+    :rtype: Dict[str, PrefixMap]
+    """
     meta = {PREFIX_MAP_KEY: msdoc.prefix_map}
     ms_meta = msdoc.mapping_set
     for key in [
@@ -740,9 +803,13 @@ def extract_global_metadata(msdoc: MappingSetDocument):
 
 
 def to_mapping_set_dataframe(doc: MappingSetDocument) -> MappingSetDataFrame:
-    ###
-    # convert MappingSetDocument into MappingSetDataFrame
-    ###
+    """Convert MappingSetDocument into MappingSetDataFrame.
+
+    :param doc: MappingSetDocument object
+    :type doc: MappingSetDocument
+    :return: MappingSetDataFrame object
+    :rtype: MappingSetDataFrame
+    """
     data = []
     if doc.mapping_set.mappings is not None:
         for mapping in doc.mapping_set.mappings:
@@ -770,10 +837,24 @@ CURIE_RE = re.compile(r"[A-Za-z0-9_]+[:][A-Za-z0-9_]")
 
 
 def is_curie(string: str) -> bool:
+    """Check if string is CURIE or not.
+
+    :param string: String
+    :type string: str
+    :return: Boolean indicating CURIE or not
+    :rtype: bool
+    """
     return bool(CURIE_RE.match(string))
 
 
 def get_prefix_from_curie(curie: str) -> str:
+    """Get prefix from CURIE.
+
+    :param curie: CURIE
+    :type curie: str
+    :return: Prefix
+    :rtype: str
+    """
     if is_curie(curie):
         return curie.split(":")[0]
     else:
@@ -812,6 +893,13 @@ def curie_from_uri(uri: str, prefix_map: Mapping[str, str]) -> str:
 
 
 def get_prefixes_used_in_table(df: pd.DataFrame) -> List[str]:
+    """Get prefixes used in table.
+
+    :param df: Pandas DatafFrame
+    :type df: pd.DataFrame
+    :return: List of unique prefixes
+    :rtype: List[str]
+    """
     prefixes = []
     for col in KEY_FEATURES:
         for v in df[col].values:
@@ -819,7 +907,16 @@ def get_prefixes_used_in_table(df: pd.DataFrame) -> List[str]:
     return list(set(prefixes))
 
 
-def filter_out_prefixes(df: pd.DataFrame, filter_prefixes) -> pd.DataFrame:
+def filter_out_prefixes(df: pd.DataFrame, filter_prefixes: List[str]) -> pd.DataFrame:
+    """Get all prefixes in filter_prefixes from pandas DataFrame.
+
+    :param df: Pandas DataFrame
+    :type df: pd.DataFrame
+    :param filter_prefixes: List of prefixes
+    :type filter_prefixes: List[str]
+    :return: Pandas Dataframe
+    :rtype: pd.DataFrame
+    """
     rows = []
 
     for _, row in df.iterrows():
@@ -836,6 +933,14 @@ def filter_out_prefixes(df: pd.DataFrame, filter_prefixes) -> pd.DataFrame:
 
 
 def guess_file_format(filename: Union[str, TextIO]) -> str:
+    """Get file format.
+
+    :param filename: filename
+    :type filename: Union[str, TextIO]
+    :raises Exception: Unrecoginized file extension
+    :return: File extension
+    :rtype: str
+    """
     extension = get_file_extension(filename)
     if extension in ["owl", "rdf"]:
         return SSSOM_DEFAULT_RDF_SERIALISATION
@@ -848,6 +953,13 @@ def guess_file_format(filename: Union[str, TextIO]) -> str:
 
 
 def prepare_context(prefix_map: Optional[PrefixMap] = None):
+    """Prepare context.
+
+    :param prefix_map: Prefix map, defaults to None
+    :type prefix_map: Optional[PrefixMap], optional
+    :return: Context
+    :rtype: Any
+    """
     context = get_jsonld_context()
     if prefix_map is None:
         prefix_map = get_default_metadata().prefix_map
@@ -867,9 +979,22 @@ def prepare_context(prefix_map: Optional[PrefixMap] = None):
 
 
 def prepare_context_str(prefix_map: Optional[PrefixMap] = None, **kwargs) -> str:
+    """Prepare context string.
+
+    :param prefix_map: Prefix map, defaults to None
+    :type prefix_map: Optional[PrefixMap], optional
+    :return: Context in str format
+    :rtype: str
+    """
     return json.dumps(prepare_context(prefix_map), **kwargs)
 
 
 def raise_for_bad_path(file_path: str) -> None:
+    """Raise exception if file path is invalid.
+
+    :param file_path: File path
+    :type file_path: str
+    :raises Exception: Invalid file path
+    """
     if not validators.url(file_path) and not os.path.exists(file_path):
         raise Exception(f"{file_path} is not a valid file path or url.")

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -18,7 +18,7 @@ from typing import (
     Tuple,
     Union,
 )
-from urllib.request import Request, urlopen
+from urllib.request import urlopen
 
 import numpy as np
 import pandas as pd

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -477,10 +477,10 @@ def merge_msdf(
     :param msdf1: The primary MappingSetDataFrame
     :param msdf2: The secondary MappingSetDataFrame
     :param reconcile: If reconcile=True, then dedupe(remove redundant lower confidence mappings)
-                      and reconcile (if msdf contains a higher confidence _negative_ mapping,
-                      then remove lower confidence positive one. If confidence is the same,
-                      prefer HumanCurated. If both HumanCurated, prefer negative mapping).
-                      Defaults to True.
+        and reconcile (if msdf contains a higher confidence _negative_ mapping,
+        then remove lower confidence positive one. If confidence is the same,
+        prefer HumanCurated. If both HumanCurated, prefer negative mapping).
+        Defaults to True.
 
     Returns:
         MappingSetDataFrame: Merged MappingSetDataFrame.

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -190,17 +190,6 @@ def collapse(df: pd.DataFrame) -> pd.DataFrame:
     return df2
 
 
-def sort_sssom_columns(columns: List[str]) -> List[str]:
-    """Sort columns: Ideally, the order of the sssom column names is parsed strictly from sssom.yaml.
-
-    :param columns: Column names
-    :return: Sorted column names
-    """
-    logging.warning("SSSOM sort columns not implemented")
-    columns.sort()
-    return columns
-
-
 def sort_sssom(df: pd.DataFrame) -> pd.DataFrame:
     """Sort SSSOM by columns.
 
@@ -208,7 +197,7 @@ def sort_sssom(df: pd.DataFrame) -> pd.DataFrame:
     :return: Sorted SSSOM DataFrame
     """
     df.sort_values(
-        by=sort_sssom_columns(list(df.columns)), ascending=False, inplace=True
+        by=sorted(df.columns), ascending=False, inplace=True
     )
     return df
 

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -5,7 +5,7 @@ import os
 import re
 from collections import defaultdict
 from dataclasses import dataclass, field
-from io import FileIO, StringIO
+from io import StringIO
 from typing import (
     Any,
     DefaultDict,
@@ -85,14 +85,10 @@ class MappingSetDataFrame:
     ) -> "MappingSetDataFrame":
         """Merge two MappingSetDataframes.
 
-        Args:
-            msdf: Secondary MappingSetDataFrame (self => primary)
-            inplace:
-                if true, msdf2 is merged into the calling MappingSetDataFrame, if false, it simply return
-                the merged data frame.
-
-        Returns:
-            MappingSetDataFrame: Merged MappingSetDataFrame
+        :param msdf2: Secondary MappingSetDataFrame (self => primary)
+        :param inplace: If true, msdf2 is merged into the calling MappingSetDataFrame,
+                        if false, it simply return the merged data frame.
+        :return: Merged MappingSetDataFrame
         """
         msdf = merge_msdf(msdf1=self, msdf2=msdf2)
         if inplace:
@@ -198,9 +194,7 @@ def sort_sssom_columns(columns: List[str]) -> List[str]:
     """Sort columns: Ideally, the order of the sssom column names is parsed strictly from sssom.yaml.
 
     :param columns: Column names
-    :type columns: List[str]
     :return: Sorted column names
-    :rtype: List[str]
     """
     logging.warning("SSSOM sort columns not implemented")
     columns.sort()
@@ -211,9 +205,7 @@ def sort_sssom(df: pd.DataFrame) -> pd.DataFrame:
     """Sort SSSOM by columns.
 
     :param df: SSSOM DataFrame to be sorted.
-    :type df: pd.DataFrame
     :return: Sorted SSSOM DataFrame
-    :rtype: pd.DataFrame
     """
     df.sort_values(
         by=sort_sssom_columns(list(df.columns)), ascending=False, inplace=True
@@ -226,9 +218,9 @@ def filter_redundant_rows(
 ) -> pd.DataFrame:
     """Remove rows if there is another row with same S/O and higher confidence.
 
-    Args:
-        df: data frame to filter
-        ignore_predicate: if true, the predicate_id column is ignored
+    :param df: Pandas DataFrame to filter
+    :param ignore_predicate: If true, the predicate_id column is ignored, defaults to False
+    :return: Filtered pandas DataFrame
     """
     # tie-breaker
     # create a 'sort' method and then replce the following line by sort()
@@ -274,9 +266,7 @@ def assign_default_confidence(df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFr
     """Assign numpy.NaN values to confidence that are blank.
 
     :param df: SSSOM DataFrame
-    :type df: pd.DataFrame
     :return: A Tuple consisting of the original DataFrame and dataframe consisting of empty confidence values.
-    :rtype: Tuple[pd.DataFrame, pd.DataFrame]
     """
     # Get rows having numpy.NaN as confidence
     if df is not None and "confidence" not in df.columns:
@@ -292,8 +282,8 @@ def remove_unmatched(df: pd.DataFrame) -> pd.DataFrame:
     """Remove rows where no match is found.
 
     TODO: https://github.com/OBOFoundry/SSSOM/issues/28
-    :param df:
-    :return:
+    :param df: Pandas DataFrame
+    :return: Pandas DataFrame with 'PREDICATE_ID' not 'noMatch'.
     """
     return df[df[PREDICATE_ID] != "noMatch"]
 
@@ -302,13 +292,9 @@ def create_entity(row, eid: str, mappings: Dict[str, Any]) -> Entity:
     """Create an Entity object.
 
     :param row: Row - [UNUSED]
-    :type row: [type]
     :param eid: Entity Id
-    :type eid: str
     :param mappings: Mapping dictionary
-    :type mappings: Dict[str, Any]
     :return: An Entity object
-    :rtype: Entity
     """
     logging.warning(f"create_entity() has row parameter ({row}), but not used.")
     e = Entity(id=eid)
@@ -384,13 +370,12 @@ def compare_dataframes(df1: pd.DataFrame, df2: pd.DataFrame) -> MappingSetDiff:
 def dataframe_to_ptable(df: pd.DataFrame, priors=None, inverse_factor: float = 0.5):
     """Export a KBOOM table.
 
-    Args:
-        df:
-        priors:
-        inverse_factor:
-
-    Returns:
-        List of rows
+    :param df: Pandas DataFrame
+    :param priors: [NOT USED], defaults to None
+    :param inverse_factor: Multiplier to (1 - confidence), defaults to 0.5
+    :raises ValueError: Predicate value error
+    :raises ValueError: Predicate type value error
+    :return: List of rows
     """
     if not priors:
         priors = [0.02, 0.02, 0.02, 0.02]
@@ -500,15 +485,13 @@ def merge_msdf(
 ) -> MappingSetDataFrame:
     """Merge msdf2 into msdf1.
 
-    if reconcile=True, then dedupe(remove redundant lower confidence mappings) and
-        reconcile (if msdf contains a higher confidence _negative_ mapping,
-        then remove lower confidence positive one. If confidence is the same,
-        prefer HumanCurated. If both HumanCurated, prefer negative mapping).
-
-    Args:
-        msdf1 (MappingSetDataFrame): The primary MappingSetDataFrame
-        msdf2 (MappingSetDataFrame): The secondary MappingSetDataFrame
-        reconcile (bool, optional): [description]. Defaults to True.
+    :param msdf1: The primary MappingSetDataFrame
+    :param msdf2: The secondary MappingSetDataFrame
+    :param reconcile: If reconcile=True, then dedupe(remove redundant lower confidence mappings)
+                      and reconcile (if msdf contains a higher confidence _negative_ mapping,
+                      then remove lower confidence positive one. If confidence is the same,
+                      prefer HumanCurated. If both HumanCurated, prefer negative mapping).
+                      Defaults to True.
 
     Returns:
         MappingSetDataFrame: Merged MappingSetDataFrame.
@@ -546,13 +529,10 @@ def merge_msdf(
 def deal_with_negation(df: pd.DataFrame) -> pd.DataFrame:
     """Combine negative and positive rows with matching [SUBJECT_ID, OBJECT_ID, CONFIDENCE] combination.
 
-    taking into account the rule that negative trumps positive given equal confidence values.
+    Taking into account the rule that negative trumps positive given equal confidence values.
 
-    Args:
-        df (pd.DataFrame): Merged Pandas DataFrame
-
-    Returns:
-        pd.DataFrame: Pandas DataFrame with negations addressed
+    :param df: Merged Pandas DataFrame
+    :return: pd.DataFrame: Pandas DataFrame with negations addressed
     """
     """
             1. Mappings in mapping1 trump mappings in mapping2 (if mapping2 contains a conflicting mapping in mapping1,
@@ -695,11 +675,9 @@ def dict_merge(
 def inject_metadata_into_df(msdf: MappingSetDataFrame) -> MappingSetDataFrame:
     """Inject metadata dictionary key-value pair into DataFrame columns in a MappingSetDataFrame.DataFrame.
 
-    Args:
-        msdf (MappingSetDataFrame): MappingSetDataFrame with metadata separate.
+    :param msdf: MappingSetDataFrame with metadata separate.
 
-    Returns:
-        MappingSetDataFrame: MappingSetDataFrame with metadata as columns
+    :return: MappingSetDataFrame with metadata as columns
     """
     if msdf.metadata is not None and msdf.df is not None:
         for k, v in msdf.metadata.items():
@@ -712,10 +690,8 @@ def get_file_extension(file: Union[str, TextIO]) -> str:
     """Get file extension.
 
     :param file: Name of the file
-    :type file: Union[str, TextIO]
     :raises Exception: Cannot determine extension exception
     :return: format of the file passed
-    :rtype: str
     """
     if isinstance(file, str):
         filename = file
@@ -733,13 +709,9 @@ def read_csv(filename: str, comment: str = "#", sep: str = ",") -> pd.DataFrame:
     """Read TSV file.
 
     :param filename: filename
-    :type filename: str
     :param comment: character that indicates beginning of a comment, defaults to "#"
-    :type comment: str, optional
     :param sep: separator, defaults to ","
-    :type sep: str, optional
     :return: Pandas DataFrame
-    :rtype: pd.DataFrame
     """
     if validators.url(filename):
         response = urlopen(filename)
@@ -789,9 +761,7 @@ def extract_global_metadata(msdoc: MappingSetDocument) -> Dict[str, PrefixMap]:
     """Extract metadata.
 
     :param msdoc: MappingSetDocument object
-    :type msdoc: MappingSetDocument
     :return: Dictionary containing metadata
-    :rtype: Dict[str, PrefixMap]
     """
     meta = {PREFIX_MAP_KEY: msdoc.prefix_map}
     ms_meta = msdoc.mapping_set
@@ -811,9 +781,7 @@ def to_mapping_set_dataframe(doc: MappingSetDocument) -> MappingSetDataFrame:
     """Convert MappingSetDocument into MappingSetDataFrame.
 
     :param doc: MappingSetDocument object
-    :type doc: MappingSetDocument
     :return: MappingSetDataFrame object
-    :rtype: MappingSetDataFrame
     """
     data = []
     if doc.mapping_set.mappings is not None:
@@ -845,9 +813,7 @@ def is_curie(string: str) -> bool:
     """Check if string is CURIE or not.
 
     :param string: String
-    :type string: str
     :return: Boolean indicating CURIE or not
-    :rtype: bool
     """
     return bool(CURIE_RE.match(string))
 
@@ -856,9 +822,7 @@ def get_prefix_from_curie(curie: str) -> str:
     """Get prefix from CURIE.
 
     :param curie: CURIE
-    :type curie: str
     :return: Prefix
-    :rtype: str
     """
     if is_curie(curie):
         return curie.split(":")[0]
@@ -901,9 +865,7 @@ def get_prefixes_used_in_table(df: pd.DataFrame) -> List[str]:
     """Get prefixes used in table.
 
     :param df: Pandas DatafFrame
-    :type df: pd.DataFrame
     :return: List of unique prefixes
-    :rtype: List[str]
     """
     prefixes = []
     for col in KEY_FEATURES:
@@ -916,11 +878,8 @@ def filter_out_prefixes(df: pd.DataFrame, filter_prefixes: List[str]) -> pd.Data
     """Get all prefixes in filter_prefixes from pandas DataFrame.
 
     :param df: Pandas DataFrame
-    :type df: pd.DataFrame
     :param filter_prefixes: List of prefixes
-    :type filter_prefixes: List[str]
     :return: Pandas Dataframe
-    :rtype: pd.DataFrame
     """
     rows = []
 
@@ -941,10 +900,8 @@ def guess_file_format(filename: Union[str, TextIO]) -> str:
     """Get file format.
 
     :param filename: filename
-    :type filename: Union[str, TextIO]
     :raises Exception: Unrecoginized file extension
     :return: File extension
-    :rtype: str
     """
     extension = get_file_extension(filename)
     if extension in ["owl", "rdf"]:
@@ -961,9 +918,7 @@ def prepare_context(prefix_map: Optional[PrefixMap] = None):
     """Prepare context.
 
     :param prefix_map: Prefix map, defaults to None
-    :type prefix_map: Optional[PrefixMap], optional
     :return: Context
-    :rtype: Any
     """
     context = get_jsonld_context()
     if prefix_map is None:
@@ -987,9 +942,7 @@ def prepare_context_str(prefix_map: Optional[PrefixMap] = None, **kwargs) -> str
     """Prepare context string.
 
     :param prefix_map: Prefix map, defaults to None
-    :type prefix_map: Optional[PrefixMap], optional
     :return: Context in str format
-    :rtype: str
     """
     return json.dumps(prepare_context(prefix_map), **kwargs)
 
@@ -998,7 +951,6 @@ def raise_for_bad_path(file_path: str) -> None:
     """Raise exception if file path is invalid.
 
     :param file_path: File path
-    :type file_path: str
     :raises Exception: Invalid file path
     """
     if not validators.url(file_path) and not os.path.exists(file_path):

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -104,13 +104,19 @@ class MappingSetDataFrame:
 
     def __str__(self) -> str:  # noqa:D105
         description = "SSSOM data table \n"
-        description += f"Number of mappings: {len(self.df.index)} \n"
         description += f"Number of prefixes: {len(self.prefix_map)} \n"
-        description += f"Metadata: {json.dumps(self.metadata)} \n"
-        description += "\nFirst rows of data: \n"
-        description += self.df.head().to_string() + "\n"
-        description += "\nLast rows of data: \n"
-        description += self.df.tail().to_string() + "\n"
+        if self.metadata is None:
+            description += "No metadata available \n"
+        else:
+            description += f"Metadata: {json.dumps(self.metadata)} \n"
+        if self.df is None:
+            description += "No dataframe available"
+        else:
+            description += f"Number of mappings: {len(self.df.index)} \n"
+            description += "\nFirst rows of data: \n"
+            description += self.df.head().to_string() + "\n"
+            description += "\nLast rows of data: \n"
+            description += self.df.tail().to_string() + "\n"
         return description
 
     def clean_prefix_map(self) -> None:
@@ -482,8 +488,7 @@ def sha256sum(filename: str) -> str:
     b = bytearray(128 * 1024)
     mv = memoryview(b)
     with open(filename, "rb", buffering=0) as f:
-        f: FileIO
-        for n in iter(lambda: f.readinto(mv), 0):
+        for n in iter(lambda: f.readinto(mv), 0):  # type: ignore
             h.update(mv[:n])
     return h.hexdigest()
 

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -678,8 +678,19 @@ def get_file_extension(file: Union[str, TextIO]) -> str:
         raise Exception(f"Cannot guess format from {filename}")
 
 
-def read_csv(filename: Union[str, TextIO], comment: str = "#", sep: str = ","):
-    """Read a CSV that contains frontmatter commented by a specific character."""
+def read_csv(
+    filename: Union[str, TextIO], comment: str = "#", sep: str = ","
+) -> pd.DataFrame:
+    """Read a CSV that contains frontmatter commented by a specific character.
+
+    :param filename: Either the file path, a URL, or a file object to read as a TSV
+        with frontmatter
+    :param comment: The comment character used for the frontmatter. This isn't the
+        same as the comment keyword in :func:`pandas.read_csv` because it only
+        works on the first charcter in the line
+    :param sep: The separator for the TSV file
+    :returns: A pandas dataframe
+    """
     if isinstance(filename, TextIO):
         return pd.read_csv(filename, sep=sep)
     if validators.url(filename):

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -354,23 +354,15 @@ def compare_dataframes(df1: pd.DataFrame, df2: pd.DataFrame) -> MappingSetDiff:
     return d
 
 
-def dataframe_to_ptable(df: pd.DataFrame, priors=None, inverse_factor: float = 0.5):
+def dataframe_to_ptable(df: pd.DataFrame, inverse_factor: float = 0.5):
     """Export a KBOOM table.
 
     :param df: Pandas DataFrame
-    :param priors: [NOT USED], defaults to None
     :param inverse_factor: Multiplier to (1 - confidence), defaults to 0.5
     :raises ValueError: Predicate value error
     :raises ValueError: Predicate type value error
     :return: List of rows
     """
-    if not priors:
-        priors = [0.02, 0.02, 0.02, 0.02]
-    else:
-        logging.warning(
-            f"Priors given ({priors}), but not being used by dataframe_to_ptable() method."
-        )
-
     df = collapse(df)
     rows = []
     for _, row in df.iterrows():

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -297,8 +297,8 @@ def group_mappings(df: pd.DataFrame) -> Dict[EntityPair, List[pd.Series]]:
     for _, row in df.iterrows():
         subject_entity = create_entity(
             row,
-            row[SUBJECT_ID],
-            {
+            eid=row[SUBJECT_ID],
+            mappings={
                 "label": SUBJECT_LABEL,
                 "category": SUBJECT_CATEGORY,
                 "source": SUBJECT_SOURCE,
@@ -306,8 +306,8 @@ def group_mappings(df: pd.DataFrame) -> Dict[EntityPair, List[pd.Series]]:
         )
         object_entity = create_entity(
             row,
-            row[OBJECT_ID],
-            {
+            eid=row[OBJECT_ID],
+            mappings={
                 "label": OBJECT_LABEL,
                 "category": OBJECT_CATEGORY,
                 "source": OBJECT_SOURCE,

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -18,7 +18,7 @@ from typing import (
     Tuple,
     Union,
 )
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 import numpy as np
 import pandas as pd
@@ -196,9 +196,7 @@ def sort_sssom(df: pd.DataFrame) -> pd.DataFrame:
     :param df: SSSOM DataFrame to be sorted.
     :return: Sorted SSSOM DataFrame
     """
-    df.sort_values(
-        by=sorted(df.columns), ascending=False, inplace=True
-    )
+    df.sort_values(by=sorted(df.columns), ascending=False, inplace=True)
     return df
 
 
@@ -451,7 +449,7 @@ RDF_FORMATS = {"ttl", "turtle", "nt", "xml"}
 
 
 def sha256sum(filename: str) -> str:
-    """Hashing function.
+    """Calculate the SHA256 hash over the bytes in a file.
 
     :param filename: Filename
     :type filename: str
@@ -518,10 +516,10 @@ def merge_msdf(
 def deal_with_negation(df: pd.DataFrame) -> pd.DataFrame:
     """Combine negative and positive rows with matching [SUBJECT_ID, OBJECT_ID, CONFIDENCE] combination.
 
-    Taking into account the rule that negative trumps positive given equal confidence values.
+    Rule: negative trumps positive if modulus of confidence values are equal.
 
     :param df: Merged Pandas DataFrame
-    :return: pd.DataFrame: Pandas DataFrame with negations addressed
+    :return: Pandas DataFrame with negations addressed
     """
     """
             1. Mappings in mapping1 trump mappings in mapping2 (if mapping2 contains a conflicting mapping in mapping1,
@@ -678,7 +676,7 @@ def inject_metadata_into_df(msdf: MappingSetDataFrame) -> MappingSetDataFrame:
 def get_file_extension(file: Union[str, TextIO]) -> str:
     """Get file extension.
 
-    :param file: Name of the file
+    :param file: File path
     :raises Exception: Cannot determine extension exception
     :return: format of the file passed
     """
@@ -694,8 +692,10 @@ def get_file_extension(file: Union[str, TextIO]) -> str:
         raise Exception(f"Cannot guess format from {filename}")
 
 
-def read_csv(filename: str, comment: str = "#", sep: str = ",") -> pd.DataFrame:
-    """Read TSV file.
+def read_csv(
+    filename: Union[str, TextIO], comment: str = "#", sep: str = ","
+) -> pd.DataFrame:
+    """Read CSV file.
 
     :param filename: filename
     :param comment: character that indicates beginning of a comment, defaults to "#"
@@ -743,7 +743,7 @@ def read_pandas(file: Union[str, TextIO], sep: Optional[str] = None) -> pd.DataF
         else:
             sep = "\t"
             logging.warning("Cannot automatically determine table format, trying tsv.")
-    return read_csv(str(file), comment="#", sep=sep).fillna("")
+    return read_csv(file, comment="#", sep=sep).fillna("")
 
 
 def extract_global_metadata(msdoc: MappingSetDocument) -> Dict[str, PrefixMap]:

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -102,7 +102,7 @@ class MappingSetDataFrame:
             # FIXME should return self if inplace
         return msdf
 
-    def __str__(self):
+    def __str__(self) -> str:  # noqa:D105
         description = "SSSOM data table \n"
         description += f"Number of mappings: {len(self.df.index)} \n"
         description += f"Number of prefixes: {len(self.prefix_map)} \n"
@@ -141,7 +141,7 @@ class EntityPair:
     subject_entity: Entity
     object_entity: Entity
 
-    def __hash__(self):
+    def __hash__(self) -> int:  # noqa:D105
         if self.subject_entity.id <= self.object_entity.id:
             t = self.subject_entity.id, self.object_entity.id
         else:

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -754,7 +754,7 @@ def read_pandas(file: Union[str, TextIO], sep: Optional[str] = None) -> pd.DataF
         else:
             sep = "\t"
             logging.warning("Cannot automatically determine table format, trying tsv.")
-    return read_csv(file, comment="#", sep=sep).fillna("")
+    return read_csv(str(file), comment="#", sep=sep).fillna("")
 
 
 def extract_global_metadata(msdoc: MappingSetDocument) -> Dict[str, PrefixMap]:

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -248,7 +248,7 @@ def filter_redundant_rows(
 
 
 def assign_default_confidence(df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
-    """Assign numpy.NaN values to confidence that are blank.
+    """Assign :data:`numpy.nan` to confidence that are blank.
 
     :param df: SSSOM DataFrame
     :return: A Tuple consisting of the original DataFrame and dataframe consisting of empty confidence values.

--- a/sssom/writers.py
+++ b/sssom/writers.py
@@ -327,6 +327,8 @@ def write_tables(
     # FIXME documentation does not actually describe what this is doing
     # FIXME explanation of sssom_dict does not make sense
     # FIXME sssom_dict is a bad variable name
+    if output_dir is None:
+        raise ValueError('Output directory not provided.')
     output_dir = Path(output_dir).resolve()
     for split_id, msdf in sssom_dict.items():
         path = output_dir.joinpath(f"{split_id}.sssom.tsv")

--- a/sssom/writers.py
+++ b/sssom/writers.py
@@ -325,7 +325,7 @@ def write_tables(
     :param output_dir: Target location
     """
     for split_id, msdf in sssom_dict.items():
-        path = os.path.join(output_dir, f"{split_id}.sssom.tsv")
+        path = os.path.join(str(output_dir), f"{split_id}.sssom.tsv")
         with open(path, "w") as file:
             write_table(msdf, file)
         logging.info(f"Writing {path} complete!")

--- a/sssom/writers.py
+++ b/sssom/writers.py
@@ -320,8 +320,7 @@ def get_writer_function(
 
 
 def write_tables(
-    sssom_dict: Dict[str, MappingSetDataFrame],
-    output_dir: TextIO
+    sssom_dict: Dict[str, MappingSetDataFrame], output_dir: TextIO
 ) -> None:
     """Write table from MappingSetDataFrame object.
 

--- a/sssom/writers.py
+++ b/sssom/writers.py
@@ -295,12 +295,9 @@ def get_writer_function(
     """Get appropriate writer function based on file format.
 
     :param output: Output file
-    :type output: TextIO
     :param output_format: Output file format, defaults to None
-    :type output_format: Optional[str], optional
     :raises ValueError: Unknown output format
     :return: Type of writer function
-    :rtype: Tuple[MSDFWriter, str]
     """
     if output_format is None:
         output_format = get_file_extension(output)
@@ -325,9 +322,7 @@ def write_tables(
     """Write table from MappingSetDataFrame object.
 
     :param sssom_dict: Dictionary of MappingSetDataframes
-    :type sssom_dict: Dict[str, MappingSetDataFrame]
     :param output_dir: Target location
-    :type output_dir: TextIO
     """
     for split_id, msdf in sssom_dict.items():
         path = os.path.join(output_dir, f"{split_id}.sssom.tsv")

--- a/sssom/writers.py
+++ b/sssom/writers.py
@@ -1,7 +1,7 @@
 import json
 import logging
-import os
-from typing import Any, Callable, Dict, Optional, TextIO, Tuple
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, TextIO, Tuple, Union
 
 import pandas as pd
 import yaml
@@ -317,16 +317,20 @@ def get_writer_function(
 
 
 def write_tables(
-    sssom_dict: Dict[str, MappingSetDataFrame], output_dir: TextIO
+    sssom_dict: Dict[str, MappingSetDataFrame], output_dir: Union[str, Path]
 ) -> None:
     """Write table from MappingSetDataFrame object.
 
     :param sssom_dict: Dictionary of MappingSetDataframes
-    :param output_dir: Target location
+    :param output_dir: The directory in which the derived SSSOM files are written
     """
+    # FIXME documentation does not actually describe what this is doing
+    # FIXME explanation of sssom_dict does not make sense
+    # FIXME sssom_dict is a bad variable name
+    output_dir = Path(output_dir).resolve()
     for split_id, msdf in sssom_dict.items():
-        path = os.path.join(str(output_dir), f"{split_id}.sssom.tsv")
-        with open(path, "w") as file:
+        path = output_dir.joinpath(f"{split_id}.sssom.tsv")
+        with path.open("w") as file:
             write_table(msdf, file)
         logging.info(f"Writing {path} complete!")
 

--- a/sssom/writers.py
+++ b/sssom/writers.py
@@ -328,7 +328,7 @@ def write_tables(
     # FIXME explanation of sssom_dict does not make sense
     # FIXME sssom_dict is a bad variable name
     if output_dir is None:
-        raise ValueError('Output directory not provided.')
+        raise ValueError("Output directory not provided.")
     output_dir = Path(output_dir).resolve()
     for split_id, msdf in sssom_dict.items():
         path = output_dir.joinpath(f"{split_id}.sssom.tsv")

--- a/sssom/writers.py
+++ b/sssom/writers.py
@@ -292,6 +292,16 @@ def to_json(msdf: MappingSetDataFrame) -> JsonObj:
 def get_writer_function(
     *, output_format: Optional[str] = None, output: TextIO
 ) -> Tuple[MSDFWriter, str]:
+    """Get appropriate writer function based on file format.
+
+    :param output: Output file
+    :type output: TextIO
+    :param output_format: Output file format, defaults to None
+    :type output_format: Optional[str], optional
+    :raises ValueError: Unknown output format
+    :return: Type of writer function
+    :rtype: Tuple[MSDFWriter, str]
+    """
     if output_format is None:
         output_format = get_file_extension(output)
 
@@ -309,7 +319,17 @@ def get_writer_function(
         raise ValueError(f"Unknown output format: {output_format}")
 
 
-def write_tables(sssom_dict, output_dir) -> None:
+def write_tables(
+    sssom_dict: Dict[str, MappingSetDataFrame],
+    output_dir: TextIO
+) -> None:
+    """Write table from MappingSetDataFrame object.
+
+    :param sssom_dict: Dictionary of MappingSetDataframes
+    :type sssom_dict: Dict[str, MappingSetDataFrame]
+    :param output_dir: Target location
+    :type output_dir: TextIO
+    """
     for split_id, msdf in sssom_dict.items():
         path = os.path.join(output_dir, f"{split_id}.sssom.tsv")
         with open(path, "w") as file:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for SSSOM."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,6 @@ from sssom.cli import (
 )
 from tests.test_data import (
     SSSOMTestCase,
-    ensure_test_dir_exists,
     get_all_test_cases,
     get_multiple_input_test_cases,
     test_out_dir,
@@ -27,7 +26,6 @@ from tests.test_data import (
 
 class SSSOMCLITestSuite(unittest.TestCase):
     def test_cli_single_input(self):
-        ensure_test_dir_exists()
         runner = CliRunner()
         test_cases = (
             get_all_test_cases()
@@ -53,7 +51,6 @@ class SSSOMCLITestSuite(unittest.TestCase):
         self.assertTrue(len(test_cases) > 2)
 
     def test_cli_multiple_input(self):
-        ensure_test_dir_exists()
         runner = CliRunner()
         test_cases = get_multiple_input_test_cases()
         self.run_diff(runner, test_cases)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -137,9 +137,7 @@ class SSSOMCLITestSuite(unittest.TestCase):
     def run_diff(self, runner, test_cases: Dict[str, SSSOMTestCase]):
         params = []
         out_file = None
-        for tid in test_cases:
-            t = test_cases[tid]
-            t: SSSOMTestCase
+        for t in test_cases.values():
             params.append(t.filepath)
             out_file = t
         if out_file:

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -22,7 +22,7 @@ class TestCollapse(unittest.TestCase):
 
     def test_df(self):
         df = self.df
-        self.assertEquals(
+        self.assertEqual(
             len(df),
             141,
             f"Dataframe should have a different number of rows {df.head(10)}",
@@ -30,7 +30,7 @@ class TestCollapse(unittest.TestCase):
 
     def test_collapse(self):
         df = collapse(self.df)
-        self.assertEquals(
+        self.assertEqual(
             len(df), 91, f"Dataframe should have a different {df.head(10)}"
         )
 

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -19,12 +19,11 @@ from sssom.writers import (
     write_table,
 )
 
-from .test_data import SSSOMTestCase, ensure_test_dir_exists, get_all_test_cases
+from .test_data import SSSOMTestCase, get_all_test_cases
 
 
 class SSSOMReadWriteTestSuite(unittest.TestCase):
     def test(self):
-        ensure_test_dir_exists()
         test_cases = get_all_test_cases()
         self.assertTrue(len(test_cases) > 2, "Less than 2 testcases in the test suite!")
         for test in test_cases:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Mapping
+from typing import Any, Mapping, TextIO
 
 import yaml
 
@@ -14,22 +14,40 @@ TEST_CONFIG = os.path.join(cwd, "test_config.yaml")
 DEFAULT_CONTEXT_PATH = os.path.join(schema_dir, "sssom.context.jsonld")
 
 
-def get_test_file(filename):
+def get_test_file(filename: TextIO) -> str:
+    """Get test file.
+
+    :param filename: Filename
+    :type filename: TextIO
+    :return: File path
+    :rtype: str
+    """
     return os.path.join(test_data_dir, filename)
 
 
 def ensure_test_dir_exists():
+    """Create directory if not already present."""
     if not os.path.exists(test_out_dir):
         os.makedirs(test_out_dir)
 
 
 def load_config():
+    """Load configuration.
+
+    :return: Confiuration
+    :rtype: Any
+    """
     with open(TEST_CONFIG) as file:
         config = yaml.safe_load(file)
     return config
 
 
 def get_all_test_cases():
+    """Get all test cases.
+
+    :return: List of test cases
+    :rtype: List[SSOMTestCase]
+    """
     test_cases = []
     config = load_config()
     for test in config["tests"]:
@@ -38,6 +56,11 @@ def get_all_test_cases():
 
 
 def get_multiple_input_test_cases():
+    """Get multiple input test cases.
+
+    :return: List of test cases
+    :rtype: List[SSOMTestCase]
+    """
     test_cases = dict()
     config = load_config()
     for test in config["tests"]:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -56,29 +56,19 @@ class SSSOMTestCase:
         """
         self.filepath = get_test_file(config["filename"])
         self.filename = config["filename"]
-        if "id" in config:
-            self.id = config["id"]
-        else:
-            self.id = config["filename"]
-
-        if "metadata_file" in config:
-            self.metadata_file = config["metadata_file"]
-        else:
-            self.metadata_file = None
+        self.id = config.get("id", self.filename)
+        self.metadata_file = config.get("metadata_file")
         self.graph_serialisation = "turtle"
         self.ct_json_elements = config["ct_json_elements"]
         self.ct_data_frame_rows = config["ct_data_frame_rows"]
-        if "inputformat" in config:
-            self.inputformat = config["inputformat"]
-        else:
-            self.inputformat = None
+        self.inputformat = config.get("inputformat")
         self.ct_graph_queries_owl = self._query_tuple(
             config, "ct_graph_queries_owl", queries
         )
         self.ct_graph_queries_rdf = self._query_tuple(
             config, "ct_graph_queries_rdf", queries
         )
-        self.prefix_map = config.pop(PREFIX_MAP_KEY, None)
+        self.prefix_map = config.get(PREFIX_MAP_KEY)
 
     def _query_tuple(self, config, tuple_id, queries_dict):
         queries = []
@@ -93,5 +83,5 @@ class SSSOMTestCase:
     def get_validate_file(self, extension):
         return os.path.join(test_validate_dir, f"{self.filename}.{extension}")
 
-    def __str__(self):
+    def __str__(self) -> str:  # noqa:D105
         return f"Testcase {self.id} (Filepath: {self.filepath})"

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Mapping
+from typing import Any, List, Mapping
 
 import yaml
 
@@ -10,51 +10,16 @@ test_data_dir = os.path.join(cwd, "data")
 test_out_dir = os.path.join(cwd, "tmp")
 os.makedirs(test_out_dir, exist_ok=True)
 test_validate_dir = os.path.join(cwd, "validate_data")
-schema_dir = os.path.join(cwd, "../schema")
-TEST_CONFIG = os.path.join(cwd, "test_config.yaml")
+schema_dir = os.path.join(cwd, os.pardir, "schema")
 DEFAULT_CONTEXT_PATH = os.path.join(schema_dir, "sssom.context.jsonld")
+TEST_CONFIG_PATH = os.path.join(cwd, "test_config.yaml")
+with open(TEST_CONFIG_PATH) as file:
+    TEST_CONFIG = yaml.safe_load(file)
 
 
 def get_test_file(filename: str) -> str:
     """Get a test file path inside the test data directory."""
     return os.path.join(test_data_dir, filename)
-
-
-def load_config():
-    """Load test file information from 'test_config.yaml'.
-
-    :return: Confiuration
-    :rtype: Any
-    """
-    with open(TEST_CONFIG) as file:
-        config = yaml.safe_load(file)
-    return config
-
-
-def get_all_test_cases():
-    """Get all test cases.
-
-    :return: List of test cases
-    """
-    test_cases = []
-    config = load_config()
-    for test in config["tests"]:
-        test_cases.append(SSSOMTestCase(test, config["queries"]))
-    return test_cases
-
-
-def get_multiple_input_test_cases():
-    """Get test cases that require multiple parameters.
-
-    :return: List of test cases
-    """
-    test_cases = dict()
-    config = load_config()
-    for test in config["tests"]:
-        if test["multiple_input"]:
-            test = SSSOMTestCase(test, config["queries"])
-            test_cases[test.id] = test
-    return test_cases
 
 
 class SSSOMTestCase:
@@ -95,3 +60,21 @@ class SSSOMTestCase:
 
     def __str__(self) -> str:  # noqa:D105
         return f"Testcase {self.id} (Filepath: {self.filepath})"
+
+
+def get_all_test_cases() -> List[SSSOMTestCase]:
+    """Get a list of all test cases."""
+    test_cases = []
+    for test in TEST_CONFIG["tests"]:
+        test_cases.append(SSSOMTestCase(test, TEST_CONFIG["queries"]))
+    return test_cases
+
+
+def get_multiple_input_test_cases() -> Mapping[str, SSSOMTestCase]:
+    """Get a mapping from identifiers to test cases that require multiple parameters."""
+    test_cases = dict()
+    for test in TEST_CONFIG["tests"]:
+        if test["multiple_input"]:
+            test = SSSOMTestCase(test, TEST_CONFIG["queries"])
+            test_cases[test.id] = test
+    return test_cases

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -21,7 +21,7 @@ def get_test_file(filename: str) -> str:
 
 
 def load_config():
-    """Load configuration.
+    """Load test file information from 'test_config.yaml'.
 
     :return: Confiuration
     :rtype: Any
@@ -35,7 +35,6 @@ def get_all_test_cases():
     """Get all test cases.
 
     :return: List of test cases
-    :rtype: List[SSOMTestCase]
     """
     test_cases = []
     config = load_config()
@@ -45,10 +44,9 @@ def get_all_test_cases():
 
 
 def get_multiple_input_test_cases():
-    """Get multiple input test cases.
+    """Get test cases that require multiple parameters.
 
     :return: List of test cases
-    :rtype: List[SSOMTestCase]
     """
     test_cases = dict()
     config = load_config()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Mapping, TextIO
+from typing import Any, Mapping
 
 import yaml
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -8,27 +8,16 @@ from sssom.util import PREFIX_MAP_KEY
 cwd = os.path.abspath(os.path.dirname(__file__))
 test_data_dir = os.path.join(cwd, "data")
 test_out_dir = os.path.join(cwd, "tmp")
+os.makedirs(test_out_dir, exist_ok=True)
 test_validate_dir = os.path.join(cwd, "validate_data")
 schema_dir = os.path.join(cwd, "../schema")
 TEST_CONFIG = os.path.join(cwd, "test_config.yaml")
 DEFAULT_CONTEXT_PATH = os.path.join(schema_dir, "sssom.context.jsonld")
 
 
-def get_test_file(filename: TextIO) -> str:
-    """Get test file.
-
-    :param filename: Filename
-    :type filename: TextIO
-    :return: File path
-    :rtype: str
-    """
+def get_test_file(filename: str) -> str:
+    """Get a test file path inside the test data directory."""
     return os.path.join(test_data_dir, filename)
-
-
-def ensure_test_dir_exists():
-    """Create directory if not already present."""
-    if not os.path.exists(test_out_dir):
-        os.makedirs(test_out_dir)
 
 
 def load_config():

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any, Mapping
 
 import yaml
 
@@ -47,7 +48,12 @@ def get_multiple_input_test_cases():
 
 
 class SSSOMTestCase:
-    def __init__(self, config, queries):
+    def __init__(self, config: Mapping[str, Any], queries: Mapping[str, str]):
+        """Initialize the SSSOM test case.
+
+        :param config: A dictionary of configuration values
+        :param queries: A mapping from query name to SPARQL query strings
+        """
         self.filepath = get_test_file(config["filename"])
         self.filename = config["filename"]
         if "id" in config:


### PR DESCRIPTION
As a follow-up to #156, this one enables even more flake8 checks from the `flake8-docstrings` plugin. I did a few of the tiny ones, but now the meatiest part is to address `D103` - all public functions need a docstring. I'm going to conscript @hrshdhgd for this bit

Keep in mind all of this flake8/mypy/code style stuff is a bit of a pain in the short term, but it will keep us sane as developers in the future and support the longevity of a community that might come to rely on this package at some point

![81mPquqrVLL _AC_SL1000_](https://user-images.githubusercontent.com/5069736/135827871-50f35a55-db2f-428a-a2e5-d55b7fa75525.jpg)

