### PR TITLE
Explicitly use Python engine for pandas

### DIFF
--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -144,7 +144,7 @@ def _read_pandas_and_metadata(input: io.StringIO, sep: str = None):
     table_stream, metadata_stream = _separate_metadata_and_table_from_stream(input)
 
     try:
-        df = pd.read_csv(table_stream, sep=sep, dtype=str)
+        df = pd.read_csv(table_stream, sep=sep, dtype=str, engine="python")
         df.fillna("", inplace=True)
     except EmptyDataError as e:
         logging.warning(f"Seems like the dataframe is empty: {e}")


### PR DESCRIPTION
Pandas was giving the following warning:

```
/Users/cthoyt/dev/sssom-py/src/sssom/parsers.py:147: ParserWarning: Falling back to the 'python' engine because the 'c' engine does not support sep=None with delim_whitespace=False; you can avoid this warning by specifying engine='python'.
  df = pd.read_csv(table_stream, sep=sep, dtype=str)
```

This PR explicitly specifies the engine to be "python" as suggested.
Another alternative would be to set the separator to tab by default, since I don't think we allow SSSOM in CSV (or at least we shouldn't :p)

This PR also deletes another superfluous `parse()` function that just wraps `pandas.read_csv()`
