### PR TITLE
Check attribute exists using `hasattr()` and anchor `SQLAlchemy` version.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ keywords =
 
 [options]
 install_requires =
-    sqlalchemy=1.4.46
+    sqlalchemy==1.4.46
     pyparsing
     bioregistry
     click

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ keywords =
 
 [options]
 install_requires =
+    sqlalchemy=1.4.46
     pyparsing
     bioregistry
     click

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ keywords =
 
 [options]
 install_requires =
-    sqlalchemy==1.4.46
+    sqlalchemy<2.0.0
     pyparsing
     bioregistry
     click

--- a/sssom/io.py
+++ b/sssom/io.py
@@ -141,7 +141,6 @@ def split_file(input_path: str, output_directory: Union[str, Path]) -> None:
 
 
 def _get_prefix_map(metadata: Metadata, prefix_map_mode: str = None):
-
     if prefix_map_mode is None:
         prefix_map_mode = PREFIX_MAP_MODE_METADATA_ONLY
 

--- a/sssom/parsers.py
+++ b/sssom/parsers.py
@@ -310,7 +310,9 @@ def _get_mdict_ms_and_bad_attrs(
 
     mdict = {}
     sssom_schema_object = (
-        SSSOMSchemaView.instance if hasattr(SSSOMSchemaView,"instance") else SSSOMSchemaView()
+        SSSOMSchemaView.instance
+        if hasattr(SSSOMSchemaView, "instance")
+        else SSSOMSchemaView()
     )
     for k, v in row.items():
         if v and v == v:

--- a/sssom/parsers.py
+++ b/sssom/parsers.py
@@ -310,7 +310,7 @@ def _get_mdict_ms_and_bad_attrs(
 
     mdict = {}
     sssom_schema_object = (
-        SSSOMSchemaView.instance if SSSOMSchemaView.instance else SSSOMSchemaView()
+        SSSOMSchemaView.instance if hasattr(SSSOMSchemaView,"instance") else SSSOMSchemaView()
     )
     for k, v in row.items():
         if v and v == v:

--- a/sssom/parsers.py
+++ b/sssom/parsers.py
@@ -307,7 +307,6 @@ def _init_mapping_set(meta: Optional[MetadataType]) -> MappingSet:
 def _get_mdict_ms_and_bad_attrs(
     row: pd.Series, ms: MappingSet, bad_attrs: Counter
 ) -> Tuple[dict, MappingSet, Counter]:
-
     mdict = {}
     sssom_schema_object = (
         SSSOMSchemaView.instance

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -1496,7 +1496,6 @@ def are_params_slots(params: dict) -> bool:
 
 
 def _get_sssom_schema_object() -> SSSOMSchemaView:
-
     sssom_sv_object = (
         SSSOMSchemaView.instance
         if hasattr(SSSOMSchemaView, "instance")

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -400,15 +400,16 @@ def assign_default_confidence(
     """
     # Get rows having numpy.NaN as confidence
     if df is not None:
-        if CONFIDENCE not in df.columns:
-            df[CONFIDENCE] = np.NaN
-            nan_df = pd.DataFrame(columns=df.columns)
+        new_df = df.copy()
+        if CONFIDENCE not in new_df.columns:
+            new_df[CONFIDENCE] = np.NaN
+            nan_df = pd.DataFrame(columns=new_df.columns)
         else:
-            df = df[~df[CONFIDENCE].isna()]
+            new_df = df[~df[CONFIDENCE].isna()]
             nan_df = df[df[CONFIDENCE].isna()]
     else:
         ValueError("DataFrame cannot be empty to 'assign_default_confidence'.")
-    return df, nan_df
+    return new_df, nan_df
 
 
 def remove_unmatched(df: pd.DataFrame) -> pd.DataFrame:

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -44,7 +44,7 @@ class TestCollapse(unittest.TestCase):
     def test_filter(self):
         """Test the row count after filtering redundant rows."""
         df = filter_redundant_rows(self.df)
-        self.assertEqual(len(df), 91)
+        self.assertEqual(len(df), 92)
 
     def test_ptable(self):
         """Test the row count of the ptable export."""

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ description = Run code formatters and linters.
 [testenv:flake8]
 skip_install = true
 commands =
-    flake8 sssom/ tests/ setup.py
+    flake8 sssom/ tests/ 
 deps =
     flake8<5.0.0
     flake8-black


### PR DESCRIPTION
 - ~SSSOMSchemaView.instance if SSSOMSchemaView.instance else SSSOMSchemaView()~ => SSSOMSchemaView.instance if hasattr(SSSOMSchemaView,"instance") else SSSOMSchemaView() fixes #340
 - `SQLAlchemy`'s latest version (v2.x.x) is causing errors in legacy code. Need to update code to be v2.x.x compliant. For now anchoring it to prior version v1.4.46
   - `SQLAlchemy` is a dependency of `pandasql` and [there is ticket for this.](https://github.com/yhat/pandasql/issues/102)
 - Removed `setup.py` from `flake8` check in `tox` due to [this issue experienced](https://github.com/PyCQA/bandit/discussions/725)
 - Fix bug mentioned in https://github.com/monarch-initiative/mondo-ingest/issues/129#issuecomment-1414535714