### PR TITLE
Fix Error with curie parsing in sssom parse  #519

### DIFF
--- a/src/sssom/io.py
+++ b/src/sssom/io.py
@@ -185,6 +185,8 @@ def extract_iris(
         return sorted(set(chain.from_iterable(extract_iris(p, converter) for p in pred_list)))
     if isinstance(input, list):
         return sorted(set(chain.from_iterable(extract_iris(p, converter) for p in input)))
+    if isinstance(input, tuple):
+        return sorted(set(chain.from_iterable(extract_iris(p, converter) for p in input)))
     if converter.is_uri(input):
         return [converter.standardize_uri(input, strict=True)]
     if converter.is_curie(input):


### PR DESCRIPTION
Fixes #519 

Seems that in the new sssom py versions, the type of the inputs is "tuple", not list.

