### PR TITLE
remove jsonasobj dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,8 +50,6 @@ keywords =
 install_requires =
     pyparsing==2.4.7
     click
-    jsonasobj==1.3.1
-    jsonasobj2>=1.0.4
     linkml-runtime>=1.1.12
     networkx
     numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     pandas
     pandasql
     pyyaml
-    rdflib
+    rdflib>=6
     recommonmark>=0.7
     scikit_learn
     scipy


### PR DESCRIPTION
This PR initiated because of discussion [here](https://github.com/mapping-commons/sssom-py/pull/193#issuecomment-1006780742). 

- Removed jsonasobj as a dependency.
- pinned rdflib to v6