### PR TITLE
Clean up extract_iri functionality

### DIFF
--- a/src/sssom/io.py
+++ b/src/sssom/io.py
@@ -12,6 +12,7 @@ import curies
 import pandas as pd
 import yaml
 from curies import Converter
+from deprecation import deprecated
 from pansql import sqldf
 
 from sssom.validators import validate
@@ -159,6 +160,17 @@ def _merge_converter(converter: Converter, prefix_map_mode: str = None) -> Conve
     if prefix_map_mode == PREFIX_MAP_MODE_MERGED:
         return curies.chain([converter, get_converter()])
     raise ValueError(f"Invalid prefix map mode: {prefix_map_mode}")
+
+
+@deprecated(deprecated_in="0.4.0", details="Use sssom.io.extract_iris() directly")
+def get_list_of_predicate_iri(predicate_filter: Iterable[str], converter: Converter) -> list:
+    """Return a list of IRIs for predicate CURIEs passed.
+
+    :param predicate_filter: CURIE OR list of CURIEs OR file path containing the same.
+    :param converter: Prefix map of mapping set (possibly) containing custom prefix:IRI combination.
+    :return: A list of IRIs.
+    """
+    return extract_iris(predicate_filter, converter)
 
 
 def extract_iris(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ from curies import Converter, Record
 
 from sssom.constants import OBJECT_ID, SUBJECT_ID
 from sssom.context import SSSOM_BUILT_IN_PREFIXES, ensure_converter
-from sssom.io import get_list_of_predicate_iri
+from sssom.io import extract_iris
 from sssom.parsers import parse_sssom_table
 from sssom.util import (
     MappingSetDataFrame,
@@ -33,10 +33,10 @@ class TestIO(unittest.TestCase):
 
     def test_broken_predicate_list(self):
         """Test merging of multiple msdfs."""
-        predicate_filter = ["skos:relatedMatch", f"{data_dir}/predicate_list3.txt"]
+        predicate_filter = ["skos:relatedMatch", [f"{data_dir}/predicate_list3.txt"]]
         prefix_map = {"skos": "http://www.w3.org/2004/02/skos/core#"}
         converter = Converter.from_prefix_map(prefix_map)
-        iri_list = get_list_of_predicate_iri(converter=converter, predicate_filter=predicate_filter)
+        iri_list = extract_iris(predicate_filter, converter=converter)
         self.assertEqual(
             [
                 "http://www.w3.org/2004/02/skos/core#narrowMatch",


### PR DESCRIPTION
This PR doesn't change any existing functionality other than getting rid of a duplicate function and cleaning up the logic for extracting IRIs from a list of strings or file paths.