### PR TITLE
Makes `clean_prefix_map()` optionally strict.

### DIFF
--- a/sssom/util.py
+++ b/sssom/util.py
@@ -145,8 +145,14 @@ class MappingSetDataFrame:
             description += self.df.tail().to_string() + "\n"
         return description
 
-    def clean_prefix_map(self) -> None:
-        """Remove unused prefixes from the internal prefix map based on the internal dataframe."""
+    def clean_prefix_map(self, strict: bool = False) -> None:
+        """
+        Remove unused prefixes from the internal prefix map based on the internal dataframe.
+
+        :param strict: Boolean if True errors out if all prefixes in dataframe are not
+                       accounted for in the 'curie_map'.
+
+        """
         all_prefixes = []
         prefixes_in_table = get_prefixes_used_in_table(self.df)
         if self.metadata:
@@ -166,7 +172,7 @@ class MappingSetDataFrame:
                 )
                 if prefix != "":
                     missing_prefixes.append(prefix)
-        if missing_prefixes:
+        if missing_prefixes and strict:
             raise ValueError(
                 f"{missing_prefixes} are used in the SSSOM mapping set but it does not exist in the prefix map"
             )

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -277,7 +277,7 @@ def filter_redundant_rows(
     # create a 'sort' method and then replce the following line by sort()
     df = sort_sssom(df)
     # df[CONFIDENCE] = df[CONFIDENCE].apply(lambda x: x + random.random() / 10000)
-    df, nan_df = assign_default_confidence(df)
+    df, nan_df, confidence_column_created = assign_default_confidence(df)
     if ignore_predicate:
         key = [SUBJECT_ID, OBJECT_ID]
     else:
@@ -359,7 +359,7 @@ def filter_redundant_rows(
             [get_row_based_on_hierarchy(concerned_df), return_df], axis=0
         ).drop_duplicates()
 
-    if return_df[CONFIDENCE].isnull().all():
+    if confidence_column_created:
         return_df = return_df.drop(columns=[CONFIDENCE], axis=1)
     return return_df
 
@@ -392,24 +392,26 @@ def get_row_based_on_hierarchy(df: pd.DataFrame):
 
 def assign_default_confidence(
     df: pd.DataFrame,
-) -> Tuple[pd.DataFrame, pd.DataFrame]:
+) -> Tuple[pd.DataFrame, pd.DataFrame, bool]:
     """Assign :data:`numpy.nan` to confidence that are blank.
 
     :param df: SSSOM DataFrame
     :return: A Tuple consisting of the original DataFrame and dataframe consisting of empty confidence values.
     """
+    confidence_column_created = False
     # Get rows having numpy.NaN as confidence
     if df is not None:
         new_df = df.copy()
         if CONFIDENCE not in new_df.columns:
             new_df[CONFIDENCE] = 0.0  # np.NaN
             nan_df = pd.DataFrame(columns=new_df.columns)
+            confidence_column_created = True
         else:
             new_df = df[~df[CONFIDENCE].isna()]
             nan_df = df[df[CONFIDENCE].isna()]
     else:
         ValueError("DataFrame cannot be empty to 'assign_default_confidence'.")
-    return new_df, nan_df
+    return new_df, nan_df, confidence_column_created
 
 
 def remove_unmatched(df: pd.DataFrame) -> pd.DataFrame:
@@ -703,7 +705,7 @@ def deal_with_negation(df: pd.DataFrame) -> pd.DataFrame:
     """
 
     # Handle DataFrames with no 'confidence' column (basically adding a np.NaN to all non-numeric confidences)
-    df, nan_df = assign_default_confidence(df)
+    df, nan_df, confidence_column_created = assign_default_confidence(df)
     if df is None:
         raise ValueError(
             "The dataframe, after assigning default confidence, appears empty (deal_with_negation)"
@@ -822,6 +824,9 @@ def deal_with_negation(df: pd.DataFrame) -> pd.DataFrame:
         return_df = reconciled_df
     else:
         return_df = reconciled_df.append(nan_df).drop_duplicates()
+
+    if confidence_column_created:
+        return_df = return_df.drop(columns=[CONFIDENCE], axis=1)
 
     return return_df
 

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -145,7 +145,7 @@ class MappingSetDataFrame:
             description += self.df.tail().to_string() + "\n"
         return description
 
-    def clean_prefix_map(self, strict: bool = False) -> None:
+    def clean_prefix_map(self, strict: bool = True) -> None:
         """
         Remove unused prefixes from the internal prefix map based on the internal dataframe.
 

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -273,8 +273,6 @@ def filter_redundant_rows(
     :param ignore_predicate: If true, the predicate_id column is ignored, defaults to False
     :return: Filtered pandas DataFrame
     """
-    if CONFIDENCE not in df.columns:
-        return df
     # tie-breaker
     # create a 'sort' method and then replce the following line by sort()
     df = sort_sssom(df)
@@ -404,7 +402,7 @@ def assign_default_confidence(
     if df is not None:
         new_df = df.copy()
         if CONFIDENCE not in new_df.columns:
-            new_df[CONFIDENCE] = np.NaN
+            new_df[CONFIDENCE] = 0.0  # np.NaN
             nan_df = pd.DataFrame(columns=new_df.columns)
         else:
             new_df = df[~df[CONFIDENCE].isna()]

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -273,6 +273,8 @@ def filter_redundant_rows(
     :param ignore_predicate: If true, the predicate_id column is ignored, defaults to False
     :return: Filtered pandas DataFrame
     """
+    if CONFIDENCE not in df.columns:
+        return df
     # tie-breaker
     # create a 'sort' method and then replce the following line by sort()
     df = sort_sssom(df)

--- a/tests/data/reconcile_1.tsv
+++ b/tests/data/reconcile_1.tsv
@@ -1,0 +1,18 @@
+# curie_map:
+#   UBERON: http://purl.obolibrary.org/obo/UBERON_
+#   ZFS: http://purl.obolibrary.org/obo/ZFS_
+#   oio: http://www.geneontology.org/formats/oboInOwl#
+#   owl: http://www.w3.org/2002/07/owl#
+#   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+#   rdfs: http://www.w3.org/2000/01/rdf-schema#
+#   semapv: https://w3id.org/semapv/
+#   skos: http://www.w3.org/2004/02/skos/core#
+#   sssom: https://w3id.org/sssom/
+# license: https://w3id.org/sssom/license/unspecified
+# mapping_set_id: https://w3id.org/sssom/mappings/72debc9d-ca69-45e8-b46d-aef8361bedf2
+# object_source: ZFS
+# subject_source: UBERON
+subject_id	subject_label	predicate_id	object_id	mapping_justification	subject_source	object_source
+UBERON:0000069	larval stage	oio:hasDbXref	ZFS:0000048	semapv:UnspecifiedMatching	UBERON	ZFS
+UBERON:0000105	life cycle stage	oio:hasDbXref	ZFS:0100000	semapv:UnspecifiedMatching	UBERON	ZFS
+UBERON:0000105	life cycle stage	oio:hasDbXref	ZFS:0000000	semapv:UnspecifiedMatching	UBERON	ZFS

--- a/tests/data/reconcile_2.tsv
+++ b/tests/data/reconcile_2.tsv
@@ -1,0 +1,19 @@
+# curie_map:
+#   UBERON: http://purl.obolibrary.org/obo/UBERON_
+#   WBls: http://purl.obolibrary.org/obo/WBls_
+#   oio: http://www.geneontology.org/formats/oboInOwl#
+#   owl: http://www.w3.org/2002/07/owl#
+#   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+#   rdfs: http://www.w3.org/2000/01/rdf-schema#
+#   semapv: https://w3id.org/semapv/
+#   skos: http://www.w3.org/2004/02/skos/core#
+#   sssom: https://w3id.org/sssom/
+# license: https://w3id.org/sssom/license/unspecified
+# mapping_set_id: https://w3id.org/sssom/mappings/c5e357f5-86df-4aaa-a30e-8a23ad523ab2
+# object_source: WBls
+# subject_source: UBERON
+subject_id	subject_label	predicate_id	object_id	mapping_justification	subject_source	object_source
+UBERON:0000066	fully formed stage	oio:hasDbXref	WBls:0000041	semapv:UnspecifiedMatching	UBERON	WBls
+UBERON:0000068	embryo stage	oio:hasDbXref	WBls:0000003	semapv:UnspecifiedMatching	UBERON	WBls
+UBERON:0000068	embryo stage	oio:hasDbXref	WBls:0000102	semapv:UnspecifiedMatching	UBERON	WBls
+UBERON:0000068	embryo stage	oio:hasDbXref	WBls:0000092	semapv:UnspecifiedMatching	UBERON	WBls

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -53,3 +53,14 @@ class TestReconcile(unittest.TestCase):
         self.assertEqual(53, len(msdf1.df))
         self.assertEqual(53, len(msdf2.df))
         self.assertEqual(len(merged_msdf.df), (len(msdf1.df) + len(msdf2.df)))
+
+    def test_merge_with_reconcile_without_confidence(self):
+        """Test merging two tables without reconciliation."""
+        msdf1 = parse_sssom_table(data_dir / "reconcile_1.tsv")
+        msdf2 = parse_sssom_table(data_dir / "reconcile_2.tsv")
+
+        merged_msdf = merge_msdf(msdf1, msdf2, reconcile=True)
+
+        self.assertEqual(3, len(msdf1.df))
+        self.assertEqual(4, len(msdf2.df))
+        self.assertEqual(len(merged_msdf.df), (len(msdf1.df) + len(msdf2.df)))


### PR DESCRIPTION
Fixes #351 

As of the current state, if all prefixes in a dataframe are not accounted for in the `curie_map`, no output is generated and the process errors out.

For now setting the default to be `True` but I'm not sure if it should be True/False. Thoughts @matentzn ?