### PR TITLE
Added strict flag for `clean_prefix_map()`

### DIFF
--- a/sssom/util.py
+++ b/sssom/util.py
@@ -147,12 +147,13 @@ class MappingSetDataFrame:
             description += self.df.tail().to_string() + "\n"
         return description
 
-    def clean_prefix_map(self, strict:bool = True) -> None:
+    def clean_prefix_map(self, strict: bool = True) -> None:
         """
         Remove unused prefixes from the internal prefix map based on the internal dataframe.
-        
+
         :param strict: Boolean if True, errors out if all prefixes in dataframe are not
                        listed in the 'curie_map'.
+        :raises ValueError: If prefixes absent in 'curie_map' and strict flag = True
         """
         all_prefixes = []
         prefixes_in_table = get_prefixes_used_in_table(self.df)

--- a/sssom/util.py
+++ b/sssom/util.py
@@ -147,8 +147,13 @@ class MappingSetDataFrame:
             description += self.df.tail().to_string() + "\n"
         return description
 
-    def clean_prefix_map(self) -> None:
-        """Remove unused prefixes from the internal prefix map based on the internal dataframe."""
+    def clean_prefix_map(self, strict:bool = True) -> None:
+        """
+        Remove unused prefixes from the internal prefix map based on the internal dataframe.
+        
+        :param strict: Boolean if True, errors out if all prefixes in dataframe are not
+                       listed in the 'curie_map'.
+        """
         all_prefixes = []
         prefixes_in_table = get_prefixes_used_in_table(self.df)
         if self.metadata:
@@ -168,7 +173,7 @@ class MappingSetDataFrame:
                 )
                 if prefix != "":
                     missing_prefixes.append(prefix)
-        if missing_prefixes:
+        if missing_prefixes and strict:
             raise ValueError(
                 f"{missing_prefixes} are used in the SSSOM mapping set but it does not exist in the prefix map"
             )


### PR DESCRIPTION
Fixes #351 

As of the current state, if all prefixes in a dataframe are not accounted for in the `curie_map`, no output is generated and the process errors out.

For now setting the default to be `True` but I'm not sure if it should be True/False. Thoughts @matentzn ?