### PR TITLE
Ensure empty last line isnt printed when writing TSV

### DIFF
--- a/src/sssom/writers.py
+++ b/src/sssom/writers.py
@@ -62,11 +62,11 @@ def write_table(
     meta[CURIE_MAP] = msdf.converter.bimap
     if sort:
         msdf.df = sort_df_rows_columns(msdf.df)
-    lines = yaml.safe_dump(meta).split("\n")
-    lines = [f"# {line}" for line in lines if line != ""]
-    s = msdf.df.to_csv(sep=sep, index=False)
 
     if embedded_mode:
+        lines = yaml.safe_dump(meta).split("\n")
+        lines = [f"# {line}" for line in lines if line != ""]
+        s = msdf.df.to_csv(sep=sep, index=False).rstrip("\n")
         lines = lines + [s]
         for line in lines:
             print(line, file=file)


### PR DESCRIPTION
when printing df.to_csv(sep=sep, index=False), a line break is added automatically;

print(x) is also adding a line break, so when the dataframe string is printed, two line breaks are printed, leading to an empty line.

I also refactored the `lines` part a bit moving it inside the conditional, as they are only needed there.