### PR TITLE
unpinned linkml-runtime version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     click
     jsonasobj==1.3.1
     jsonasobj2>=1.0.4
-    linkml-runtime==1.1.10
+    linkml-runtime>=1.1.6
     networkx
     numpy
     pandas


### PR DESCRIPTION
Undoing pining of linkml-runtime as a solution used tin PR #163 . Addresses issue #188 