### PR TITLE
Simplify reading CSV/TSV

### DIFF
--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -132,11 +132,11 @@ def _read_pandas_and_metadata(file_path: Union[str, Path, TextIO], sep: Optional
     if isinstance(file_path, (str, Path)):
         raise_for_bad_path(file_path)
 
-    stream = _open_input(file_path)
+    table_stream = _open_input(file_path)
 
     # consume from the top of the stream until there's no more preceding #
     header_yaml = ""
-    while (line := stream.readline()).startswith("#"):
+    while (line := table_stream.readline()).startswith("#"):
         line = line.lstrip("#").rstrip()
         if not line:
             continue
@@ -150,7 +150,7 @@ def _read_pandas_and_metadata(file_path: Union[str, Path, TextIO], sep: Optional
 
     try:
         # pandas can keep going and read from the same stream that we already have
-        df = pd.read_csv(stream, sep=sep, dtype=str, engine="python", header=None, names=names)
+        df = pd.read_csv(table_stream, sep=sep, dtype=str, engine="python", header=None, names=names)
     except EmptyDataError as e:
         logging.warning(f"Seems like the dataframe is empty: {e}")
         df = pd.DataFrame(

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -131,11 +131,11 @@ def _read_pandas_and_metadata(file_path: Union[str, Path, TextIO], sep: Optional
     if isinstance(file_path, (str, Path)):
         raise_for_bad_path(file_path)
 
-    table_stream = _open_input(file_path)
+    stream = _open_input(file_path)
 
     # consume from the top of the stream until there's no more preceding #
     header_yaml = ""
-    while (line := table_stream.readline()).startswith("#"):
+    while (line := stream.readline()).startswith("#"):
         line = line.lstrip("#").rstrip()
         if not line:
             continue
@@ -150,7 +150,7 @@ def _read_pandas_and_metadata(file_path: Union[str, Path, TextIO], sep: Optional
     try:
         # pandas can keep going and read from the same stream that we already have
         df = pd.read_csv(
-            table_stream, sep=sep, dtype=str, engine="python", header=None, names=names
+            stream, sep=sep, dtype=str, engine="python", header=None, names=names
         )
     except EmptyDataError as e:
         logging.warning(f"Seems like the dataframe is empty: {e}")

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -118,7 +118,9 @@ def _open_input(p: PathOrIO) -> TextIO:
         return io.StringIO(file_content)
 
 
-def _read_pandas_and_metadata(file_path: Union[str, Path, TextIO], sep: Optional[str] = None):
+def _read_pandas_and_metadata(
+    file_path: Union[str, Path, TextIO], sep: Optional[str] = None
+) -> tuple[pd.DataFrame, dict[str, Any]]:
     """Read a tabular data file by wrapping func:`pd.read_csv` to handles comment lines correctly.
 
     :param file_path: The file path or stream to read
@@ -141,7 +143,7 @@ def _read_pandas_and_metadata(file_path: Union[str, Path, TextIO], sep: Optional
             continue
         header_yaml += line + "\n"
 
-    sssom_metadata = yaml.safe_load(header_yaml)
+    sssom_metadata = yaml.safe_load(header_yaml) if header_yaml else {}
 
     # The first line that doesn't start with a # is assumed
     # to be the header, so we split it with the inferred separator
@@ -149,9 +151,7 @@ def _read_pandas_and_metadata(file_path: Union[str, Path, TextIO], sep: Optional
 
     try:
         # pandas can keep going and read from the same stream that we already have
-        df = pd.read_csv(
-            stream, sep=sep, dtype=str, engine="python", header=None, names=names
-        )
+        df = pd.read_csv(stream, sep=sep, dtype=str, engine="python", header=None, names=names)
     except EmptyDataError as e:
         logging.warning(f"Seems like the dataframe is empty: {e}")
         df = pd.DataFrame(

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -6,7 +6,6 @@ import itertools as itt
 import json
 import logging as _logging
 import os.path
-import re
 import typing
 from collections import ChainMap, Counter
 from pathlib import Path
@@ -150,7 +149,9 @@ def _read_pandas_and_metadata(file_path: Union[str, Path, TextIO], sep: Optional
 
     try:
         # pandas can keep going and read from the same stream that we already have
-        df = pd.read_csv(table_stream, sep=sep, dtype=str, engine="python", header=None, names=names)
+        df = pd.read_csv(
+            table_stream, sep=sep, dtype=str, engine="python", header=None, names=names
+        )
     except EmptyDataError as e:
         logging.warning(f"Seems like the dataframe is empty: {e}")
         df = pd.DataFrame(
@@ -873,7 +874,6 @@ def _swap_object_subject(mapping: Mapping) -> Mapping:
         setattr(mapping, "subject_" + var, object_val)
         setattr(mapping, "object_" + var, subject_val)
     return mapping
-
 
 
 def _set_metadata_in_mapping_set(

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -147,7 +147,7 @@ def _read_pandas_and_metadata(
 
     # The first line that doesn't start with a # is assumed
     # to be the header, so we split it with the inferred separator
-    names = line.split(sep)
+    names = line.strip().split(sep)
 
     try:
         # pandas can keep going and read from the same stream that we already have

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -120,12 +120,12 @@ def _open_input(p: PathOrIO) -> TextIO:
 
 def _read_pandas_and_metadata(
     file_path: Union[str, Path, TextIO], sep: Optional[str] = None
-) -> tuple[pd.DataFrame, dict[str, Any]]:
+) -> tuple[pd.DataFrame, MetadataType]:
     """Read a tabular data file by wrapping func:`pd.read_csv` to handles comment lines correctly.
 
     :param file_path: The file path or stream to read
     :param sep: File separator for pandas
-    :return: A pandas dataframe
+    :return: A pair of a dataframe and metadata dictionary
     """
     if sep is None:
         sep = _infer_separator(file_path) or "\t"

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -283,7 +283,7 @@ def parse_sssom_table(
     sep: Optional[str] = None,
     **kwargs: Any,
 ) -> MappingSetDataFrame:
-    """Parse a SSSOM CSV or TSV file to a :class:`MappingSetDocument` to a :class:`MappingSetDataFrame`.
+    """Parse a SSSOM CSV or TSV file.
 
     :param file_path:
         A file path, URL, or I/O object that contains SSSOM encoded in TSV
@@ -305,9 +305,8 @@ def parse_sssom_table(
     """
     if kwargs:
         logging.warning("unhandled keyword arguments passed: %s", kwargs)
-    if isinstance(file_path, Path) or isinstance(file_path, str):
-        raise_for_bad_path(file_path)
-    df, sssom_metadata = _read_pandas_and_metadata(file_path, sep=sep)
+
+    df, sssom_metadata = _read_pandas_and_metadata(file_path, sep)
     if meta is None:
         meta = {}
 

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -127,7 +127,7 @@ def _read_pandas_and_metadata(file_path: Union[str, Path, TextIO], sep: Optional
     :return: A pandas dataframe
     """
     if sep is None:
-        sep = _get_seperator_symbol_from_file_path(file_path) or "\t"
+        sep = _infer_separator(file_path) or "\t"
 
     if isinstance(file_path, (str, Path)):
         raise_for_bad_path(file_path)

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -128,7 +128,7 @@ def _read_pandas_and_metadata(file_path: Union[str, Path, TextIO], sep: Optional
     # consume from the top of the stream until there's no more preceding #
     header_yaml = ""
     while (line := stream.readline()).startswith("#"):
-        line = line.lstrip("#").rstrip("\n").rstrip("\t")
+        line = line.lstrip("#").rstrip()
         if not line:
             continue
         header_yaml += line + "\n"

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -470,8 +470,11 @@ class TestParseExplicit(unittest.TestCase):
             parse_sssom_table(stream, strict=True)
 
         # Make sure it parses in non-strict mode
-        msdf = parse_sssom_table(stream)
-        self.assertEqual(len(msdf.df), 2)
+        with open(input_path, "r") as file:
+            input_string = file.read()
+        stream2 = io.StringIO(input_string)
+        msdf = parse_sssom_table(stream2, strict=False)
+        self.assertEqual(2, len(msdf.df))
 
     def test_check_irregular_metadata(self):
         """Test if irregular metadata check works according to https://w3id.org/sssom/spec."""


### PR DESCRIPTION
This PR reduces complexity in the way TSV files are read, requiring only a single pass through the file instead of two.

This PR does not need new tests, as the code that is changed is part of a private API, which is thoroughly tested by reading many SSSOM documents via the user-facing functions that call this.