### PR TITLE
Change parse methods to support StringIO

### DIFF
--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -170,7 +170,7 @@ def _read_pandas(input: io.StringIO, sep: str = None) -> pd.DataFrame:
     :return: A pandas dataframe
     """
     try:
-        df = pd.read_csv(input, sep=sep, low_memory=False, comment="#")
+        df = pd.read_csv(input, sep=sep, comment="#")
     except EmptyDataError as e:
         logging.warning(f"Seems like the dataframe is empty: {e}")
         df = pd.DataFrame(

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -161,6 +161,20 @@ def _open_input(input: Union[str, Path, TextIO]) -> io.StringIO:
 
     raise IOError(f"Could not determine the type of input {input}")
 
+def _filter_commented_lines_from_stream(s: io.StringIO):
+    s.seek(0)
+
+    # Create a new StringIO object for filtered data
+    filtered_s = io.StringIO()
+
+    # Filter out lines starting with '#'
+    for line in s:
+        if not line.startswith('#'):
+            filtered_s.write(line)
+
+    # Reset the cursor to the start of the new StringIO object
+    filtered_s.seek(0)
+    return filtered_s
 
 def _read_pandas(input: io.StringIO, sep: str = None) -> pd.DataFrame:
     """Read a tabular data file by wrapping func:`pd.read_csv` to handles comment lines correctly.
@@ -170,7 +184,8 @@ def _read_pandas(input: io.StringIO, sep: str = None) -> pd.DataFrame:
     :return: A pandas dataframe
     """
     try:
-        df = pd.read_csv(input, sep=sep, comment="#")
+        s = _filter_commented_lines_from_stream(input)
+        df = pd.read_csv(s, sep=sep)
     except EmptyDataError as e:
         logging.warning(f"Seems like the dataframe is empty: {e}")
         df = pd.DataFrame(

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -67,7 +67,6 @@ from .util import (
     NoCURIEException,
     curie_from_uri,
     get_file_extension,
-    get_seperator_symbol_from_file_path,
     is_multivalued_slot,
     raise_for_bad_path,
     to_mapping_set_dataframe,
@@ -222,6 +221,23 @@ def _read_pandas_and_metadata(input: io.StringIO, sep: str = None):
     return None, None
 
 
+def _get_seperator_symbol_from_file_path(file):
+    r"""
+    Take as an input a filepath and return the seperate symbol used, for example, by pandas.
+
+    :param file: the file path
+    :return: the seperator symbols as a string, e.g. '\t'
+    """
+    if isinstance(file, Path) or isinstance(file, str):
+        extension = get_file_extension(file)
+        if extension == "tsv":
+            return "\t"
+        elif extension == "csv":
+            return ","
+        logging.warning(f"Could not guess file extension for {file}")
+    return None
+
+
 def parse_sssom_table(
     file_path: Union[str, Path, TextIO],
     prefix_map: Optional[PrefixMap] = None,
@@ -232,7 +248,7 @@ def parse_sssom_table(
     if isinstance(file_path, Path) or isinstance(file_path, str):
         raise_for_bad_path(file_path)
     stream: io.StringIO = _open_input(file_path)
-    sep_new = get_seperator_symbol_from_file_path(file_path)
+    sep_new = _get_seperator_symbol_from_file_path(file_path)
     df, sssom_metadata = _read_pandas_and_metadata(stream, sep_new)
     # if mapping_predicates:
     #     # Filter rows based on presence of predicate_id list provided.

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -226,6 +226,7 @@ def parse_sssom_table(
     file_path: Union[str, Path, TextIO],
     prefix_map: Optional[PrefixMap] = None,
     meta: Optional[MetadataType] = None,
+    **kwargs,
 ) -> MappingSetDataFrame:
     """Parse a TSV to a :class:`MappingSetDocument` to a :class:`MappingSetDataFrame`."""
     if isinstance(file_path, Path) or isinstance(file_path, str):

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -161,6 +161,7 @@ def _open_input(input: Union[str, Path, TextIO]) -> io.StringIO:
 
     raise IOError(f"Could not determine the type of input {input}")
 
+
 def _separate_metadata_and_table_from_stream(s: io.StringIO):
     s.seek(0)
 
@@ -172,20 +173,23 @@ def _separate_metadata_and_table_from_stream(s: io.StringIO):
 
     # Filter out lines starting with '#'
     for line in s:
-        if not line.startswith('#'):
+        if not line.startswith("#"):
             table_component.write(line)
             if header_section:
                 header_section = False
         elif header_section:
             metadata_component.write(line)
         else:
-            logging.info(f"Line {line} is starting with hash symbol, but header section is already passed. "
-                         f"This line is skipped")
+            logging.info(
+                f"Line {line} is starting with hash symbol, but header section is already passed. "
+                f"This line is skipped"
+            )
 
     # Reset the cursor to the start of the new StringIO object
     table_component.seek(0)
     metadata_component.seek(0)
     return table_component, metadata_component
+
 
 def _read_pandas_and_metadata(input: io.StringIO, sep: str = None):
     """Read a tabular data file by wrapping func:`pd.read_csv` to handles comment lines correctly.
@@ -198,7 +202,7 @@ def _read_pandas_and_metadata(input: io.StringIO, sep: str = None):
 
     try:
         df = pd.read_csv(table_stream, sep=sep)
-        df.fillna("",inplace=True)
+        df.fillna("", inplace=True)
     except EmptyDataError as e:
         logging.warning(f"Seems like the dataframe is empty: {e}")
         df = pd.DataFrame(
@@ -234,7 +238,6 @@ def parse_sssom_table(
     #     df = df[df["predicate_id"].isin(mapping_predicates)]
 
     # If SSSOM external metadata is provided, merge it with the internal metadata
-
 
     if sssom_metadata:
         if meta:

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -193,7 +193,7 @@ def _separate_metadata_and_table_from_stream(s: io.StringIO):
 def _read_pandas_and_metadata(input: io.StringIO, sep: str = None):
     """Read a tabular data file by wrapping func:`pd.read_csv` to handles comment lines correctly.
 
-    :param file: The file to read. If no separator is given, this file should be named.
+    :param input: The file to read. If no separator is given, this file should be named.
     :param sep: File separator for pandas
     :return: A pandas dataframe
     """

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -871,7 +871,7 @@ def get_file_extension(file: Union[str, Path, TextIO]) -> str:
             return f_format.strip(punctuation)
         else:
             logging.warning(f"Cannot guess format from {filename}")
-    logging.info(f"Cannot guess format extension for this file, assuming TSV.")
+    logging.info("Cannot guess format extension for this file, assuming TSV.")
     return "tsv"
 
 
@@ -938,26 +938,17 @@ def read_pandas(file: Union[str, Path, TextIO], sep: Optional[str] = None) -> pd
     :param sep: File separator for pandas
     :return: A pandas dataframe
     """
-    sep_new = get_seperator_symbol_from_file_path(file) if sep is None else sep
+    sep_new = sep
+    if set is None:
+        if isinstance(file, Path) or isinstance(file, str):
+            extension = get_file_extension(file)
+            if extension == "tsv":
+                sep_new = "\t"
+            elif extension == "csv":
+                sep_new = ","
+            logging.warning(f"Could not guess file extension for {file}")
     df = read_csv(file, comment="#", sep=sep_new).fillna("")
     return sort_df_rows_columns(df)
-
-
-def get_seperator_symbol_from_file_path(file):
-    r"""
-    Take as an input a filepath and return the seperate symbol used, for example, by pandas.
-
-    :param file: the file path
-    :return: the seperator symbols as a string, e.g. '\t'
-    """
-    if isinstance(file, Path) or isinstance(file, str):
-        extension = get_file_extension(file)
-        if extension == "tsv":
-            return "\t"
-        elif extension == "csv":
-            return ","
-        logging.warning(f"Could not guess file extension for {file}")
-    return None
 
 
 def extract_global_metadata(msdoc: MappingSetDocument) -> Dict[str, PrefixMap]:

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -946,13 +946,11 @@ def get_seperator_symbol_from_file_path(file):
     if file is isinstance(file, Path) or file is isinstance(file, str):
         extension = get_file_extension(file)
         if extension == "tsv":
-            sep = "\t"
+            return "\t"
         elif extension == "csv":
-            sep = ","
-        else:
-            sep = "\t"
-            logging.warning("Cannot automatically determine table format, trying tsv.")
-    return sep
+            return ","
+        logging.warning(f"Could not guess file extension for {file}")
+    return None
 
 
 def extract_global_metadata(msdoc: MappingSetDocument) -> Dict[str, PrefixMap]:

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -1252,11 +1252,9 @@ def raise_for_bad_path(file_path: Union[str, Path]) -> None:
     if isinstance(file_path, Path):
         if not file_path.is_file():
             raise FileNotFoundError(f"{file_path} is not a valid file path or url.")
-    elif (
-        not isinstance(file_path, TextIO)
-        and not validators.url(file_path)
-        and not os.path.exists(file_path)
-    ):
+    elif not isinstance(file_path, str):
+        logging.info("Path provided to raise_for_bad_path() is neither a Path nor str-like object.")
+    elif not validators.url(file_path) and not os.path.exists(file_path):
         raise FileNotFoundError(f"{file_path} is not a valid file path or url.")
 
 

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -938,16 +938,15 @@ def read_pandas(file: Union[str, Path, TextIO], sep: Optional[str] = None) -> pd
     :param sep: File separator for pandas
     :return: A pandas dataframe
     """
-    sep_new = sep
-    if set is None:
+    if sep is None:
         if isinstance(file, Path) or isinstance(file, str):
             extension = get_file_extension(file)
             if extension == "tsv":
-                sep_new = "\t"
+                sep = "\t"
             elif extension == "csv":
-                sep_new = ","
+                sep = ","
             logging.warning(f"Could not guess file extension for {file}")
-    df = read_csv(file, comment="#", sep=sep_new).fillna("")
+    df = read_csv(file, comment="#", sep=sep).fillna("")
     return sort_df_rows_columns(df)
 
 

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -1196,6 +1196,23 @@ def filter_prefixes(
     return pd.DataFrame(rows) if rows else pd.DataFrame(columns=features)
 
 
+@deprecation.deprecated(details="This is no longer used and will be removed from the public API.")
+def guess_file_format(filename: Union[str, TextIO]) -> str:
+    """Get file format.
+
+    :param filename: filename
+    :raises ValueError: Unrecognized file extension
+    :return: File extension
+    """
+    extension = get_file_extension(filename)
+    if extension in ["owl", "rdf"]:
+        return SSSOM_DEFAULT_RDF_SERIALISATION
+    elif extension in RDF_FORMATS:
+        return extension
+    else:
+        raise ValueError(f"File extension {extension} does not correspond to a legal file format")
+
+
 def prepare_context(
     prefix_map: Optional[PrefixMap] = None,
 ) -> Mapping[str, Any]:

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -868,7 +868,9 @@ def get_file_extension(file: Union[str, Path, TextIO]) -> str:
         if file.suffix:
             return file.suffix.strip(punctuation)
         else:
-            logging.warning(f"Cannot guess format from {file}, despite appearing to be a Path-like object.")
+            logging.warning(
+                f"Cannot guess format from {file}, despite appearing to be a Path-like object."
+            )
     return "tsv"
 
 
@@ -950,7 +952,7 @@ def get_seperator_symbol_from_file_path(file):
     if isinstance(file, Path) or isinstance(file, str):
         extension = get_file_extension(file)
         if extension == "tsv":
-            return '\t'
+            return "\t"
         elif extension == "csv":
             return ","
         logging.warning(f"Could not guess file extension for {file}")

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from functools import reduce
 from io import StringIO
 from pathlib import Path
+from string import punctuation
 from typing import (
     Any,
     ChainMap,
@@ -860,11 +861,14 @@ def get_file_extension(file: Union[str, Path, TextIO]) -> str:
         parts = filename.split(".")
         if len(parts) > 0:
             f_format = parts[-1]
-            return f_format
+            return f_format.strip(punctuation)
         else:
             logging.warning(f"Cannot guess format from {filename}")
     elif isinstance(file, Path):
-        return file.suffix
+        if file.suffix:
+            return file.suffix.strip(punctuation)
+        else:
+            logging.warning(f"Cannot guess format from {file}, despite appearing to be a Path-like object.")
     return "tsv"
 
 
@@ -943,10 +947,10 @@ def get_seperator_symbol_from_file_path(file):
     :param file: the file path
     :return: the seperator symbols as a string, e.g. '\t'
     """
-    if file is isinstance(file, Path) or file is isinstance(file, str):
+    if isinstance(file, Path) or isinstance(file, str):
         extension = get_file_extension(file)
         if extension == "tsv":
-            return "\t"
+            return '\t'
         elif extension == "csv":
             return ","
         logging.warning(f"Could not guess file extension for {file}")

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -856,7 +856,14 @@ def get_file_extension(file: Union[str, Path, TextIO]) -> str:
     :param file: File path
     :return: format of the file passed, default tsv
     """
-    if isinstance(file, str):
+    if isinstance(file, Path):
+        if file.suffix:
+            return file.suffix.strip(punctuation)
+        else:
+            logging.warning(
+                f"Cannot guess format from {file}, despite appearing to be a Path-like object."
+            )
+    elif isinstance(file, str):
         filename = file
         parts = filename.split(".")
         if len(parts) > 0:
@@ -864,13 +871,7 @@ def get_file_extension(file: Union[str, Path, TextIO]) -> str:
             return f_format.strip(punctuation)
         else:
             logging.warning(f"Cannot guess format from {filename}")
-    elif isinstance(file, Path):
-        if file.suffix:
-            return file.suffix.strip(punctuation)
-        else:
-            logging.warning(
-                f"Cannot guess format from {file}, despite appearing to be a Path-like object."
-            )
+    logging.info(f"Cannot guess format extension for this file, assuming TSV.")
     return "tsv"
 
 

--- a/src/sssom/writers.py
+++ b/src/sssom/writers.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict, List, Optional, TextIO, Tuple, Union
 
 import pandas as pd
 import yaml
+from deprecation import deprecated
 from jsonasobj2 import JsonObj
 from linkml_runtime.dumpers import JSONDumper, rdflib_dumper
 from linkml_runtime.utils.schemaview import SchemaView
@@ -161,6 +162,9 @@ def write_ontoportal_json(
 # Converters convert a mappingsetdataframe to an object of the supportes types (json, pandas dataframe)
 
 
+@deprecated(
+    details="Use df variable of 'MappingSetDataFrame' instead (msdf.df).",
+)
 def to_dataframe(msdf: MappingSetDataFrame) -> pd.DataFrame:
     """Convert a mapping set dataframe to a dataframe."""
     data = []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,7 @@ from sssom.cli import (
     split,
     validate,
 )
+from tests.constants import data_dir
 from tests.test_data import (
     RECON_YAML,
     SSSOMTestCase,
@@ -34,8 +35,6 @@ from tests.test_data import (
     get_multiple_input_test_cases,
     test_out_dir,
 )
-
-from .constants import data_dir
 
 
 class SSSOMCLITestSuite(unittest.TestCase):

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -9,11 +9,10 @@ from typing import Dict
 import yaml
 from rdflib import Graph
 
-from sssom.parsers import get_parsing_function, to_mapping_set_document
+from sssom.parsers import get_parsing_function, parse_sssom_table, to_mapping_set_document
 from sssom.sssom_document import MappingSetDocument
-from sssom.util import read_pandas, to_mapping_set_dataframe
+from sssom.util import to_mapping_set_dataframe
 from sssom.writers import (
-    to_dataframe,
     to_json,
     to_ontoportal_json,
     to_owl_graph,
@@ -138,7 +137,7 @@ class SSSOMReadWriteTestSuite(unittest.TestCase):
 
     def _test_to_dataframe(self, mdoc, test):
         msdf = to_mapping_set_dataframe(mdoc)
-        df = to_dataframe(msdf)
+        df = msdf.df
         self.assertEqual(
             len(df),
             test.ct_data_frame_rows,
@@ -146,7 +145,7 @@ class SSSOMReadWriteTestSuite(unittest.TestCase):
         )
         df.to_csv(test.get_out_file("roundtrip.tsv"), sep="\t")
         # data = pd.read_csv(test.get_out_file("roundtrip.tsv"), sep="\t")
-        data = read_pandas(test.get_out_file("roundtrip.tsv"))
+        data = parse_sssom_table(test.get_out_file("roundtrip.tsv")).df
         self.assertEqual(
             len(data),
             test.ct_data_frame_rows,
@@ -156,7 +155,7 @@ class SSSOMReadWriteTestSuite(unittest.TestCase):
         with open(path, "w") as file:
             write_table(msdf, file)
         # self._test_files_equal(test.get_out_file("tsv"), test.get_validate_file("tsv"))
-        df = read_pandas(path)
+        df = parse_sssom_table(path).df
         self.assertEqual(
             len(df),
             test.ct_data_frame_rows,

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -23,9 +23,8 @@ from sssom.writers import (
     write_rdf,
     write_table,
 )
-
-from .constants import data_dir
-from .test_data import SSSOMTestCase, get_all_test_cases
+from tests.constants import data_dir
+from tests.test_data import SSSOMTestCase, get_all_test_cases
 
 
 class SSSOMReadWriteTestSuite(unittest.TestCase):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,5 +1,6 @@
 """Tests for parsers."""
 
+import io
 import json
 import math
 import os
@@ -63,7 +64,7 @@ class TestParse(unittest.TestCase):
         self.alignmentxml = minidom.parse(self.alignmentxml_file)
         self.metadata = get_default_metadata()
 
-    def test_parse_sssom_dataframe(self):
+    def test_parse_sssom_dataframe_from_file(self):
         """Test parsing a TSV."""
         input_path = f"{test_data_dir}/basic.tsv"
         msdf = parse_sssom_table(input_path)
@@ -76,7 +77,23 @@ class TestParse(unittest.TestCase):
             f"{input_path} has the wrong number of mappings.",
         )
 
-    def test_parse_sssom_dataframe_url(self):
+    def test_parse_sssom_dataframe_from_stringio(self):
+        """Test parsing a TSV."""
+        input_path = f"{test_data_dir}/basic.tsv"
+        with open(input_path, "r") as file:
+            input_string = file.read()
+        stream = io.StringIO(input_string)
+        msdf = parse_sssom_table(stream)
+        output_path = os.path.join(test_out_dir, "test_parse_sssom_dataframe_stream.tsv")
+        with open(output_path, "w") as file:
+            write_table(msdf, file)
+        self.assertEqual(
+            len(msdf.df),
+            141,
+            f"{input_path} has the wrong number of mappings.",
+        )
+
+    def test_parse_sssom_dataframe_from_url(self):
         """Test parsing a TSV from a URL."""
         msdf = parse_sssom_table(self.df_url)
         output_path = os.path.join(test_out_dir, "test_parse_sssom_dataframe_url.tsv")


### PR DESCRIPTION
This ended up doing a bit more than just adding support for StringIO:

- Localising all the file processing to a private `_open_input()` method. No other function will deal with opening the filestream, and the target format is io.StreamIO
- Providing a single method _separate_metadata_and_table_from_stream to take in the full stream for an sssom mapping table and splitting it into the metadata and dataframe component, before parsing it with pandas/yaml.
- Simplified a few tests and removed the broken `to_dataframe()` method (which is never needed).
