### PR TITLE
Update for latest changes of the SSSOM schema

### DIFF
--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -914,6 +914,16 @@ def _ensure_valid_mapping_from_dict(mdict: Dict[str, Any]):
 
     try:
         m = Mapping(**mdict)
+        if m.subject_type == "rdfs literal":
+            if m.subject_label is None:
+                raise ValueError("Missing subject_label")
+        elif m.subject_id is None:
+            raise ValueError("Missing subject_id")
+        if m.object_type == "rdfs literal":
+            if m.object_label is None:
+                raise ValueError("Missing object_label")
+        elif m.object_id is None:
+            raise ValueError("Missing object_id")
     except ValueError as e:
         logging.warning(
             f"One mapping in the mapping set is not well-formed, "

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ import pandas as pd
 import yaml
 from curies import Converter, Record, chain
 from sssom_schema import Mapping as SSSOM_Mapping
+from sssom_schema import slots as SSSOM_Slots
 
 from sssom.constants import (
     CREATOR_ID,
@@ -409,13 +410,18 @@ class TestUtils(unittest.TestCase):
             "match_string": "",
             "subject_preprocessing": "",
             "object_preprocessing": "",
-            "semantic_similarity_score": np.nan,
-            "semantic_similarity_measure": "",
             "see_also": "",
             "issue_tracker_item": "",
             "other": "",
             "comment": "",
         }
+
+        if hasattr(SSSOM_Slots, "similarity_score"):
+            expected_result["similarity_score"] = np.nan
+            expected_result["similarity_measure"] = ""
+        else:
+            expected_result["semantic_similarity_score"] = np.nan
+            expected_result["semantic_similarity_measure"] = ""
 
         result_with_mapping_object = get_dict_from_mapping(mapping_obj)
         result_with_dict = get_dict_from_mapping(mapping_dict)


### PR DESCRIPTION
This PR updates SSSOM-Py to prepare it for changes that either have already occurred or that will occur in the SSSOM schema:

* the `semantic_similarity_{score|measure}` slots have been renamed to `similarity_{score|measure}`;
* the `subject_id` and `object_id` slots will no longer be _unconditionally_ required, but instead will be required or not depending on the value of `subject_type` and `object_type` (something the generated Python class is unfortunately unable to enforce on its own, despite the proper `rules` expressed in the schema).