### PR TITLE
Fix test after EPM update

### DIFF
--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -127,7 +127,7 @@ class TestParse(unittest.TestCase):
         self.assertEqual(
             # this number went up from 8099 when the curies.Converter was introduced
             # since it was able to handle CURIE prefix and URI prefix synonyms
-            8488,
+            8489,
             len(msdf.df),
             f"{self.obographs_file} has the wrong number of mappings.",
         )


### PR DESCRIPTION
The reason for the increase in the count here is that the EPM caught at least 1 more URI prefix during the parsing process