### PR TITLE
Unpin `pyparsing` dependency to latest version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ keywords =
 
 [options]
 install_requires =
-    pyparsing==2.4.7
+    pyparsing
     bioregistry
     click
     deprecation


### PR DESCRIPTION
Fixes #313 