### PR TITLE
Remove duplicate definition of schema constant

### DIFF
--- a/src/sssom/io.py
+++ b/src/sssom/io.py
@@ -15,6 +15,7 @@ from pansql import sqldf
 from sssom.validators import validate
 
 from .constants import (
+    CURIE_MAP,
     DEFAULT_LICENSE,
     PREFIX_MAP_MODE_MERGED,
     PREFIX_MAP_MODE_METADATA_ONLY,
@@ -25,7 +26,6 @@ from .context import get_converter
 from .parsers import get_parsing_function, parse_sssom_table, split_dataframe
 from .typehints import Metadata, generate_mapping_set_id
 from .util import (
-    PREFIX_MAP_KEY,
     MappingSetDataFrame,
     are_params_slots,
     augment_metadata,
@@ -154,8 +154,8 @@ def get_metadata_and_prefix_map(
         metadata["license"] = DEFAULT_LICENSE
         logging.warning(f"No License provided, using {DEFAULT_LICENSE}")
 
-    if PREFIX_MAP_KEY in metadata:
-        prefix_map = metadata.pop(PREFIX_MAP_KEY)
+    if CURIE_MAP in metadata:
+        prefix_map = metadata.pop(CURIE_MAP)
     else:
         prefix_map = {}
     converter = Converter.from_prefix_map(prefix_map)

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -58,7 +58,6 @@ from .context import HINT, _get_built_in_prefix_map, ensure_converter
 from .sssom_document import MappingSetDocument
 from .typehints import Metadata, MetadataType, generate_mapping_set_id, get_default_metadata
 from .util import (
-    PREFIX_MAP_KEY,
     SSSOM_DEFAULT_RDF_SERIALISATION,
     URI_SSSOM_MAPPINGS,
     MappingSetDataFrame,
@@ -303,12 +302,12 @@ def parse_obographs_json(
 def _get_prefix_map_and_metadata(
     prefix_map: HINT = None, meta: Optional[MetadataType] = None
 ) -> Metadata:
-    if prefix_map and meta and PREFIX_MAP_KEY in meta:
+    if prefix_map and meta and CURIE_MAP in meta:
         logging.info(
             "Prefix map provided as parameter, but SSSOM file provides its own prefix map. "
             "Prefix map provided externally is disregarded in favour of the prefix map in the SSSOM file."
         )
-        prefix_map = meta[PREFIX_MAP_KEY]
+        prefix_map = meta[CURIE_MAP]
     converter = ensure_converter(prefix_map)
     if meta is None:
         meta = Metadata.default().metadata
@@ -771,7 +770,7 @@ def _set_metadata_in_mapping_set(
         logging.info("Tried setting metadata but none provided.")
     else:
         for k, v in metadata.items():
-            if k != PREFIX_MAP_KEY:
+            if k != CURIE_MAP:
                 mapping_set[k] = v
 
 
@@ -827,7 +826,7 @@ def to_mapping_set_document(msdf: MappingSetDataFrame) -> MappingSetDocument:
         logging.warning(f"No attr for {k} [{v} instances]")
     ms.mappings = mlist  # type: ignore
     for k, v in msdf.metadata.items():
-        if k != PREFIX_MAP_KEY:
+        if k != CURIE_MAP:
             ms[k] = _address_multivalued_slot(k, v)
     return MappingSetDocument(mapping_set=ms, converter=msdf.converter)
 

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -27,6 +27,7 @@ from .constants import (
     COLUMN_INVERT_DICTIONARY,
     COMMENT,
     CONFIDENCE,
+    CURIE_MAP,
     MAPPING_JUSTIFICATION,
     MAPPING_SET_ID,
     MAPPING_SET_SOURCE,
@@ -70,9 +71,6 @@ from .sssom_document import MappingSetDocument
 from .typehints import MetadataType, PrefixMap, get_default_metadata
 
 logging = _logging.getLogger(__name__)
-
-#: The key that's used in the YAML section of an SSSOM file
-PREFIX_MAP_KEY = "curie_map"
 
 SSSOM_DEFAULT_RDF_SERIALISATION = "turtle"
 
@@ -152,7 +150,7 @@ class MappingSetDataFrame:
 
         df = pd.DataFrame(get_dict_from_mapping(mapping) for mapping in doc.mapping_set.mappings)
         meta = extract_global_metadata(doc)
-        meta.pop(PREFIX_MAP_KEY, None)
+        meta.pop(CURIE_MAP, None)
 
         # remove columns where all values are blank.
         df.replace("", np.nan, inplace=True)
@@ -1019,7 +1017,7 @@ def extract_global_metadata(msdoc: MappingSetDocument) -> Dict[str, PrefixMap]:
     :return: Dictionary containing metadata
     """
     # TODO mark as private
-    meta = {PREFIX_MAP_KEY: msdoc.prefix_map}
+    meta = {CURIE_MAP: msdoc.prefix_map}
     ms_meta = msdoc.mapping_set
     for key in [
         slot

--- a/src/sssom/writers.py
+++ b/src/sssom/writers.py
@@ -16,10 +16,9 @@ from sssom_schema import slots
 
 from sssom.validators import check_all_prefixes_in_curie_map
 
-from .constants import SCHEMA_YAML, SSSOM_URI_PREFIX
+from .constants import CURIE_MAP, SCHEMA_YAML, SSSOM_URI_PREFIX
 from .parsers import to_mapping_set_document
 from .util import (
-    PREFIX_MAP_KEY,
     RDF_FORMATS,
     SSSOM_DEFAULT_RDF_SERIALISATION,
     URI_SSSOM_MAPPINGS,
@@ -56,7 +55,7 @@ def write_table(
 
     meta: Dict[str, Any] = {}
     meta.update(msdf.metadata)
-    meta[PREFIX_MAP_KEY] = msdf.converter.bimap
+    meta[CURIE_MAP] = msdf.converter.bimap
     if sort:
         msdf.df = sort_df_rows_columns(msdf.df)
     lines = yaml.safe_dump(meta).split("\n")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -5,7 +5,7 @@ from typing import Any, List, Mapping
 
 import yaml
 
-from sssom.util import PREFIX_MAP_KEY
+from sssom.constants import CURIE_MAP
 from tests.constants import cwd, data_dir, test_out_dir
 
 test_validate_dir = os.path.join(cwd, "validate_data")
@@ -41,7 +41,7 @@ class SSSOMTestCase:
         self.inputformat = config.get("inputformat")
         self.ct_graph_queries_owl = self._query_tuple(config, "ct_graph_queries_owl", queries)
         self.ct_graph_queries_rdf = self._query_tuple(config, "ct_graph_queries_rdf", queries)
-        self.prefix_map = config.get(PREFIX_MAP_KEY)
+        self.prefix_map = config.get(CURIE_MAP)
 
     @staticmethod
     def _query_tuple(config, tuple_id, queries_dict):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -29,7 +29,7 @@ from sssom.parsers import (
     parse_sssom_table,
 )
 from sssom.typehints import Metadata
-from sssom.util import PREFIX_MAP_KEY, MappingSetDataFrame, sort_df_rows_columns
+from sssom.util import MappingSetDataFrame, sort_df_rows_columns
 from sssom.writers import write_table
 from tests.test_data import data_dir as test_data_dir
 from tests.test_data import test_out_dir
@@ -65,7 +65,7 @@ class TestParse(unittest.TestCase):
 
         with open(f"{test_data_dir}/basic-meta-external.yml") as file:
             df_meta = yaml.safe_load(file)
-            self.df_prefix_map = df_meta.pop(PREFIX_MAP_KEY)
+            self.df_prefix_map = df_meta.pop(CURIE_MAP)
             self.df_meta = df_meta
 
         self.alignmentxml_file = f"{test_data_dir}/oaei-ordo-hp.rdf"


### PR DESCRIPTION
`sssom.constants.CURIE_MAP` was redefined as `sssom.util.PREFIX_MAP`. This PR switches all of the second to use the first.