### PR TITLE
unpinned rdflib

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     pandas
     pandasql
     pyyaml
-    rdflib==5.0.0
+    rdflib
     recommonmark>=0.7
     scikit_learn
     scipy


### PR DESCRIPTION
Initiated by the conversation [here](https://github.com/mapping-commons/sssom-py/pull/190#issuecomment-1006758131)

- Unpinned `rdflib` from v5.0.0 to 6.