### PR TITLE
Fix mapping set inversion

### DIFF
--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -1464,7 +1464,7 @@ def invert_mappings(
     inverted_df = df_to_invert.rename(
         columns=_invert_column_names(list_of_subject_object_columns, columns_invert_map)
     )
-    inverted_df = inverted_df[df.columns]
+    inverted_df = sort_df_rows_columns(inverted_df, by_rows=False)
     inverted_df[PREDICATE_ID] = inverted_df[PREDICATE_ID].map(predicate_invert_map)
     if update_justification:
         inverted_df[MAPPING_JUSTIFICATION] = SEMAPV.MappingInversion.value

--- a/tests/data/asymmetric.tsv
+++ b/tests/data/asymmetric.tsv
@@ -1,0 +1,17 @@
+#curie_map:
+#  orcid: https://orcid.org/
+#  x: http://example.org/x/
+#  y: http://example.org/y/
+#  z: http://example.org/z/
+#mapping_set_id: https://w3id.org/sssom/mapping/tests/data/asymmetric.tsv
+#creator_id:
+#  - orcid:1234
+#  - orcid:5678
+#license: https://creativecommons.org/publicdomain/zero/1.0/
+#mapping_date: 2020-05-30
+subject_id	subject_label	predicate_id	object_id	mapping_justification	object_source	confidence
+x:appendage	appendage	owl:equivalentClass	y:appendage	semapv:ManualMappingCuration	y:example	0.841
+x:appendage	appendage	owl:equivalentClass	z:appendage	semapv:LexicalMatching	z:example	0.882
+x:appendage	appendage	owl:equivalentClass	z:appendage	semapv:ManualMappingCuration	z:example	0.841
+x:bone_element	bone element	owl:equivalentClass	y:bone	semapv:LexicalMatching	y:example	0.739
+x:bone_element	bone element	owl:equivalentClass	y:bone	semapv:ManualMappingCuration	y:example	0.535

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -175,6 +175,15 @@ class TestIO(unittest.TestCase):
         inverted_df = invert_mappings(df=self.msdf2.df, merge_inverted=False)
         self.assertEqual(len(inverted_df), len(self.msdf2.df.drop_duplicates()))
 
+    def test_invert_asymmetric_nodes(self):
+        """Test inverting sets containing imbalanced subject/object columns."""
+        msdf = parse_sssom_table(f"{data_dir}/asymmetric.tsv")
+        inverted_df = invert_mappings(msdf.df, merge_inverted=False)
+        self.assertEqual(len(inverted_df), len(msdf.df))
+        original_subject_labels = msdf.df["subject_label"].values
+        inverted_object_labels = inverted_df["object_label"].values
+        self.assertNotIn(False, original_subject_labels == inverted_object_labels)
+
     def test_inject_metadata_into_df(self):
         """Test injecting metadata into DataFrame is as expected."""
         expected_creators = "orcid:0000-0001-5839-2535|orcid:0000-0001-5839-2532"


### PR DESCRIPTION
This is a putative fix to #554.

It implements the fix suggested in [this comment](https://github.com/mapping-commons/sssom-py/issues/554#issuecomment-2433482030), and adds a test case to check that inverting a set containing “imbalanced” columns (e.g., with a `subject_label` column but without a `object_label` column) does not trigger the #554 bug.