### PR TITLE
Return validation reports

### DIFF
--- a/src/sssom/io.py
+++ b/src/sssom/io.py
@@ -19,7 +19,6 @@ from sssom.validators import validate
 
 from .constants import (
     CURIE_MAP,
-    DEFAULT_VALIDATION_TYPES,
     PREFIX_MAP_MODE_MERGED,
     PREFIX_MAP_MODE_METADATA_ONLY,
     PREFIX_MAP_MODE_SSSOM_DEFAULT_ONLY,

--- a/src/sssom/io.py
+++ b/src/sssom/io.py
@@ -102,7 +102,7 @@ def parse_file(
 def validate_file(
     input_path: str,
     *,
-    validation_types: List[SchemaValidationType] | None = None,
+    validation_types: Optional[List[SchemaValidationType]] = None,
     fail_on_error: bool = True,
 ) -> dict[SchemaValidationType, ValidationReport]:
     """Validate the incoming SSSOM TSV according to the SSSOM specification.

--- a/src/sssom/io.py
+++ b/src/sssom/io.py
@@ -101,7 +101,6 @@ def parse_file(
 
 def validate_file(
     input_path: str,
-    *,
     validation_types: Optional[List[SchemaValidationType]] = None,
     fail_on_error: bool = True,
 ) -> dict[SchemaValidationType, ValidationReport]:

--- a/src/sssom/io.py
+++ b/src/sssom/io.py
@@ -13,11 +13,13 @@ import pandas as pd
 import yaml
 from curies import Converter
 from deprecation import deprecated
+from linkml.validator import ValidationReport
 
 from sssom.validators import validate
 
 from .constants import (
     CURIE_MAP,
+    DEFAULT_VALIDATION_TYPES,
     PREFIX_MAP_MODE_MERGED,
     PREFIX_MAP_MODE_METADATA_ONLY,
     PREFIX_MAP_MODE_SSSOM_DEFAULT_ONLY,
@@ -98,17 +100,24 @@ def parse_file(
     write_table(doc, output, embedded_mode)
 
 
-def validate_file(input_path: str, validation_types: List[SchemaValidationType]) -> None:
+def validate_file(
+    input_path: str,
+    *,
+    validation_types: List[SchemaValidationType] | None = None,
+    fail_on_error: bool = True,
+) -> dict[SchemaValidationType, ValidationReport]:
     """Validate the incoming SSSOM TSV according to the SSSOM specification.
 
     :param input_path: The path to the input file in one of the legal formats, eg obographs, aligmentapi-xml
     :param validation_types: A list of validation types to run.
+    :param fail_on_error: Should an exception be raised on error of _any_ validator?
+    :returns: A dictionary from validation types to validation reports
     """
     # Two things to check:
     # 1. All prefixes in the DataFrame are define in prefix_map
     # 2. All columns in the DataFrame abide by sssom-schema.
     msdf = parse_sssom_table(file_path=input_path)
-    validate(msdf=msdf, validation_types=validation_types)
+    return validate(msdf=msdf, validation_types=validation_types, fail_on_error=fail_on_error)
 
 
 def split_file(input_path: str, output_directory: Union[str, Path]) -> None:

--- a/src/sssom/validators.py
+++ b/src/sssom/validators.py
@@ -1,7 +1,7 @@
 """Validators."""
 
 import logging
-from typing import Callable, List, Mapping
+from typing import Callable, List, Mapping, Optional
 
 from jsonschema import ValidationError
 from linkml.validator import ValidationReport, Validator
@@ -22,7 +22,7 @@ from .constants import (
 
 def validate(
     msdf: MappingSetDataFrame,
-    validation_types: List[SchemaValidationType] | None = None,
+    validation_types: Optional[List[SchemaValidationType]] = None,
     *,
     fail_on_error: bool = True,
 ) -> dict[SchemaValidationType, ValidationReport]:

--- a/src/sssom/validators.py
+++ b/src/sssom/validators.py
@@ -12,22 +12,30 @@ from linkml_runtime.dumpers import json_dumper
 from sssom.parsers import to_mapping_set_document
 from sssom.util import MappingSetDataFrame, get_all_prefixes
 
-from .constants import SCHEMA_YAML, SchemaValidationType, _get_sssom_schema_object
+from .constants import (
+    DEFAULT_VALIDATION_TYPES,
+    SCHEMA_YAML,
+    SchemaValidationType,
+    _get_sssom_schema_object,
+)
 
 
 def validate(
     msdf: MappingSetDataFrame,
-    validation_types: List[SchemaValidationType],
+    *,
+    validation_types: List[SchemaValidationType] | None = None,
     fail_on_error: bool = True,
-) -> None:
+) -> dict[SchemaValidationType, ValidationReport]:
     """Validate SSSOM files against `sssom-schema` using linkML's validator function.
 
     :param msdf: MappingSetDataFrame.
     :param validation_types: SchemaValidationType
     :param fail_on_error: If true, throw an error when execution of a method has failed
+    :returns: A dictionary from validation types to validation reports
     """
-    for vt in validation_types:
-        VALIDATION_METHODS[vt](msdf, fail_on_error)
+    if validation_types is None:
+        validation_types = DEFAULT_VALIDATION_TYPES
+    return {vt: VALIDATION_METHODS[vt](msdf, fail_on_error) for vt in validation_types}
 
 
 def print_linkml_report(report: ValidationReport, fail_on_error: bool = True):
@@ -88,7 +96,7 @@ def _clean_dict(d):
     return cleaned_dict
 
 
-def validate_json_schema(msdf: MappingSetDataFrame, fail_on_error: bool = True) -> None:
+def validate_json_schema(msdf: MappingSetDataFrame, fail_on_error: bool = True) -> ValidationReport:
     """Validate JSON Schema using linkml's JsonSchemaDataValidator.
 
     :param msdf: MappingSetDataFrame to eb validated.
@@ -106,9 +114,10 @@ def validate_json_schema(msdf: MappingSetDataFrame, fail_on_error: bool = True) 
 
     report = validator.validate(mapping_set_dict, "mapping set")
     print_linkml_report(report, fail_on_error)
+    return report
 
 
-def validate_shacl(msdf: MappingSetDataFrame, fail_on_error: bool = True) -> None:
+def validate_shacl(msdf: MappingSetDataFrame, fail_on_error: bool = True) -> ValidationReport:
     """Validate SCHACL file.
 
     :param msdf: TODO: https://github.com/linkml/linkml/issues/850 .
@@ -118,7 +127,7 @@ def validate_shacl(msdf: MappingSetDataFrame, fail_on_error: bool = True) -> Non
     raise NotImplementedError
 
 
-def validate_sparql(msdf: MappingSetDataFrame, fail_on_error: bool = True) -> None:
+def validate_sparql(msdf: MappingSetDataFrame, fail_on_error: bool = True) -> ValidationReport:
     """Validate SPARQL file.
 
     :param msdf: MappingSetDataFrame
@@ -132,7 +141,9 @@ def validate_sparql(msdf: MappingSetDataFrame, fail_on_error: bool = True) -> No
     raise NotImplementedError
 
 
-def check_all_prefixes_in_curie_map(msdf: MappingSetDataFrame, fail_on_error: bool = True) -> None:
+def check_all_prefixes_in_curie_map(
+    msdf: MappingSetDataFrame, fail_on_error: bool = True
+) -> ValidationReport:
     """Check all `EntityReference` slots are mentioned in 'curie_map'.
 
     :param msdf: MappingSetDataFrame
@@ -154,9 +165,12 @@ def check_all_prefixes_in_curie_map(msdf: MappingSetDataFrame, fail_on_error: bo
         )
     report = ValidationReport(results=validation_results)
     print_linkml_report(report, fail_on_error)
+    return report
 
 
-def check_strict_curie_format(msdf: MappingSetDataFrame, fail_on_error: bool = True) -> None:
+def check_strict_curie_format(
+    msdf: MappingSetDataFrame, fail_on_error: bool = True
+) -> ValidationReport:
     """Check all `EntityReference` slots are formatted as unambiguous curies.
 
     Implemented rules:
@@ -194,9 +208,10 @@ def check_strict_curie_format(msdf: MappingSetDataFrame, fail_on_error: bool = T
 
     report = ValidationReport(results=validation_results)
     print_linkml_report(report, fail_on_error)
+    return report
 
 
-VALIDATION_METHODS: Mapping[SchemaValidationType, Callable] = {
+VALIDATION_METHODS: Mapping[SchemaValidationType, Callable[..., ValidationReport]] = {
     SchemaValidationType.JsonSchema: validate_json_schema,
     SchemaValidationType.Shacl: validate_shacl,
     SchemaValidationType.Sparql: validate_sparql,

--- a/src/sssom/validators.py
+++ b/src/sssom/validators.py
@@ -23,7 +23,6 @@ from .constants import (
 def validate(
     msdf: MappingSetDataFrame,
     validation_types: Optional[List[SchemaValidationType]] = None,
-    *,
     fail_on_error: bool = True,
 ) -> dict[SchemaValidationType, ValidationReport]:
     """Validate SSSOM files against `sssom-schema` using linkML's validator function.

--- a/src/sssom/validators.py
+++ b/src/sssom/validators.py
@@ -22,8 +22,8 @@ from .constants import (
 
 def validate(
     msdf: MappingSetDataFrame,
-    *,
     validation_types: List[SchemaValidationType] | None = None,
+    *,
     fail_on_error: bool = True,
 ) -> dict[SchemaValidationType, ValidationReport]:
     """Validate SSSOM files against `sssom-schema` using linkML's validator function.

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -28,7 +28,11 @@ class TestValidate(unittest.TestCase):
         Validate of the incoming file (basic.tsv) abides
         by the rules set by `sssom-schema`.
         """
-        self.assertIsNone(validate(self.correct_msdf1, self.validation_types))
+        rv = validate(self.correct_msdf1, self.validation_types)
+        self.assertIsNotNone(rv)
+        self.assertIn(SchemaValidationType.JsonSchema, rv)
+        json_validation = rv[SchemaValidationType.JsonSchema]
+        self.assertEqual([], json_validation.results)
 
     @unittest.skip(
         reason="""\

--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,10 @@ exclude =
 
 
 [testenv:mypy]
-deps = mypy
+deps =
+    mypy
+    types-PyYAML
+    types-requests
 skip_install = true
 commands = mypy --install-types --non-interactive --ignore-missing-imports --implicit-optional src/sssom tests/
 description = Run the mypy tool to check static typing on the project.


### PR DESCRIPTION
I'm currently trying to use `sssom.io.validate_path` to check that SSSOM files generated by SeMRA are valid, but it's very difficult to get access to the results of validation programmatically. There _should_ be some logging output to stderr, but this isn't so helpful in a unit testing environment.

This PR makes the validation functions return the reports generated by LinkML, so they can be returned and used downstream.

This PR also operationalizes the default validator list, meaning you don't have to import them or know what they are to get this function up and running.

Blocked by #580

Alternative to #387, but that PR uses custom results instead of returning the LinkML objects