### PR TITLE
Just removed pinning of SQLAlchemy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ keywords =
 
 [options]
 install_requires =
-    sqlalchemy<2.0.0
+    sqlalchemy
     pyparsing
     bioregistry
     click

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ install_requires =
     networkx
     numpy
     pandas
-    pandasql@git+https://git@github.com/hrshdhgd/pandasql.git
+    pansql
     pyyaml
     rdflib>=6
     scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,6 @@ keywords =
 
 [options]
 install_requires =
-    sqlalchemy
     pyparsing
     bioregistry
     click

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ install_requires =
     networkx
     numpy
     pandas
-    pandasql@git+ssh://git@github.com/hrshdhgd/pandasql.git
+    pandasql@git+https://git@github.com/hrshdhgd/pandasql.git
     pyyaml
     rdflib>=6
     scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ install_requires =
     networkx
     numpy
     pandas
-    pandasql
+    pandasql@git+ssh://git@github.com/hrshdhgd/pandasql.git
     pyyaml
     rdflib>=6
     scipy

--- a/sssom/io.py
+++ b/sssom/io.py
@@ -8,7 +8,7 @@ from typing import List, Optional, TextIO, Union
 
 import pandas as pd
 from bioregistry import get_iri
-from pandasql import sqldf
+from pansql import sqldf
 
 from sssom.validators import validate
 

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -3,7 +3,7 @@
 import unittest
 
 import yaml
-from pandasql import sqldf
+from pansql import sqldf
 
 from sssom import (
     collapse,


### PR DESCRIPTION
Fixes #343 

So now we can use the latest version of SQLAlchemy.

The fix was pretty simple: 
 - Here's my PR in the `pandasql` repo: https://github.com/yhat/pandasql/pull/104
 - Until this is merged (seems unlikely since the repo has been inactive since 2017), I have added my fork as the dependency as a fix. 
 - Not sure if PyPI would accept this as a release.

Possible solutions:

1. Re-release `pandasql` as `pandasql2` but I don't want to take credit for something I didn't develop.
2. Bypass use of `pandasql` and directly use SQLAlchemy for our purposes. This I think will be quite an undertaking.

Thoughts @cmungall , @matentzn ?
