### PR TITLE
Make MSDF with default converter

### DIFF
--- a/src/sssom/__init__.py
+++ b/src/sssom/__init__.py
@@ -10,6 +10,7 @@ except importlib_metadata.PackageNotFoundError:
 from sssom_schema import Mapping, MappingSet, slots  # noqa:401
 
 from sssom.util import (  # noqa:401
+    MappingSetDataFrame,
     collapse,
     compare_dataframes,
     dataframe_to_ptable,

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -59,7 +59,7 @@ from .constants import (
     UNKNOWN_IRI,
     SSSOMSchemaView,
 )
-from .context import SSSOM_BUILT_IN_PREFIXES, _get_built_in_prefix_map
+from .context import SSSOM_BUILT_IN_PREFIXES, _get_built_in_prefix_map, get_converter
 from .sssom_document import MappingSetDocument
 from .typehints import MetadataType, PrefixMap, get_default_metadata
 
@@ -82,7 +82,7 @@ class MappingSetDataFrame:
     """A collection of mappings represented as a DataFrame, together with additional metadata."""
 
     df: pd.DataFrame
-    converter: Converter
+    converter: Converter = field(default_factory=get_converter)
     metadata: MetadataType = field(default_factory=get_default_metadata)
 
     @property


### PR DESCRIPTION
This makes it possible to create a MSDF with only a pandas dataframe

```python
from sssom import MappingSetDataFrame

df = ... # some pandas dataframe
msdf = MappingSetDataFrame(df=df)

# align to default converter
msdf.standardize_references() 
```