### PR TITLE
suppress the FutureWarning: Downcasting behavior in `replace` is depr…

### DIFF
--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -425,7 +425,7 @@ def from_sssom_dataframe(
     # This is to address: A value is trying to be set on a copy of a slice from a DataFrame
     if CONFIDENCE in df.columns:
         df2 = df.copy()
-        df2[CONFIDENCE].replace(r"^\s*$", np.nan, regex=True, inplace=True)
+        df2[CONFIDENCE] = df2[CONFIDENCE].replace(r"^\s*$", np.nan, regex=True)
         df = df2
 
     mapping_set = _get_mapping_set_from_df(df=df, meta=meta)

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -165,7 +165,7 @@ class MappingSetDataFrame:
             # For pandas < 2.0.0, call 'infer_objects()' without any parameters
             df = df.infer_objects()
         # remove columns where all values are blank
-        
+
         # ! This will break when pandas >= 3.0.0 is released
         # https://github.com/pandas-dev/pandas/issues/57734
         pd.set_option("future.no_silent_downcasting", True)

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -168,7 +168,8 @@ class MappingSetDataFrame:
 
         # ! This will break when pandas >= 3.0.0 is released
         # https://github.com/pandas-dev/pandas/issues/57734
-        pd.set_option("future.no_silent_downcasting", True)
+        if "future.no_silent_downcasting" in pd.options:
+            pd.set_option("future.no_silent_downcasting", True)
         df.replace("", np.nan, inplace=True)
         df.dropna(axis=1, how="all", inplace=True)  # remove columns with all row = 'None'-s.
 

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -168,8 +168,11 @@ class MappingSetDataFrame:
 
         # ! This will break when pandas >= 3.0.0 is released
         # https://github.com/pandas-dev/pandas/issues/57734
-        if "future.no_silent_downcasting" in pd.options:
+        try:
             pd.set_option("future.no_silent_downcasting", True)
+        except KeyError:
+            # Option does not exist in this version of pandas
+            pass
         df.replace("", np.nan, inplace=True)
         df.dropna(axis=1, how="all", inplace=True)  # remove columns with all row = 'None'-s.
 

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -164,7 +164,11 @@ class MappingSetDataFrame:
         else:
             # For pandas < 2.0.0, call 'infer_objects()' without any parameters
             df = df.infer_objects()
-        # remove columns where all values are blank.
+        # remove columns where all values are blank
+        
+        # ! This will break when pandas >= 3.0.0 is released
+        # https://github.com/pandas-dev/pandas/issues/57734
+        pd.set_option("future.no_silent_downcasting", True)
         df.replace("", np.nan, inplace=True)
         df.dropna(axis=1, how="all", inplace=True)  # remove columns with all row = 'None'-s.
 

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -164,10 +164,9 @@ class MappingSetDataFrame:
         else:
             # For pandas < 2.0.0, call 'infer_objects()' without any parameters
             df = df.infer_objects()
-        # remove columns where all values are blank
+        # remove columns where all values are blank.
 
-        # ! This will break when pandas >= 3.0.0 is released
-        # https://github.com/pandas-dev/pandas/issues/57734
+        # Context https://github.com/pandas-dev/pandas/issues/57734
         try:
             pd.set_option("future.no_silent_downcasting", True)
         except KeyError:


### PR DESCRIPTION
…ecated

Previously we got

```
/Users/matentzn/ws/sssom-py/src/sssom/util.py:168: FutureWarning: Downcasting behavior in `replace` is deprecated and will be removed in a future version. To retain the old behavior, explicitly call `result.infer_objects(copy=False)`. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
  df = df.replace("", np.nan)
```

Here I am hiding the root cause of the issue (which would require me to ensure the I am not type casting accidentally while replacing) by surpressing the warning.