### PR TITLE
Deprecate `get_metadata_and_prefix_map`

### DIFF
--- a/src/sssom/__init__.py
+++ b/src/sssom/__init__.py
@@ -10,7 +10,7 @@ except importlib.metadata.PackageNotFoundError:
 
 from sssom_schema import Mapping, MappingSet, slots  # noqa:401
 
-from sssom.io import _get_metadata_and_prefix_map  # noqa:401
+from sssom.io import get_metadata_and_prefix_map  # noqa:401
 from sssom.sssom_document import MappingSetDocument  # noqa:401
 from sssom.util import (  # noqa:401
     MappingSetDataFrame,

--- a/src/sssom/__init__.py
+++ b/src/sssom/__init__.py
@@ -10,7 +10,7 @@ except importlib.metadata.PackageNotFoundError:
 
 from sssom_schema import Mapping, MappingSet, slots  # noqa:401
 
-from sssom.io import get_metadata_and_prefix_map  # noqa:401
+from sssom.io import _get_metadata_and_prefix_map  # noqa:401
 from sssom.sssom_document import MappingSetDocument  # noqa:401
 from sssom.util import (  # noqa:401
     MappingSetDataFrame,

--- a/src/sssom/io.py
+++ b/src/sssom/io.py
@@ -12,6 +12,7 @@ import curies
 import pandas as pd
 import yaml
 from curies import Converter
+from deprecation import deprecated
 
 from sssom.validators import validate
 

--- a/src/sssom/io.py
+++ b/src/sssom/io.py
@@ -139,9 +139,7 @@ def get_metadata_and_prefix_map(
     metadata_path: Union[None, str, Path] = None, *, prefix_map_mode: Optional[MergeMode] = None
 ) -> Tuple[Converter, MetadataType]:
     """Load metadata and a prefix map in a deprecated way."""
-    return _get_metadata_and_prefix_map(
-        metadata_path=metadata_path, prefix_map_mode=prefix_map_mode
-    )
+    return _get_metadata_and_prefix_map(metadata_path=metadata_path,prefix_map_mode=prefix_map_mode)
 
 
 def _get_metadata_and_prefix_map(

--- a/src/sssom/io.py
+++ b/src/sssom/io.py
@@ -139,7 +139,9 @@ def get_metadata_and_prefix_map(
     metadata_path: Union[None, str, Path] = None, *, prefix_map_mode: Optional[MergeMode] = None
 ) -> Tuple[Converter, MetadataType]:
     """Load metadata and a prefix map in a deprecated way."""
-    return _get_metadata_and_prefix_map(metadata_path=metadata_path,prefix_map_mode=prefix_map_mode)
+    return _get_metadata_and_prefix_map(
+        metadata_path=metadata_path, prefix_map_mode=prefix_map_mode
+    )
 
 
 def _get_metadata_and_prefix_map(

--- a/src/sssom/io.py
+++ b/src/sssom/io.py
@@ -135,9 +135,13 @@ def split_file(input_path: str, output_directory: Union[str, Path]) -> None:
     details="This functionality for loading SSSOM metadata from a YAML file is deprecated from the "
     "public API since it has internal assumptions which are usually not valid for downstream users.",
 )
-def get_metadata_and_prefix_map(*args, **kwargs):
+def get_metadata_and_prefix_map(
+    metadata_path: Union[None, str, Path] = None, *, prefix_map_mode: Optional[MergeMode] = None
+) -> Tuple[Converter, MetadataType]:
     """Load metadata and a prefix map in a deprecated way."""
-    return _get_metadata_and_prefix_map(*args, **kwargs)
+    return _get_metadata_and_prefix_map(
+        metadata_path=metadata_path, prefix_map_mode=prefix_map_mode
+    )
 
 
 def _get_metadata_and_prefix_map(

--- a/src/sssom/io.py
+++ b/src/sssom/io.py
@@ -77,7 +77,7 @@ def parse_file(
     :param mapping_predicate_filter: Optional list of mapping predicates or filepath containing the same.
     """
     raise_for_bad_path(input_path)
-    converter, meta = _get_metadata_and_prefix_map(
+    converter, meta = _get_converter_and_metadata(
         metadata_path=metadata_path, prefix_map_mode=prefix_map_mode
     )
     parse_func = get_parsing_function(input_format, input_path)
@@ -139,12 +139,10 @@ def get_metadata_and_prefix_map(
     metadata_path: Union[None, str, Path] = None, *, prefix_map_mode: Optional[MergeMode] = None
 ) -> Tuple[Converter, MetadataType]:
     """Load metadata and a prefix map in a deprecated way."""
-    return _get_metadata_and_prefix_map(
-        metadata_path=metadata_path, prefix_map_mode=prefix_map_mode
-    )
+    return _get_converter_and_metadata(metadata_path=metadata_path, prefix_map_mode=prefix_map_mode)
 
 
-def _get_metadata_and_prefix_map(
+def _get_converter_and_metadata(
     metadata_path: Union[None, str, Path] = None, *, prefix_map_mode: Optional[MergeMode] = None
 ) -> Tuple[Converter, MetadataType]:
     """

--- a/src/sssom/io.py
+++ b/src/sssom/io.py
@@ -77,7 +77,7 @@ def parse_file(
     :param mapping_predicate_filter: Optional list of mapping predicates or filepath containing the same.
     """
     raise_for_bad_path(input_path)
-    converter, meta = get_metadata_and_prefix_map(
+    converter, meta = _get_metadata_and_prefix_map(
         metadata_path=metadata_path, prefix_map_mode=prefix_map_mode
     )
     parse_func = get_parsing_function(input_format, input_path)
@@ -130,7 +130,17 @@ def split_file(input_path: str, output_directory: Union[str, Path]) -> None:
     write_tables(splitted, output_directory)
 
 
-def get_metadata_and_prefix_map(
+@deprecated(
+    deprecated_in="0.4.3",
+    details="This functionality for loading SSSOM metadata from a YAML file is deprecated from the "
+    "public API since it has internal assumptions which are usually not valid for downstream users.",
+)
+def get_metadata_and_prefix_map(*args, **kwargs):
+    """Load metadata and a prefix map in a deprecated way."""
+    return _get_metadata_and_prefix_map(*args, **kwargs)
+
+
+def _get_metadata_and_prefix_map(
     metadata_path: Union[None, str, Path] = None, *, prefix_map_mode: Optional[MergeMode] = None
 ) -> Tuple[Converter, MetadataType]:
     """


### PR DESCRIPTION
This function used to be used in OAK's lexical matcher pipeline, but has since been removed. Now, the only place it's (potentially mis)used is in the MONDO ingest pipeline (see https://github.com/search?q=get_metadata_and_prefix_map+-is%3Afork+-user%3Amapping-commons&type=code)

This PR deprecates it, and we can remove it in a future version.