### PR TITLE
Add flip step for the built-in sssom:superClassOf predicate during OWL conversion

### DIFF
--- a/src/sssom/writers.py
+++ b/src/sssom/writers.py
@@ -26,7 +26,8 @@ from .util import (
     URI_SSSOM_MAPPINGS,
     MappingSetDataFrame,
     get_file_extension,
-    sort_df_rows_columns, invert_mappings,
+    invert_mappings,
+    sort_df_rows_columns,
 )
 
 logging = _logging.getLogger(__name__)
@@ -154,7 +155,8 @@ def to_owl_graph(msdf: MappingSetDataFrame) -> Graph:
         df=msdf.df,
         merge_inverted=False,
         update_justification=False,
-        predicate_invert_dictionary={"sssom:superClassOf": 'rdfs:subClassOf'})
+        predicate_invert_dictionary={"sssom:superClassOf": "rdfs:subClassOf"},
+    )
     graph = to_rdf_graph(msdf=msdf)
 
     for _s, _p, o in graph.triples((None, URIRef(URI_SSSOM_MAPPINGS), None)):

--- a/src/sssom/writers.py
+++ b/src/sssom/writers.py
@@ -26,7 +26,7 @@ from .util import (
     URI_SSSOM_MAPPINGS,
     MappingSetDataFrame,
     get_file_extension,
-    sort_df_rows_columns,
+    sort_df_rows_columns, invert_mappings,
 )
 
 logging = _logging.getLogger(__name__)
@@ -150,6 +150,11 @@ def write_ontoportal_json(
 
 def to_owl_graph(msdf: MappingSetDataFrame) -> Graph:
     """Convert a mapping set dataframe to OWL in an RDF graph."""
+    msdf.df = invert_mappings(
+        df=msdf.df,
+        merge_inverted=False,
+        update_justification=False,
+        predicate_invert_dictionary={"sssom:superClassOf": 'rdfs:subClassOf'})
     graph = to_rdf_graph(msdf=msdf)
 
     for _s, _p, o in graph.triples((None, URIRef(URI_SSSOM_MAPPINGS), None)):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -67,7 +67,6 @@ class TestConvert(unittest.TestCase):
         size = len(results)
         self.assertEqual(size, 0)
 
-
     def test_to_rdf(self):
         """Test converting the basic example to a basic RDF graph."""
         g = to_rdf_graph(self.msdf)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -49,6 +49,25 @@ class TestConvert(unittest.TestCase):
         size = len(results)
         self.assertEqual(size, 60)
 
+        results = g.query(
+            """SELECT DISTINCT ?e1 ?e2
+                WHERE {
+                  ?e1 <http://www.w3.org/2000/01/rdf-schema#subClassOf> ?e2 .
+                }"""
+        )
+        size = len(results)
+        self.assertEqual(size, 22)
+
+        results = g.query(
+            """SELECT DISTINCT ?e1 ?e2
+                WHERE {
+                  ?e1 <https://w3id.org/sssom/superClassOf> ?e2 .
+                }"""
+        )
+        size = len(results)
+        self.assertEqual(size, 0)
+
+
     def test_to_rdf(self):
         """Test converting the basic example to a basic RDF graph."""
         g = to_rdf_graph(self.msdf)


### PR DESCRIPTION
Depends on

- [ ] #505 

This PR adds a preprocessing step to the to_owl_graph() method which flips "sssom:superClassOf" edges. I should really document sssom:superClassOf as syntactic sugar, but right now I dont have the bandwidth. I am certain it will come up.