### PR TITLE
Error out gracefully on missing optional module

### DIFF
--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -423,7 +423,9 @@ def partition(inputs: List[str], output_directory: str):
         cliquedocs = split_into_cliques(doc)
     except ModuleNotFoundError as e:
         if e.name == "networkx":
-            raise click.ClickException("The partition command requires the optional networkx module.")
+            raise click.ClickException(
+                "The partition command requires the optional networkx module."
+            )
         raise
     for n, cdoc in enumerate(cliquedocs, start=1):
         ofn = f"{output_directory}/clique_{n}.sssom.tsv"
@@ -452,7 +454,9 @@ def cliquesummary(input: str, output: TextIO, metadata: str, statsfile: str):
         df = summarize_cliques(doc)
     except ModuleNotFoundError as e:
         if e.name == "networkx":
-            raise click.ClickException("The cliquesummary command requires the optional networkx module.")
+            raise click.ClickException(
+                "The cliquesummary command requires the optional networkx module."
+            )
         raise
     df.to_csv(output, sep="\t")
     if statsfile is None:
@@ -484,7 +488,6 @@ def crosstab(input: str, output: TextIO, transpose: bool, fields: Tuple[str, str
 @input_argument
 def correlations(input: str, output: TextIO, transpose: bool, fields: Tuple[str, str]):
     """Calculate correlations."""
-
     try:
         from scipy.stats import chi2_contingency
     except ModuleNotFoundError:


### PR DESCRIPTION
Three of the dependencies of `sssom` are considered optional:

* `scipy`,
* `pansql`,
* and `networkx`.

However, wherever they are needed, those modules are always imported unconditionally and without any code to deal with the possibility that they may very well be absent.

This is especially problematic for the `scipy` module, since it is imported at the root of the `sssom.cli` module, resulting in that module being unloadable if `scipy` itself cannot be found – resulting in turn in the entire `sssom` command being unusable (#599).

For the other twos, their absence does not prevent the `sssom` command to run, but any attempt to use one of the subcommands that need them will result in a loud crash (uncaught `ModuleErrorNotFoundError`).

Since those modules are _optional_, the `sssom` command-line tool should deal gracefully with their possible absence. That is, it should not spit out an exception stack trace, but instead print out a simple error message highlighting that the particular subcommand the user tried to run requires an optional module.

This is what this PR does.

For `scipy`, which is only used within the `correlations` subcommand, we `try` to import the module within that subcommand, and error out if the module cannot be found.

For `pansql` and `networkx`, we guard all calls to functions that use them in a `try` block to catch the specific error indicating that they are not present.