### PR TITLE
Rename type hint for Converters

### DIFF
--- a/src/sssom/context.py
+++ b/src/sssom/context.py
@@ -2,7 +2,7 @@
 
 import json
 from functools import lru_cache
-from typing import Union
+from typing import Mapping, Union
 
 import curies
 import pkg_resources
@@ -10,7 +10,13 @@ from curies import Converter
 from rdflib.namespace import is_ncname
 
 from .constants import EXTENDED_PREFIX_MAP
-from .typehints import PrefixMap
+
+__all__ = [
+    "SSSOM_BUILT_IN_PREFIXES",
+    "get_converter",
+    "ConverterHint",
+    "ensure_converter",
+]
 
 SSSOM_BUILT_IN_PREFIXES = ("sssom", "owl", "rdf", "rdfs", "skos", "semapv")
 SSSOM_CONTEXT = pkg_resources.resource_filename(
@@ -49,10 +55,16 @@ def _get_built_in_prefix_map() -> Converter:
     return Converter.from_prefix_map(prefix_map)
 
 
-HINT = Union[None, PrefixMap, Converter]
+#: A type hint that specifies a place where one of three options can be given:
+#:   1. a legacy prefix mapping dictionary can be given, which will get upgraded
+#:      into a :class:`curies.Converter`,
+#:   2. a converter can be given, which might get modified. In SSSOM-py, this typically
+#:      means chaining behind the "default" prefix map
+#:   3. None, which means a default converter is loaded
+ConverterHint = Union[None, Mapping[str, str], Converter]
 
 
-def ensure_converter(prefix_map: HINT = None, *, use_defaults: bool = True) -> Converter:
+def ensure_converter(prefix_map: ConverterHint = None, *, use_defaults: bool = True) -> Converter:
     """Ensure a converter is available.
 
     :param prefix_map: One of the following:

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -54,7 +54,7 @@ from sssom.constants import (
     SSSOMSchemaView,
 )
 
-from .context import HINT, _get_built_in_prefix_map, ensure_converter
+from .context import ConverterHint, _get_built_in_prefix_map, ensure_converter
 from .sssom_document import MappingSetDocument
 from .typehints import Metadata, MetadataType, generate_mapping_set_id, get_default_metadata
 from .util import (
@@ -184,7 +184,7 @@ def _get_seperator_symbol_from_file_path(file):
 
 def parse_sssom_table(
     file_path: Union[str, Path, TextIO],
-    prefix_map: HINT = None,
+    prefix_map: ConverterHint = None,
     meta: Optional[MetadataType] = None,
     **kwargs,
 ) -> MappingSetDataFrame:
@@ -229,7 +229,7 @@ def parse_sssom_table(
 
 def parse_sssom_rdf(
     file_path: str,
-    prefix_map: HINT = None,
+    prefix_map: ConverterHint = None,
     meta: Optional[MetadataType] = None,
     serialisation=SSSOM_DEFAULT_RDF_SERIALISATION,
     **kwargs
@@ -250,7 +250,7 @@ def parse_sssom_rdf(
 
 def parse_sssom_json(
     file_path: str,
-    prefix_map: HINT = None,
+    prefix_map: ConverterHint = None,
     meta: Optional[MetadataType] = None,
     **kwargs
     # mapping_predicates: Optional[List[str]] = None,
@@ -273,7 +273,7 @@ def parse_sssom_json(
 
 def parse_obographs_json(
     file_path: str,
-    prefix_map: HINT = None,
+    prefix_map: ConverterHint = None,
     meta: Optional[MetadataType] = None,
     mapping_predicates: Optional[List[str]] = None,
 ) -> MappingSetDataFrame:
@@ -301,7 +301,7 @@ def parse_obographs_json(
 
 
 def _get_prefix_map_and_metadata(
-    prefix_map: HINT = None, meta: Optional[MetadataType] = None
+    prefix_map: ConverterHint = None, meta: Optional[MetadataType] = None
 ) -> Metadata:
     if prefix_map and meta and PREFIX_MAP_KEY in meta:
         logging.info(
@@ -363,7 +363,7 @@ def _get_mdict_ms_and_bad_attrs(row: pd.Series, bad_attrs: Counter) -> Tuple[dic
 
 def parse_alignment_xml(
     file_path: str,
-    prefix_map: HINT = None,
+    prefix_map: ConverterHint = None,
     meta: Optional[MetadataType] = None,
     mapping_predicates: Optional[List[str]] = None,
 ) -> MappingSetDataFrame:
@@ -387,7 +387,7 @@ def parse_alignment_xml(
 
 def from_sssom_dataframe(
     df: pd.DataFrame,
-    prefix_map: HINT = None,
+    prefix_map: ConverterHint = None,
     meta: Optional[MetadataType] = None,
 ) -> MappingSetDataFrame:
     """Convert a dataframe to a MappingSetDataFrame.
@@ -424,7 +424,7 @@ def from_sssom_dataframe(
 
 def from_sssom_rdf(
     g: Graph,
-    prefix_map: HINT = None,
+    prefix_map: ConverterHint = None,
     meta: Optional[MetadataType] = None,
 ) -> MappingSetDataFrame:
     """Convert an SSSOM RDF graph into a SSSOM data table.
@@ -488,7 +488,7 @@ def from_sssom_rdf(
 
 def from_sssom_json(
     jsondoc: Union[str, dict, TextIO],
-    prefix_map: HINT = None,
+    prefix_map: ConverterHint = None,
     meta: Optional[MetadataType] = None,
 ) -> MappingSetDataFrame:
     """Load a mapping set dataframe from a JSON object.
@@ -508,7 +508,7 @@ def from_sssom_json(
 
 def from_alignment_minidom(
     dom: Document,
-    prefix_map: HINT = None,
+    prefix_map: ConverterHint = None,
     meta: Optional[MetadataType] = None,
     mapping_predicates: Optional[List[str]] = None,
 ) -> MappingSetDataFrame:
@@ -570,7 +570,7 @@ def _get_obographs_predicate_id(obographs_predicate: str):
 
 def from_obographs(
     jsondoc: Dict,
-    prefix_map: HINT = None,
+    prefix_map: ConverterHint = None,
     meta: Optional[MetadataType] = None,
     mapping_predicates: Optional[List[str]] = None,
 ) -> MappingSetDataFrame:

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -60,8 +60,8 @@ from .constants import (
     SSSOMSchemaView,
 )
 from .context import (
-    HINT,
     SSSOM_BUILT_IN_PREFIXES,
+    ConverterHint,
     _get_built_in_prefix_map,
     ensure_converter,
     get_converter,
@@ -116,7 +116,7 @@ class MappingSetDataFrame:
         cls,
         mappings: List[SSSOM_Mapping],
         *,
-        converter: HINT = None,
+        converter: ConverterHint = None,
         metadata: Optional[MetadataType] = None,
     ) -> "MappingSetDataFrame":
         """Instantiate from a list of mappings, mapping set metadata, and an optional converter."""
@@ -132,7 +132,7 @@ class MappingSetDataFrame:
 
     @classmethod
     def from_mapping_set(
-        cls, mapping_set: MappingSet, *, converter: HINT = None
+        cls, mapping_set: MappingSet, *, converter: ConverterHint = None
     ) -> "MappingSetDataFrame":
         """Instantiate from a mapping set and an optional converter.
 


### PR DESCRIPTION
This PR renames `HINT` to `ConverterHint` and adds additional documentation. It also relaxes the typing on prefix maps from `Dict[str,str]` to `Mapping[str,str]`