### PR TITLE
Fix bug with default metadata

### DIFF
--- a/sssom/io.py
+++ b/sssom/io.py
@@ -112,11 +112,11 @@ def get_metadata_and_prefix_map(
     # TODO reduce complexity by flipping conditionals
     #  and returning eagerly (it's fine if there are multiple returns)
     if prefix_map_mode != "metadata_only":
-        meta_sssom, prefix_map_sssom = get_default_metadata()
+        metadata: Metadata= get_default_metadata()
         if prefix_map_mode == "sssom_default_only":
-            prefix_map = prefix_map_sssom
+            prefix_map = metadata.prefix_map
         elif prefix_map_mode == "merged":
-            for prefix, uri_prefix in prefix_map_sssom.items():
+            for prefix, uri_prefix in metadata.prefix_map.items():
                 if prefix not in prefix_map:
                     prefix_map[prefix] = uri_prefix
     return Metadata(prefix_map=prefix_map, metadata=metadata)

--- a/sssom/io.py
+++ b/sssom/io.py
@@ -112,11 +112,11 @@ def get_metadata_and_prefix_map(
     # TODO reduce complexity by flipping conditionals
     #  and returning eagerly (it's fine if there are multiple returns)
     if prefix_map_mode != "metadata_only":
-        metadata: Metadata= get_default_metadata()
+        default_metadata: Metadata = get_default_metadata()
         if prefix_map_mode == "sssom_default_only":
-            prefix_map = metadata.prefix_map
+            prefix_map = default_metadata.prefix_map
         elif prefix_map_mode == "merged":
-            for prefix, uri_prefix in metadata.prefix_map.items():
+            for prefix, uri_prefix in default_metadata.prefix_map.items():
                 if prefix not in prefix_map:
                     prefix_map[prefix] = uri_prefix
     return Metadata(prefix_map=prefix_map, metadata=metadata)


### PR DESCRIPTION
Fixing bug where `get_default_metadata()` was processing a completely wrong return type! That is why --prefix-map-mode didn't work anywhere!