### PR TITLE
Corrected flag and remove blank prefixes

### DIFF
--- a/sssom/cli.py
+++ b/sssom/cli.py
@@ -179,7 +179,7 @@ def convert(input: str, output: TextIO, output_format: str):
 )
 @click.option(
     "-p",
-    "--clean-prefixes",
+    "--clean-prefixes / --no-clean-prefixes",
     default=True,
     is_flag=True,
     required=True,

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -1105,8 +1105,8 @@ def get_prefixes_used_in_table(df: pd.DataFrame) -> List[str]:
         for col in _get_sssom_schema_object().entity_reference_slots:
             if col in df.columns:
                 prefixes.extend(list(set(df[col].str.split(":", n=1, expand=True)[0])))
-    list(set(prefixes)).remove("")
-    return prefixes
+    if "" in prefixes: prefixes.remove("")
+    return list(set(prefixes))
 
 
 def get_prefixes_used_in_metadata(meta: MetadataType) -> List[str]:

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -1105,7 +1105,7 @@ def get_prefixes_used_in_table(df: pd.DataFrame) -> List[str]:
         for col in _get_sssom_schema_object().entity_reference_slots:
             if col in df.columns:
                 prefixes.extend(list(set(df[col].str.split(":", n=1, expand=True)[0])))
-    return list(set(prefixes))
+    return list(set(prefixes)).remove("")
 
 
 def get_prefixes_used_in_metadata(meta: MetadataType) -> List[str]:

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -1105,7 +1105,7 @@ def get_prefixes_used_in_table(df: pd.DataFrame) -> List[str]:
         for col in _get_sssom_schema_object().entity_reference_slots:
             if col in df.columns:
                 prefixes.extend(list(set(df[col].str.split(":", n=1, expand=True)[0])))
-    prefixes = list(set(prefixes)).remove("")
+    list(set(prefixes)).remove("")
     return prefixes
 
 

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -1105,7 +1105,8 @@ def get_prefixes_used_in_table(df: pd.DataFrame) -> List[str]:
         for col in _get_sssom_schema_object().entity_reference_slots:
             if col in df.columns:
                 prefixes.extend(list(set(df[col].str.split(":", n=1, expand=True)[0])))
-    if "" in prefixes: prefixes.remove("")
+    if "" in prefixes:
+        prefixes.remove("")
     return list(set(prefixes))
 
 

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -1105,7 +1105,8 @@ def get_prefixes_used_in_table(df: pd.DataFrame) -> List[str]:
         for col in _get_sssom_schema_object().entity_reference_slots:
             if col in df.columns:
                 prefixes.extend(list(set(df[col].str.split(":", n=1, expand=True)[0])))
-    return list(set(prefixes)).remove("")
+    prefixes = list(set(prefixes)).remove("")
+    return prefixes
 
 
 def get_prefixes_used_in_metadata(meta: MetadataType) -> List[str]:


### PR DESCRIPTION
 - [x] Corrected `click` flag syntax from `--clean-prefixes` => `--clean-prefixes / --no-clean-prefixes`
 - [x] When a dataframe  has no value the function `get_prefixes_used_in_table()` adds a `""` to the list of prefixes. This PR fixes it.
