### PR TITLE
Standardize MSDF

### DIFF
--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -109,6 +109,39 @@ class MappingSetDataFrame:
         """Clean up the context."""
         self.converter = curies.chain([_get_built_in_prefix_map(), self.converter])
 
+    def _standardize_curie_or_iri(self, curie_or_iri: str) -> str:
+        """Standardize a CURIE or IRI, returning the original if not possible.
+
+        :param curie_or_iri: Either a string representing a CURIE or an IRI
+        :returns:
+            - If the string represents an IRI, tries to standardize it. If not possible, returns the original value
+            - If the string represents a CURIE, tries to standardize it. If not possible, returns the original value
+            - Otherwise, return the original value
+        """
+        if is_iri(curie_or_iri):
+            return self.converter.standardize_uri(curie_or_iri) or curie_or_iri
+        if is_curie(curie_or_iri):
+            return self.converter.standardize_curie(curie_or_iri) or curie_or_iri
+        return curie_or_iri
+
+    def standardize(self) -> None:
+        """Standardize this MSDF's dataframe and metadata with respect to its converter."""
+        self._standardize_metadata()
+        self._standardize_df()
+
+    def _standardize_df(self) -> None:
+        """Standardize this MSDF's dataframe with respect to its converter."""
+        for column, values in _get_sssom_schema_object().dict["slots"].items():
+            if values["range"] != "EntityReference":
+                continue
+            if column not in self.df.columns:
+                continue
+            self.df[column] = self.df[column].map(self._standardize_curie_or_iri)
+
+    def _standardize_metadata(self) -> None:
+        """Standardize this MSDF's metadata with respect to its converter."""
+        raise NotImplementedError
+
     def merge(self, *msdfs: "MappingSetDataFrame", inplace: bool = True) -> "MappingSetDataFrame":
         """Merge two MappingSetDataframes.
 
@@ -1116,22 +1149,8 @@ def reconcile_prefix_and_data(
     converter = msdf.converter
     converter = curies.remap_curie_prefixes(converter, prefix_reconciliation["prefix_synonyms"])
     converter = curies.rewire(converter, prefix_reconciliation["prefix_expansion_reconciliation"])
-
-    # TODO make this standardization code directly part of msdf after
-    #  switching to native converter
-    def _upgrade(curie_or_iri: str) -> str:
-        if not is_iri(curie_or_iri) and is_curie(curie_or_iri):
-            return converter.standardize_curie(curie_or_iri) or curie_or_iri
-        return curie_or_iri
-
-    for column, values in _get_sssom_schema_object().dict["slots"].items():
-        if values["range"] != "EntityReference":
-            continue
-        if column not in msdf.df.columns:
-            continue
-        msdf.df[column] = msdf.df[column].map(_upgrade)
-
     msdf.converter = converter
+    msdf.standardize()
     return msdf
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,9 @@
 
 import unittest
 
+import pandas as pd
 import yaml
-from curies import Converter
+from curies import Converter, Record
 
 from sssom.constants import OBJECT_ID, SUBJECT_ID
 from sssom.context import SSSOM_BUILT_IN_PREFIXES
@@ -193,4 +194,23 @@ class TestUtils(unittest.TestCase):
                 "orcid",
             }.union(SSSOM_BUILT_IN_PREFIXES),
             prefixes,
+        )
+
+    def test_standardize_df(self):
+        """Test standardizing a dataframe."""
+        rows = [("a:1", "b:2", "c:3")]
+        columns = ["subject_id", "predicate_id", "object_id"]
+        df = pd.DataFrame(rows, columns=columns)
+        converter = Converter(
+            [
+                Record(prefix="new.a", prefix_synonyms=["a"], uri_prefix="https://example.org/a/"),
+                Record(prefix="new.b", prefix_synonyms=["b"], uri_prefix="https://example.org/b/"),
+                Record(prefix="new.c", prefix_synonyms=["c"], uri_prefix="https://example.org/c/"),
+            ]
+        )
+        msdf = MappingSetDataFrame(df=df, converter=converter)
+        msdf._standardize_df()
+        self.assertEqual(
+            ("new.a:1", "new.b:2", "new.c:3"),
+            tuple(df.iloc[0]),
         )


### PR DESCRIPTION
The functionality for standardizing a MSDF was already built in to the `reconcile_prefix_and_data()` function. This PR does the following:

1. Makes this a re-usable instance-level function of an MSDF
2. Adds similar functionality for standardizing the metadata of the MSDF
3. Add explicit unit tests!