### PR TITLE
Add default `confidence` param to sssom file while creating `ptable`

### DIFF
--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -49,8 +49,6 @@ from .util import (
     SSSOM_EXPORT_FORMATS,
     SSSOM_READ_FORMATS,
     MappingSetDataFrame,
-    add_default_confidence,
-    collapse,
     compare_dataframes,
     dataframe_to_ptable,
     filter_redundant_rows,

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -254,7 +254,7 @@ def split(input: str, output_directory: str):
 @click.option("-W", "--inverse-factor", help="Inverse factor.")
 @click.option(
     "--default-confidence",
-    default=None,
+    type=float,
     help="Default confidence to be assigned if absent.",
 )
 def ptable(input, output: TextIO, inverse_factor: float, default_confidence: float):

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -24,6 +24,7 @@ from rdflib import Graph
 from scipy.stats import chi2_contingency
 
 from sssom.constants import (
+    CONFIDENCE,
     DEFAULT_VALIDATION_TYPES,
     PREFIX_MAP_MODES,
     SchemaValidationType,
@@ -49,6 +50,7 @@ from .util import (
     SSSOM_EXPORT_FORMATS,
     SSSOM_READ_FORMATS,
     MappingSetDataFrame,
+    add_default_confidence,
     collapse,
     compare_dataframes,
     dataframe_to_ptable,
@@ -266,6 +268,7 @@ def ptable(input, output: TextIO, inverse_factor, default_confidence: bool):
     # TODO should maybe move to boomer (but for now it can live here, so cjm can tweak
     msdf = parse_sssom_table(input)
     # df = parse(input)
+    msdf.df = add_default_confidence(msdf.df)
     df = collapse(msdf.df)
     # , priors=list(priors)
     rows = dataframe_to_ptable(

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -268,7 +268,9 @@ def ptable(input, output: TextIO, inverse_factor: float, default_confidence: flo
         msdf.df = add_default_confidence(msdf.df, default_confidence)
     df = collapse(msdf.df)
     # , priors=list(priors)
-    rows = dataframe_to_ptable(df, inverse_factor=inverse_factor, confidence=default_confidence)
+    rows = dataframe_to_ptable(
+        df, inverse_factor=inverse_factor, default_confidence=default_confidence
+    )
     for row in rows:
         print(*row, sep="\t", file=output)
 

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -253,14 +253,24 @@ def split(input: str, output_directory: str):
 @input_argument
 @output_option
 @click.option("-W", "--inverse-factor", help="Inverse factor.")
-def ptable(input, output: TextIO, inverse_factor):
+@click.option(
+    "--default-confidence / --no-default-confidence",
+    default=False,
+    is_flag=True,
+    help="If True and SSSOM file does not have the `confidence` column,\
+          it is created and initialized to 0.95. But if the `confidence` column exists,\
+          only `None` values are imputed to 0.95.",
+)
+def ptable(input, output: TextIO, inverse_factor, default_confidence: bool):
     """Convert an SSSOM file to a ptable for kboom/`boomer <https://github.com/INCATools/boomer>`_."""
     # TODO should maybe move to boomer (but for now it can live here, so cjm can tweak
     msdf = parse_sssom_table(input)
     # df = parse(input)
     df = collapse(msdf.df)
     # , priors=list(priors)
-    rows = dataframe_to_ptable(df, inverse_factor=inverse_factor)
+    rows = dataframe_to_ptable(
+        df, inverse_factor=inverse_factor, default_confidence=default_confidence
+    )
     for row in rows:
         print(*row, sep="\t", file=output)
 

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -263,13 +263,8 @@ def ptable(input, output: TextIO, inverse_factor: float, default_confidence: flo
     """Convert an SSSOM file to a ptable for kboom/`boomer <https://github.com/INCATools/boomer>`_."""
     # TODO should maybe move to boomer (but for now it can live here, so cjm can tweak
     msdf = parse_sssom_table(input)
-    # df = parse(input)
-    if default_confidence:
-        msdf.df = add_default_confidence(msdf.df, default_confidence)
-    df = collapse(msdf.df)
-    # , priors=list(priors)
     rows = dataframe_to_ptable(
-        df, inverse_factor=inverse_factor, default_confidence=default_confidence
+        msdf.df, inverse_factor=inverse_factor, default_confidence=default_confidence
     )
     for row in rows:
         print(*row, sep="\t", file=output)

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -255,23 +255,21 @@ def split(input: str, output_directory: str):
 @output_option
 @click.option("-W", "--inverse-factor", help="Inverse factor.")
 @click.option(
-    "--default-confidence / --no-default-confidence",
-    default=False,
-    is_flag=True,
-    help="If True and SSSOM file does not have the `confidence` column,\
-          it is created and initialized to 0.95. But if the `confidence` column exists,\
-          only `None` values are imputed to 0.95.",
+    "--default-confidence",
+    default=None,
+    help="Default confidence to be assigned if absent.",
 )
-def ptable(input, output: TextIO, inverse_factor, default_confidence: bool):
+def ptable(input, output: TextIO, inverse_factor: float, default_confidence: float):
     """Convert an SSSOM file to a ptable for kboom/`boomer <https://github.com/INCATools/boomer>`_."""
     # TODO should maybe move to boomer (but for now it can live here, so cjm can tweak
     msdf = parse_sssom_table(input)
     # df = parse(input)
-    msdf.df = add_default_confidence(msdf.df)
+    if default_confidence:
+        msdf.df = add_default_confidence(msdf.df, default_confidence)
     df = collapse(msdf.df)
     # , priors=list(priors)
     rows = dataframe_to_ptable(
-        df, inverse_factor=inverse_factor, default_confidence=default_confidence
+        df, inverse_factor=inverse_factor, confidence=default_confidence
     )
     for row in rows:
         print(*row, sep="\t", file=output)

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -254,7 +254,7 @@ def split(input: str, output_directory: str):
 @click.option("-W", "--inverse-factor", help="Inverse factor.")
 @click.option(
     "--default-confidence",
-    type=click.FloatRange(0, 1), 
+    type=click.FloatRange(0, 1),
     help="Default confidence to be assigned if absent.",
 )
 def ptable(input, output: TextIO, inverse_factor: float, default_confidence: float):

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -268,9 +268,7 @@ def ptable(input, output: TextIO, inverse_factor: float, default_confidence: flo
         msdf.df = add_default_confidence(msdf.df, default_confidence)
     df = collapse(msdf.df)
     # , priors=list(priors)
-    rows = dataframe_to_ptable(
-        df, inverse_factor=inverse_factor, confidence=default_confidence
-    )
+    rows = dataframe_to_ptable(df, inverse_factor=inverse_factor, confidence=default_confidence)
     for row in rows:
         print(*row, sep="\t", file=output)
 

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -6,7 +6,7 @@ later, but that will cause problems--the code will get executed twice:
 - When you run ``python3 -m sssom`` python will execute``__main__.py`` as a script. That means there won't be any
   ``sssom.__main__`` in ``sys.modules``.
 - When you import __main__ it will get executed again (as a module) because
-  there's no ``sssom.__main__`` in ``sys.modules``.
+  there's no ``sssom.__main__`` in ``sys.modules`` .
 
 .. seealso:: https://click.palletsprojects.com/en/8.0.x/setuptools/
 """

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -254,7 +254,7 @@ def split(input: str, output_directory: str):
 @click.option("-W", "--inverse-factor", help="Inverse factor.")
 @click.option(
     "--default-confidence",
-    type=float,
+    type=click.FloatRange(0, 1),
     help="Default confidence to be assigned if absent.",
 )
 def ptable(input, output: TextIO, inverse_factor: float, default_confidence: float):

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -254,7 +254,7 @@ def split(input: str, output_directory: str):
 @click.option("-W", "--inverse-factor", help="Inverse factor.")
 @click.option(
     "--default-confidence",
-    type=click.FloatRange(0, 1),
+    type=click.FloatRange(0, 1), 
     help="Default confidence to be assigned if absent.",
 )
 def ptable(input, output: TextIO, inverse_factor: float, default_confidence: float):

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -24,7 +24,6 @@ from rdflib import Graph
 from scipy.stats import chi2_contingency
 
 from sssom.constants import (
-    CONFIDENCE,
     DEFAULT_VALIDATION_TYPES,
     PREFIX_MAP_MODES,
     SchemaValidationType,

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -511,6 +511,7 @@ def dataframe_to_ptable(
 
     :param df: Pandas DataFrame
     :param inverse_factor: Multiplier to (1 - confidence), defaults to 0.5
+    :param default_confidence: Boolean that if True initializes blank confidences to 0.95
     :raises ValueError: Predicate value error
     :raises ValueError: Predicate type value error
     :return: List of rows

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -504,7 +504,7 @@ def compare_dataframes(df1: pd.DataFrame, df2: pd.DataFrame) -> MappingSetDiff:
     return d
 
 
-def add_default_confidence(df: pd.DataFrame, confidence: float) -> pd.DataFrame:
+def add_default_confidence(df: pd.DataFrame, confidence: float = None) -> pd.DataFrame:
     """Add `confidence` column to DataFrame if absent and initializes to 0.95.
 
     If `confidence` column already exists, only fill in the None ones by 0.95.
@@ -526,7 +526,7 @@ def dataframe_to_ptable(
 
     :param df: Pandas DataFrame
     :param inverse_factor: Multiplier to (1 - confidence), defaults to 0.5
-    :param confidence: Default confidence to be assigned if absent.
+    :param default_confidence: Default confidence to be assigned if absent.
     :raises ValueError: Predicate value error
     :raises ValueError: Predicate type value error
     :return: List of rows

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -504,6 +504,18 @@ def compare_dataframes(df1: pd.DataFrame, df2: pd.DataFrame) -> MappingSetDiff:
     return d
 
 
+def add_default_confidence(df: pd.DataFrame) -> pd.DataFrame:
+    """Add `confidence` column to DataFrame if absent and initializes to 0.95.
+
+    If `confidence` column already exists, only fill in the None ones by 0.95.
+
+    :param df: DataFrame whose `confidence` column needs to be filled.
+    :return: DataFrame with a complete `confidence` column.
+    """
+    df.loc[df[CONFIDENCE].isnull(), CONFIDENCE] = 0.95
+    return df.fillna({CONFIDENCE: 0.95})
+
+
 def dataframe_to_ptable(
     df: pd.DataFrame, *, inverse_factor: float = None, default_confidence: bool = False
 ):
@@ -519,10 +531,9 @@ def dataframe_to_ptable(
     """
     if not inverse_factor:
         inverse_factor = 0.5
-    if default_confidence and CONFIDENCE not in df:
-        df[CONFIDENCE] = 0.95
-    elif default_confidence:
-        df.loc[df[CONFIDENCE].isnull(), CONFIDENCE] = 0.95
+
+    if default_confidence:
+        df = add_default_confidence(df)
 
     df = collapse(df)
     rows = []

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -504,7 +504,7 @@ def compare_dataframes(df1: pd.DataFrame, df2: pd.DataFrame) -> MappingSetDiff:
     return d
 
 
-def add_default_confidence(df: pd.DataFrame) -> pd.DataFrame:
+def add_default_confidence(df: pd.DataFrame, confidence: float) -> pd.DataFrame:
     """Add `confidence` column to DataFrame if absent and initializes to 0.95.
 
     If `confidence` column already exists, only fill in the None ones by 0.95.
@@ -512,20 +512,21 @@ def add_default_confidence(df: pd.DataFrame) -> pd.DataFrame:
     :param df: DataFrame whose `confidence` column needs to be filled.
     :return: DataFrame with a complete `confidence` column.
     """
-    df[CONFIDENCE] = df.get(CONFIDENCE, 0.95)
-    df.loc[df[CONFIDENCE].isnull(), CONFIDENCE] = 0.95
+    # df[CONFIDENCE] = df.get(CONFIDENCE, confidence)
+    if df.get(CONFIDENCE) is not None:
+        df[CONFIDENCE] = confidence * df[CONFIDENCE]
+    df.loc[df[CONFIDENCE].isnull(), CONFIDENCE] = confidence
     return df
 
 
 def dataframe_to_ptable(
-    df: pd.DataFrame, *, inverse_factor: float = None, default_confidence: bool = False
+    df: pd.DataFrame, *, inverse_factor: float = None, default_confidence: float = None
 ):
     """Export a KBOOM table.
 
     :param df: Pandas DataFrame
     :param inverse_factor: Multiplier to (1 - confidence), defaults to 0.5
-    :param default_confidence: Boolean that if True
-        initializes blank confidences to 0.95, defaults to False
+    :param confidence: Default confidence to be assigned if absent.
     :raises ValueError: Predicate value error
     :raises ValueError: Predicate type value error
     :return: List of rows
@@ -534,7 +535,7 @@ def dataframe_to_ptable(
         inverse_factor = 0.5
 
     if default_confidence:
-        df = add_default_confidence(df)
+        df = add_default_confidence(df, default_confidence)
 
     df = collapse(df)
     rows = []

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -504,7 +504,7 @@ def compare_dataframes(df1: pd.DataFrame, df2: pd.DataFrame) -> MappingSetDiff:
     return d
 
 
-def add_default_confidence(df: pd.DataFrame, confidence: float = None) -> pd.DataFrame:
+def add_default_confidence(df: pd.DataFrame, confidence: float = np.NAN) -> pd.DataFrame:
     """Add `confidence` column to DataFrame if absent and initializes to 0.95.
 
     If `confidence` column already exists, only fill in the None ones by 0.95.

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -512,8 +512,9 @@ def add_default_confidence(df: pd.DataFrame) -> pd.DataFrame:
     :param df: DataFrame whose `confidence` column needs to be filled.
     :return: DataFrame with a complete `confidence` column.
     """
+    df[CONFIDENCE] = df.get(CONFIDENCE, 0.95)
     df.loc[df[CONFIDENCE].isnull(), CONFIDENCE] = 0.95
-    return df.fillna({CONFIDENCE: 0.95})
+    return df
 
 
 def dataframe_to_ptable(

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -515,7 +515,7 @@ def add_default_confidence(df: pd.DataFrame, confidence: float = None) -> pd.Dat
     if CONFIDENCE in df.columns:
         df[CONFIDENCE] = confidence * df.get(CONFIDENCE, 1)
     else:
-        df[CONFIDENCE] = confidence
+        df[CONFIDENCE] = float(confidence)
 
     return df
 

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -512,11 +512,11 @@ def add_default_confidence(df: pd.DataFrame, confidence: float = None) -> pd.Dat
     :param df: DataFrame whose `confidence` column needs to be filled.
     :return: DataFrame with a complete `confidence` column.
     """
-    if 'CONFIDENCE' in df.columns:
-        df['CONFIDENCE'] = confidence * df.get('CONFIDENCE', 1)
+    if CONFIDENCE in df.columns:
+        df[CONFIDENCE] = confidence * df.get(CONFIDENCE, 1)
     else:
-        df['CONFIDENCE'] = confidence
-    
+        df[CONFIDENCE] = confidence
+
     return df
 
 

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -504,7 +504,9 @@ def compare_dataframes(df1: pd.DataFrame, df2: pd.DataFrame) -> MappingSetDiff:
     return d
 
 
-def dataframe_to_ptable(df: pd.DataFrame, *, inverse_factor: float = None):
+def dataframe_to_ptable(
+    df: pd.DataFrame, *, inverse_factor: float = None, default_confidence: bool = False
+):
     """Export a KBOOM table.
 
     :param df: Pandas DataFrame
@@ -515,6 +517,11 @@ def dataframe_to_ptable(df: pd.DataFrame, *, inverse_factor: float = None):
     """
     if not inverse_factor:
         inverse_factor = 0.5
+    if default_confidence and CONFIDENCE not in df:
+        df[CONFIDENCE] = 0.95
+    elif default_confidence:
+        df.loc[df[CONFIDENCE].isnull(), CONFIDENCE] = 0.95
+
     df = collapse(df)
     rows = []
     for _, row in df.iterrows():

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -512,10 +512,11 @@ def add_default_confidence(df: pd.DataFrame, confidence: float = None) -> pd.Dat
     :param df: DataFrame whose `confidence` column needs to be filled.
     :return: DataFrame with a complete `confidence` column.
     """
-    # df[CONFIDENCE] = df.get(CONFIDENCE, confidence)
-    if df.get(CONFIDENCE) is not None:
-        df[CONFIDENCE] = confidence * df[CONFIDENCE]
-    df.loc[df[CONFIDENCE].isnull(), CONFIDENCE] = confidence
+    if 'CONFIDENCE' in df.columns:
+        df['CONFIDENCE'] = confidence * df.get('CONFIDENCE', 1)
+    else:
+        df['CONFIDENCE'] = confidence
+    
     return df
 
 

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -511,7 +511,8 @@ def dataframe_to_ptable(
 
     :param df: Pandas DataFrame
     :param inverse_factor: Multiplier to (1 - confidence), defaults to 0.5
-    :param default_confidence: Boolean that if True initializes blank confidences to 0.95
+    :param default_confidence: Boolean that if True
+        initializes blank confidences to 0.95, defaults to False
     :raises ValueError: Predicate value error
     :raises ValueError: Predicate type value error
     :return: List of rows

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -513,7 +513,8 @@ def add_default_confidence(df: pd.DataFrame, confidence: float = None) -> pd.Dat
     :return: DataFrame with a complete `confidence` column.
     """
     if CONFIDENCE in df.columns:
-        df[CONFIDENCE] = confidence * df.get(CONFIDENCE, 1)
+        df[CONFIDENCE] = df[CONFIDENCE].apply(lambda x: confidence * x if x is not None else x)
+        df[CONFIDENCE].fillna(float(confidence), inplace=True)
     else:
         df[CONFIDENCE] = float(confidence)
 


### PR DESCRIPTION
 If the confidence column is absent, `ptable` cannot be generated.

Fix: Add the `confidence` column if absent and initialize it to a user provided value. If present, then fill `None`s by that value