### PR TITLE
Refactor `_extract_global_metadata()`

### DIFF
--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -149,8 +149,7 @@ class MappingSetDataFrame:
             return cls(df=pd.DataFrame(), converter=doc.converter)
 
         df = pd.DataFrame(get_dict_from_mapping(mapping) for mapping in doc.mapping_set.mappings)
-        meta = extract_global_metadata(doc)
-        meta.pop(CURIE_MAP, None)
+        meta = _extract_global_metadata(doc)
 
         # remove columns where all values are blank.
         df.replace("", np.nan, inplace=True)
@@ -1010,14 +1009,13 @@ def get_file_extension(file: Union[str, Path, TextIO]) -> str:
     return "tsv"
 
 
-def extract_global_metadata(msdoc: MappingSetDocument) -> Dict[str, PrefixMap]:
+def _extract_global_metadata(msdoc: MappingSetDocument) -> MetadataType:
     """Extract metadata.
 
     :param msdoc: MappingSetDocument object
     :return: Dictionary containing metadata
     """
-    # TODO mark as private
-    meta = {CURIE_MAP: msdoc.prefix_map}
+    meta = {}
     ms_meta = msdoc.mapping_set
     for key in [
         slot

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -27,7 +27,6 @@ from .constants import (
     COLUMN_INVERT_DICTIONARY,
     COMMENT,
     CONFIDENCE,
-    CURIE_MAP,
     MAPPING_JUSTIFICATION,
     MAPPING_SET_ID,
     MAPPING_SET_SOURCE,
@@ -68,7 +67,7 @@ from .context import (
     get_converter,
 )
 from .sssom_document import MappingSetDocument
-from .typehints import MetadataType, PrefixMap, get_default_metadata
+from .typehints import MetadataType, get_default_metadata
 
 logging = _logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR does 3 things:

1. Makes `_extract_global_metadata()` private
2. Removes the part in the definition where it adds a `CURIE_MAP` since this is subsequently popped off
3. Updates the return type to be more accurate