### PR TITLE
Add `linkml` NOT`linkml-runtime` as dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     bioregistry
     click
     deprecation
-    linkml-runtime>=1.1.12
+    linkml
     networkx
     numpy
     pandas


### PR DESCRIPTION
`Linkml` automatically installs `linkml-runtime` as its dependency. Fixes #288 