### PR TITLE
Update testing and type checking

### DIFF
--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -1,6 +1,5 @@
 """Utility functions."""
 
-import hashlib
 import itertools as itt
 import json
 import logging
@@ -9,7 +8,6 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass, field
 from functools import reduce
-from io import StringIO
 from pathlib import Path
 from string import punctuation
 from typing import (
@@ -25,17 +23,14 @@ from typing import (
     Tuple,
     Union,
 )
-from urllib.request import urlopen
 
 import numpy as np
 import pandas as pd
 import validators
 import yaml
 from curies import Converter
-from deprecation import deprecated
 from jsonschema import ValidationError
 from linkml_runtime.linkml_model.types import Uriorcurie
-from pandas.errors import EmptyDataError
 from sssom_schema import Mapping as SSSOM_Mapping
 from sssom_schema import slots
 
@@ -257,12 +252,10 @@ class MappingSetDiff:
     """
 
 
-def parse(filename: str) -> pd.DataFrame:
+def parse(filename: Union[str, Path]) -> pd.DataFrame:
     """Parse a TSV to a pandas frame."""
-    # return from_tsv(filename)
     logging.info(f"Parsing {filename}")
     return pd.read_csv(filename, sep="\t", comment="#")
-    # return read_pandas(filename)
 
 
 def collapse(df: pd.DataFrame) -> pd.DataFrame:
@@ -406,16 +399,15 @@ def assign_default_confidence(
     :return: A Tuple consisting of the original DataFrame and dataframe consisting of empty confidence values.
     """
     # Get rows having numpy.NaN as confidence
-    if df is not None:
-        new_df = df.copy()
-        if CONFIDENCE not in new_df.columns:
-            new_df[CONFIDENCE] = 0.0  # np.NaN
-            nan_df = pd.DataFrame(columns=new_df.columns)
-        else:
-            new_df = df[~df[CONFIDENCE].isna()]
-            nan_df = df[df[CONFIDENCE].isna()]
-    else:
+    if df is None:
         ValueError("DataFrame cannot be empty to 'assign_default_confidence'.")
+    new_df = df.copy()
+    if CONFIDENCE not in new_df.columns:
+        new_df[CONFIDENCE] = 0.0  # np.NaN
+        nan_df = pd.DataFrame(columns=new_df.columns)
+    else:
+        new_df = df[~df[CONFIDENCE].isna()]
+        nan_df = df[df[CONFIDENCE].isna()]
     return new_df, nan_df
 
 
@@ -643,21 +635,6 @@ PREDICATE_RELATED_MATCH = 5
 # * ########################################
 
 RDF_FORMATS = {"ttl", "turtle", "nt", "xml"}
-
-
-def sha256sum(path: str) -> str:
-    """Calculate the SHA256 hash over the bytes in a file.
-
-    :param path: Filename
-    :return: Hashed value
-    """
-    h = hashlib.sha256()
-    b = bytearray(128 * 1024)
-    mv = memoryview(b)
-    with open(path, "rb", buffering=0) as file:
-        for n in iter(lambda: file.readinto(mv), 0):  # type: ignore
-            h.update(mv[:n])
-    return h.hexdigest()
 
 
 def merge_msdf(
@@ -904,51 +881,6 @@ def get_file_extension(file: Union[str, Path, TextIO]) -> str:
     return "tsv"
 
 
-@deprecated(details="Use pandas.read_csv() instead.")
-def read_csv(
-    filename: Union[str, Path, TextIO], comment: str = "#", sep: str = ","
-) -> pd.DataFrame:
-    """Read a CSV that contains frontmatter commented by a specific character.
-
-    :param filename: Either the file path, a URL, or a file object to read as a TSV
-        with frontmatter
-    :param comment: The comment character used for the frontmatter. This isn't the
-        same as the comment keyword in :func:`pandas.read_csv` because it only
-        works on the first charcter in the line
-    :param sep: The separator for the TSV file
-    :returns: A pandas dataframe
-    """
-    if isinstance(filename, TextIO):
-        return pd.read_csv(filename, sep=sep)
-    if isinstance(filename, Path) or not validators.url(filename):
-        with open(filename, "r") as f:
-            lines = "".join([line for line in f if not line.startswith(comment)])
-    else:
-        response = urlopen(filename)
-        lines = "".join(
-            [
-                line.decode("utf-8")
-                for line in response
-                if not line.decode("utf-8").startswith(comment)
-            ]
-        )
-    try:
-        df = pd.read_csv(StringIO(lines), sep=sep, low_memory=False)
-    except EmptyDataError as e:
-        logging.warning(f"Seems like the dataframe is empty: {e}")
-        df = pd.DataFrame(
-            columns=[
-                SUBJECT_ID,
-                SUBJECT_LABEL,
-                PREDICATE_ID,
-                OBJECT_ID,
-                MAPPING_JUSTIFICATION,
-            ]
-        )
-
-    return df
-
-
 def read_metadata(filename: str) -> Metadata:
     """Read a metadata file (yaml) that is supplied separately from a TSV."""
     prefix_map = {}
@@ -957,26 +889,6 @@ def read_metadata(filename: str) -> Metadata:
     if PREFIX_MAP_KEY in metadata:
         prefix_map = metadata.pop(PREFIX_MAP_KEY)
     return Metadata(prefix_map=prefix_map, metadata=metadata)
-
-
-@deprecated(details="Use pandas.read_csv() instead.")
-def read_pandas(file: Union[str, Path, TextIO], sep: Optional[str] = None) -> pd.DataFrame:
-    """Read a tabular data file by wrapping func:`pd.read_csv` to handles comment lines correctly.
-
-    :param file: The file to read. If no separator is given, this file should be named.
-    :param sep: File separator for pandas
-    :return: A pandas dataframe
-    """
-    if sep is None:
-        if isinstance(file, Path) or isinstance(file, str):
-            extension = get_file_extension(file)
-            if extension == "tsv":
-                sep = "\t"
-            elif extension == "csv":
-                sep = ","
-            logging.warning(f"Could not guess file extension for {file}")
-    df = read_csv(file, comment="#", sep=sep).fillna("")
-    return sort_df_rows_columns(df)
 
 
 def extract_global_metadata(msdoc: MappingSetDocument) -> Dict[str, PrefixMap]:

--- a/src/sssom/writers.py
+++ b/src/sssom/writers.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, Dict, List, Optional, TextIO, Tuple, Union
 
 import pandas as pd
 import yaml
-from deprecation import deprecated
 from jsonasobj2 import JsonObj
 from linkml_runtime.dumpers import JSONDumper, rdflib_dumper
 from linkml_runtime.utils.schemaview import SchemaView
@@ -153,26 +152,6 @@ def write_ontoportal_json(
 
 # Converters
 # Converters convert a mappingsetdataframe to an object of the supportes types (json, pandas dataframe)
-
-
-@deprecated(
-    details="Use df variable of 'MappingSetDataFrame' instead (msdf.df).",
-)
-def to_dataframe(msdf: MappingSetDataFrame) -> pd.DataFrame:
-    """Convert a mapping set dataframe to a dataframe."""
-    data = []
-    doc = to_mapping_set_document(msdf)
-    if doc.mapping_set.mappings is None:
-        raise TypeError
-    for mapping in doc.mapping_set.mappings:
-        mdict = mapping.__dict__
-        m = {}
-        for key in mdict:
-            if mdict[key]:
-                m[key] = mdict[key]
-        data.append(m)
-    df = pd.DataFrame(data=data)
-    return df
 
 
 def to_owl_graph(msdf: MappingSetDataFrame) -> Graph:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,8 @@
 import os
 import subprocess  # noqa
 import unittest
-from typing import Mapping
+from pathlib import Path
+from typing import Any, Mapping, Optional, cast
 
 from click.testing import CliRunner, Result
 
@@ -83,12 +84,12 @@ class SSSOMCLITestSuite(unittest.TestCase):
 
         self.assertTrue(len(test_cases) >= 2)
 
-    def run_successful(self, result: Result, test_case: SSSOMTestCase) -> None:
+    def run_successful(self, result: Result, obj: Any) -> None:
         """Check the test result is successful."""
         self.assertEqual(
             result.exit_code,
             0,
-            f"{test_case} did not perform as expected: {result.exception}",
+            f"{obj} did not perform as expected: {result.exception}",
         )
 
     def run_convert(self, runner: CliRunner, test_case: SSSOMTestCase) -> Result:
@@ -183,12 +184,16 @@ class SSSOMCLITestSuite(unittest.TestCase):
     def run_partition(self, runner: CliRunner, test_cases: Mapping[str, SSSOMTestCase]) -> Result:
         """Run the partition test."""
         params = []
-        primary_test_case = None
+        primary_test_case: Optional[SSSOMTestCase] = None
         for t in test_cases.values():
             if not primary_test_case:
                 primary_test_case = t
             params.append(t.filepath)
-        params.extend(["--output-directory", test_out_dir.as_posix()])
+        primary_test_case = cast(SSSOMTestCase, primary_test_case)
+        name = Path(primary_test_case.filepath).stem
+        directory = test_out_dir.joinpath(name)
+        directory.mkdir(exist_ok=True, parents=True)
+        params.extend(["--output-directory", directory.as_posix()])
         result = runner.invoke(partition, params)
         self.run_successful(result, primary_test_case)
         return result
@@ -351,15 +356,15 @@ class SSSOMCLITestSuite(unittest.TestCase):
         self.run_successful(result, test_case)
         return result
 
-    def test_convert_cli(self) -> Result:
+    @unittest.skip("this test doesn't actually test anything, just runs help")
+    def test_convert_cli(self):
         """Test conversion of SSSOM tsv to OWL format when multivalued metadata items are present."""
         test_sssom = data_dir / "test_inject_metadata_msdf.tsv"
-        command = [
+        args = [
             "sssom",
             "convert",
             test_sssom,
             "--output-format",
             "owl",
         ]
-        result = subprocess.run(command, shell=True)  # noqa
-        self.assertEqual(result.returncode, 0)
+        result = subprocess.check_output(args, shell=True)  # noqa

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -88,11 +88,12 @@ class SSSOMReadWriteTestSuite(unittest.TestCase):
         jsonob = to_ontoportal_json(msdf)
         self.assertEqual(len(jsonob), test.ct_data_frame_rows)
         first_ob: Dict = jsonob[0]
-        self.assertTrue("classes" in first_ob)
-        self.assertTrue(len(first_ob.get("classes")) == 2)
-        self.assertTrue("relation" in first_ob)
-        self.assertIsInstance(first_ob.get("relation"), list)
-        self.assertGreater(len(first_ob.get("relation")), 0)
+        self.assertIn("classes", first_ob)
+        self.assertIsInstance(first_ob["classes"], list)
+        self.assertEqual(2, len(first_ob["classes"]))
+        self.assertIn("relation", first_ob)
+        self.assertIsInstance(first_ob["relation"], list)
+        self.assertGreater(len(first_ob["relation"]), 0)
 
     def _test_to_rdf_graph(self, mdoc, test):
         msdf = to_mapping_set_dataframe(mdoc)
@@ -173,9 +174,11 @@ class SSSOMReadWriteTestSuite(unittest.TestCase):
             f"JSON document has less elements than the orginal one for {test.filename}. Json: {json.dumps(json_dict)}",
         )
 
+        self.assertIsNotNone(msdf.df)
+        self.assertIsInstance(json_dict["mappings"], list)
         self.assertEqual(
             len(json_dict["mappings"]),
-            len(msdf.df),
+            len(msdf.df.index),  # type:ignore
             f"JSON document has less mappings than the orginal ({test.filename}). Json: {json.dumps(json_dict)}",
         )
 

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -1,9 +1,8 @@
 """Tests for SSSOM writers."""
+
 import json
 import os
 import unittest
-
-from jsonasobj2 import JsonObj
 
 from sssom.parsers import parse_sssom_json, parse_sssom_rdf, parse_sssom_table
 from sssom.writers import (
@@ -75,7 +74,7 @@ class TestWrite(unittest.TestCase):
             write_fhir_json(self.msdf, file)
         # todo: @Joe: after implementing reader/importer, change this to `msdf = parse_sssom_fhir_json()`
         with open(path, "r") as file:
-            d: JsonObj = json.load(file)
+            d = json.load(file)
         # todo: @Joe: What else is worth checking?
         self.assertEqual(
             len(d["group"][0]["element"]),
@@ -88,9 +87,6 @@ class TestWrite(unittest.TestCase):
         tmp_file = os.path.join(test_out_dir, "test_write_sssom_owl.owl")
         with open(tmp_file, "w") as file:
             write_owl(self.msdf, file)
-        # FIXME this test doesn't test anything
-        # TODO implement "read_owl" function
-        self.assertEqual(1, 1)
 
     def test_write_sssom_ontoportal_json(self):
         """Test writing as ontoportal JSON."""
@@ -99,7 +95,7 @@ class TestWrite(unittest.TestCase):
             write_ontoportal_json(self.msdf, file)
 
         with open(path, "r") as file:
-            d: list = json.load(file)
+            d = json.load(file)
 
         self.assertEqual(
             len(d),

--- a/tox.ini
+++ b/tox.ini
@@ -87,14 +87,13 @@ ignore =
     S310 # TODO remove this later and switch to using requests
     B018 # This is 'useless' statements which are new atm.
 exclude =
-    src/sssom/sssom_datamodel.py
     src/sssom/cliquesummary.py
 
 
 [testenv:mypy]
 deps = mypy
 skip_install = true
-commands = mypy --install-types --non-interactive --ignore-missing-imports --implicit-optional src/sssom
+commands = mypy --install-types --non-interactive --ignore-missing-imports --implicit-optional src/sssom tests/
 description = Run the mypy tool to check static typing on the project.
 
 [testenv:docstr-coverage]


### PR DESCRIPTION
This PR does a second round of fall cleaning
- Remove more deprecated code
- Invert type guards to reduce code complexity
- Turn on type checking for tests
  - fix typing issues in tests
- Identify that `test_convert_cli` is doing nothing