### PR TITLE
New method: flip

### DIFF
--- a/sssom/cli.py
+++ b/sssom/cli.py
@@ -58,6 +58,7 @@ from .util import (
     remove_unmatched,
     sort_df_rows_columns,
     to_mapping_set_dataframe,
+    flip_nodes,
 )
 from .writers import write_table
 
@@ -713,6 +714,32 @@ def remove(input: str, output: TextIO, remove_map: str):
     remove_msdf = parse_sssom_table(remove_map)
     input_msdf.remove_mappings(remove_msdf)
     write_table(input_msdf, output)
+
+@main.command()
+@input_argument
+@output_option
+@click.option(
+    "-P",
+    "--subject-prefix",
+    help="Flip subject_id and object_id such that all subject_ids have the same prefix.",
+)
+@click.option(
+    "--merge-flipped/--no-merge-flipped",
+    default=True,
+    is_flag=True,
+    help="If True (default), add flipped dataframe to input else, just return flipped data.",
+)
+def flip(input: str, output: TextIO, subject_prefix: str, merge_flipped: bool):
+    """
+    Flip subject and object IDs such that all subjects have the prefix provided.
+
+    :param input: SSSOM TSV file.
+    :param prefix: Prefix of all subject_ids.
+    :param output: SSSOM TSV file with columns sorted.
+    """
+    msdf = parse_sssom_table(input)
+    msdf.df = flip_nodes(msdf.df, subject_prefix, merge_flipped)
+    write_table(msdf, output)
 
 
 if __name__ == "__main__":

--- a/sssom/constants.py
+++ b/sssom/constants.py
@@ -139,6 +139,17 @@ PREDICATE_LIST = [
     RDF_SEE_ALSO,
 ]
 
+PREDICATE_FLIP_DICTIONARY = {
+        "skos:closeMatch": "skos:closeMatch",
+        "skos:relatedMatch": "skos:relatedMatch",
+        "skos:narrowMatch" : "skos:broadMatch",
+        "skos:broadMatch" : "skos:narrowMatch",
+        "skos:exactMatch" : "skos:exactMatch",
+        "semapv:crossSpeciesExactMatch" : "semapv:crossSpeciesExactMatch",
+        "semapv:crossSpeciesNarrowMatch" : "semapv:crossSpeciesBroadMatch",
+        "semapv:crossSpeciesBroadMatch" : "semapv:crossSpeciesNarrowMatch",
+    }
+
 
 class SEMAPV(Enum):
     """SEMAPV Enum containing different mapping_justification."""

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -46,10 +46,12 @@ from .constants import (
     OBJECT_CATEGORY,
     OBJECT_ID,
     OBJECT_LABEL,
+    OBJECT_MATCH_FIELD,
     OBJECT_SOURCE,
     OBO_HAS_DB_XREF,
     OWL_DIFFERENT_FROM,
     OWL_EQUIVALENT_CLASS,
+    PREDICATE_FLIP_DICTIONARY,
     PREDICATE_ID,
     PREDICATE_LIST,
     PREDICATE_MODIFIER,
@@ -67,6 +69,7 @@ from .constants import (
     SUBJECT_CATEGORY,
     SUBJECT_ID,
     SUBJECT_LABEL,
+    SUBJECT_MATCH_FIELD,
     SUBJECT_SOURCE,
     SSSOMSchemaView,
 )
@@ -1505,3 +1508,42 @@ def _get_sssom_schema_object() -> SSSOMSchemaView:
         else SSSOMSchemaView()
     )
     return sssom_sv_object
+
+def flip_nodes(df: pd.DataFrame, subject_prefix: str, merge_flipped: bool = True) -> pd.DataFrame:
+    """Switching subject and objects based on their prefixes and adjusting predicates accordingly.
+
+    :param df: Pandas dataframe.
+    :param prefix: Prefix of subjects desired.
+    :return: Pandas dataframe with all subject IDs having the same prefix.
+    """
+    condition_1 = df[SUBJECT_ID].str.startswith(subject_prefix+":")
+    condition_2 = df[OBJECT_ID].str.startswith(subject_prefix+":")
+    condition_3 = df[PREDICATE_MODIFIER] == PREDICATE_MODIFIER_NOT
+    predicate_flip_map = PREDICATE_FLIP_DICTIONARY
+
+    predicate_modified_df = pd.DataFrame(df[condition_3])
+    non_predicate_modified_df = pd.DataFrame(df[~condition_3])
+
+    prefixed_subjects_df = pd.DataFrame(non_predicate_modified_df[(condition_1 & ~condition_2)])
+    non_prefix_subjects_df = pd.DataFrame(non_predicate_modified_df[(~condition_1 & condition_2)])
+    df_to_flip = non_prefix_subjects_df.loc[non_prefix_subjects_df[PREDICATE_ID].isin(list(predicate_flip_map.keys()))]
+    flipped_df = df_to_flip.rename(columns={
+        SUBJECT_ID:OBJECT_ID, 
+        SUBJECT_LABEL:OBJECT_LABEL,
+        SUBJECT_CATEGORY: OBJECT_CATEGORY,
+        SUBJECT_MATCH_FIELD: OBJECT_MATCH_FIELD,
+        SUBJECT_SOURCE: OBJECT_SOURCE,
+        OBJECT_ID:SUBJECT_ID, 
+        OBJECT_LABEL:SUBJECT_LABEL,
+        OBJECT_CATEGORY: SUBJECT_CATEGORY,
+        OBJECT_MATCH_FIELD: SUBJECT_MATCH_FIELD,
+        OBJECT_SOURCE: SUBJECT_SOURCE,
+    })
+    flipped_df = flipped_df[df.columns]
+    flipped_df[PREDICATE_ID] = flipped_df[PREDICATE_ID].apply(lambda x: predicate_flip_map[x])
+
+    return_df = pd.concat([prefixed_subjects_df, predicate_modified_df, flipped_df]).drop_duplicates()
+    if merge_flipped:
+        return pd.concat([df, return_df]).drop_duplicates()
+    else:
+        return return_df

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import unittest
 from sssom.constants import OBJECT_ID, SUBJECT_ID
 from sssom.io import extract_iri
 from sssom.parsers import parse_sssom_table
-from sssom.util import MappingSetDataFrame, filter_out_prefixes, filter_prefixes
+from sssom.util import MappingSetDataFrame, filter_out_prefixes, filter_prefixes, flip_nodes
 from tests.constants import data_dir
 
 
@@ -14,6 +14,7 @@ class TestIO(unittest.TestCase):
     def setUp(self) -> None:
         """Set up."""
         self.msdf = parse_sssom_table(f"{data_dir}/basic.tsv")
+        self.msdf2 = parse_sssom_table(f"{data_dir}/basic7.tsv")
         self.features = [SUBJECT_ID, OBJECT_ID]
 
     def test_broken_predicate_list(self):
@@ -81,3 +82,17 @@ class TestIO(unittest.TestCase):
                 set(new_msdf.prefix_map.keys())
             ),
         )
+
+    def test_flip_nodes(self):
+        """Test flip nodes."""
+        subject_prefix = "a"
+        original_msdf = self.msdf2
+        flipped_df = flip_nodes(original_msdf.df, subject_prefix, False)
+        self.assertEqual(len(flipped_df), 14)
+    
+    def test_flip_nodes_merged(self):
+        """Test flip nodes."""
+        subject_prefix = "a"
+        original_msdf = self.msdf2
+        flipped_df = flip_nodes(original_msdf.df, subject_prefix, True)
+        self.assertEqual(len(flipped_df), 36)


### PR DESCRIPTION
 - Flips `subject_id`<=>`object_id` such that all prefixes for the `subject_id` are the one provided by the user. 
 - The `predicate_id` also gets flipped accordingly.

Fixes #315 