### PR TITLE
Directly unpack metadata tuple

### DIFF
--- a/src/sssom/io.py
+++ b/src/sssom/io.py
@@ -80,27 +80,27 @@ def parse_file(
     :param mapping_predicate_filter: Optional list of mapping predicates or filepath containing the same.
     """
     raise_for_bad_path(input_path)
-    metadata = get_metadata_and_prefix_map(
+    converter, meta = get_metadata_and_prefix_map(
         metadata_path=metadata_path, prefix_map_mode=prefix_map_mode
     )
     parse_func = get_parsing_function(input_format, input_path)
     mapping_predicates = None
     # Get list of predicates of interest.
     if mapping_predicate_filter:
-        mapping_predicates = get_list_of_predicate_iri(mapping_predicate_filter, metadata.converter)
+        mapping_predicates = get_list_of_predicate_iri(mapping_predicate_filter, converter)
 
     # if mapping_predicates:
     doc = parse_func(
         input_path,
-        prefix_map=metadata.prefix_map,
-        meta=metadata.metadata,
+        prefix_map=converter,
+        meta=meta,
         mapping_predicates=mapping_predicates,
     )
     # else:
     #     doc = parse_func(
     #         input_path,
-    #         prefix_map=metadata.prefix_map,
-    #         meta=metadata.metadata,
+    #         prefix_map=converter,
+    #         meta=meta,
     #     )
     if clean_prefixes:
         # We do this because we got a lot of prefixes from the default SSSOM prefixes!

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -236,11 +236,11 @@ def parse_sssom_rdf(
 ) -> MappingSetDataFrame:
     """Parse a TSV to a :class:`MappingSetDocument` to a :class:`MappingSetDataFrame`."""
     raise_for_bad_path(file_path)
-    metadata = _get_prefix_map_and_metadata(prefix_map=prefix_map, meta=meta)
+    converter, meta = _get_prefix_map_and_metadata(prefix_map=prefix_map, meta=meta)
 
     g = Graph()
     g.parse(file_path, format=serialisation)
-    msdf = from_sssom_rdf(g, prefix_map=metadata.prefix_map, meta=metadata.metadata)
+    msdf = from_sssom_rdf(g, prefix_map=converter, meta=meta)
     # df: pd.DataFrame = msdf.df
     # if mapping_predicates and not df.empty():
     #     msdf.df = df[df["predicate_id"].isin(mapping_predicates)]
@@ -256,11 +256,11 @@ def parse_sssom_json(
 ) -> MappingSetDataFrame:
     """Parse a TSV to a :class:`MappingSetDocument` to a  :class`MappingSetDataFrame`."""
     raise_for_bad_path(file_path)
-    metadata = _get_prefix_map_and_metadata(prefix_map=prefix_map, meta=meta)
+    converter, meta = _get_prefix_map_and_metadata(prefix_map=prefix_map, meta=meta)
 
     with open(file_path) as json_file:
         jsondoc = json.load(json_file)
-    msdf = from_sssom_json(jsondoc=jsondoc, prefix_map=metadata.prefix_map, meta=metadata.metadata)
+    msdf = from_sssom_json(jsondoc=jsondoc, prefix_map=converter, meta=meta)
     # df: pd.DataFrame = msdf.df
     # if mapping_predicates and not df.empty():
     #     msdf.df = df[df["predicate_id"].isin(mapping_predicates)]
@@ -286,15 +286,15 @@ def parse_obographs_json(
     """
     raise_for_bad_path(file_path)
 
-    _xmetadata = _get_prefix_map_and_metadata(prefix_map=prefix_map, meta=meta)
+    converter, meta = _get_prefix_map_and_metadata(prefix_map=prefix_map, meta=meta)
 
     with open(file_path) as json_file:
         jsondoc = json.load(json_file)
 
     return from_obographs(
         jsondoc,
-        prefix_map=_xmetadata.prefix_map,
-        meta=_xmetadata.metadata,
+        prefix_map=converter,
+        meta=meta,
         mapping_predicates=mapping_predicates,
     )
 
@@ -359,13 +359,13 @@ def parse_alignment_xml(
     """Parse a TSV -> MappingSetDocument -> MappingSetDataFrame."""
     raise_for_bad_path(file_path)
 
-    metadata = _get_prefix_map_and_metadata(prefix_map=prefix_map, meta=meta)
+    converter, meta = _get_prefix_map_and_metadata(prefix_map=prefix_map, meta=meta)
     logging.info("Loading from alignment API")
     xmldoc = minidom.parse(file_path)
     msdf = from_alignment_minidom(
         xmldoc,
-        prefix_map=metadata.prefix_map,
-        meta=metadata.metadata,
+        prefix_map=converter,
+        meta=meta,
         mapping_predicates=mapping_predicates,
     )
     return msdf

--- a/src/sssom/typehints.py
+++ b/src/sssom/typehints.py
@@ -27,11 +27,6 @@ class Metadata(NamedTuple):
     converter: Converter
     metadata: MetadataType
 
-    @property
-    def prefix_map(self):
-        """Get the bimap."""
-        return self.converter.bimap
-
     @classmethod
     def default(cls):
         """Get default metadata."""

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -126,8 +126,10 @@ class TestParse(unittest.TestCase):
         with open(path, "w") as file:
             write_table(msdf, file)
         self.assertEqual(
+            # this number went up from 8099 when the curies.Converter was introduced
+            # since it was able to handle CURIE prefix and URI prefix synonyms
+            8488,
             len(msdf.df),
-            8099,
             f"{self.obographs_file} has the wrong number of mappings.",
         )
 


### PR DESCRIPTION
This PR makes it much more direct how the Metadata tuple object is unpacked. Additionally, the need to expose a "prefix_map" is no longer there, so this is removed.