### PR TITLE
Add support for propagating/condensing slots.

### DIFF
--- a/src/sssom/constants.py
+++ b/src/sssom/constants.py
@@ -268,6 +268,16 @@ class SSSOMSchemaView(object):
         """Return the slot names for SSSOMSchemaView object."""
         return {k for k, v in self.dict["slots"].items() if v["range"] == "double"}
 
+    @cached_property
+    def propagatable_slots(self) -> List[str]:
+        """Return the names of all propagatable slots."""
+        slots = []
+        for slot_name in self.mapping_set_slots:
+            annotations = self.view.annotation_dict(slot_name)
+            if annotations is not None and "propagated" in annotations:
+                slots.append(slot_name)
+        return slots
+
 
 @lru_cache(1)
 def _get_sssom_schema_object() -> SSSOMSchemaView:

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -343,6 +343,8 @@ class MappingSetDataFrame:
                 value = values[0].split("|")
             else:
                 value = values[0]
+            if slot in self.metadata and self.metadata[slot] != value:
+                continue  # Set already has a different value
 
             self.metadata[slot] = value
             condensed.append(slot)

--- a/tests/data/propagatable.tsv
+++ b/tests/data/propagatable.tsv
@@ -1,0 +1,22 @@
+#curie_map:
+#  c: http://example.org/c/
+#  orcid: https://orcid.org/
+#  x: http://example.org/x/
+#  y: http://example.org/y/
+#  z: http://example.org/z/
+#mapping_set_id: https://w3id.org/sssom/mapping/tests/data/propagatable.tsv
+#creator_id:
+#  - orcid:1234
+#  - orcid:5678
+#license: https://creativecommons.org/publicdomain/zero/1.0/
+#mapping_provider: https://example.org/mappings
+#mapping_tool: https://github.com/cmungall/rdf_matcher
+#subject_preprocessing:
+#  - c:rule1
+#  - c:rule2
+subject_id	predicate_id	object_id	mapping_justification	mapping_tool
+x:appendage	owl:equivalentClass	y:appendage	semapv:ManualMappingCuration	
+x:appendage	owl:equivalentClass	z:appendage	semapv:LexicalMatching	
+x:appendage	owl:equivalentClass	z:appendage	semapv:ManualMappingCuration	foo matcher
+x:bone_element	owl:equivalentClass	y:bone	semapv:LexicalMatching	
+x:bone_element	owl:equivalentClass	y:bone	semapv:ManualMappingCuration	

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -563,6 +563,29 @@ class TestUtils(unittest.TestCase):
         # Set has been condensed already, no further condensation possible
         self.assertEqual(0, len(condensed_slots))
 
+    def test_condensation_with_existing_set_values(self) -> None:
+        """Test that condensation works as expected with the mapping set already contains values for the to-be-condensed slots."""
+        msdf = parse_sssom_table(f"{data_dir}/propagatable.tsv")
+        msdf.propagate()
+        # Following propagation, all records in msdf have the same
+        # mapping_provider ("https://example.org/mappings/)"
+
+        # Inject a different mapping_provider value in the set metadata;
+        # this should prevent that slot from being condensed back
+        msdf.metadata["mapping_provider"] = "https://example.org/mappings/2"
+        condensed_slots = msdf.condense()
+        self.assertNotIn("mapping_provider", condensed_slots)
+        self.assertIn("mapping_provider", msdf.df.columns)
+        self.assertEqual("https://example.org/mappings/2", msdf.metadata["mapping_provider"])
+
+        # Inject the same mapping_provider value as the one contained in
+        # the records; this should allow the slot to be condensed
+        msdf.metadata["mapping_provider"] = "https://example.org/mappings"
+        condensed_slots = msdf.condense()
+        self.assertIn("mapping_provider", condensed_slots)
+        self.assertNotIn("mapping_provider", msdf.df.columns)
+        self.assertEqual("https://example.org/mappings", msdf.metadata["mapping_provider"])
+
     def test_propagation_fill_empty_mode(self) -> None:
         """Test propagate with fill_empty=True."""
         msdf = parse_sssom_table(f"{data_dir}/propagatable.tsv")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -562,3 +562,13 @@ class TestUtils(unittest.TestCase):
         condensed_slots = msdf.condense()
         # Set has been condensed already, no further condensation possible
         self.assertEqual(0, len(condensed_slots))
+
+    def test_propagation_fill_empty_mode(self) -> None:
+        """Test propagate with fill_empty=True."""
+        msdf = parse_sssom_table(f"{data_dir}/propagatable.tsv")
+
+        propagated_slots = msdf.propagate(fill_empty=True)
+        # mapping_tool should have been propagated
+        self.assertIn("mapping_tool", propagated_slots)
+        self.assertNotIn("mapping_tool", msdf.metadata)
+        self.assertEqual(2, len(msdf.df["mapping_tool"].unique()))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -522,3 +522,43 @@ class TestUtils(unittest.TestCase):
             with self.subTest(path=path, mode="file"), tempfile.TemporaryDirectory() as d:
                 with Path(d).joinpath(part).open("w") as file:
                     self.assertEqual(value, get_file_extension(file))
+
+    def test_propagation_and_condensation(self) -> None:
+        """Test propagating/condensing values of propagatable slots."""
+        msdf = parse_sssom_table(f"{data_dir}/propagatable.tsv")
+
+        propagated_slots = msdf.propagate()
+        # creator_id is not a propagatable slot
+        self.assertNotIn("creator_id", propagated_slots)
+        self.assertNotIn("creator_id", msdf.df.columns)
+        # mapping_tool has values for some records and should not be propagated
+        self.assertNotIn("mapping_tool", propagated_slots)
+        # mapping_provider should be propagated
+        self.assertIn("mapping_provider", propagated_slots)
+        self.assertIn("mapping_provider", msdf.df.columns)
+        self.assertNotIn("mapping_provider", msdf.metadata)
+        # Ditto for subject_preprocessing
+        self.assertIn("subject_preprocessing", propagated_slots)
+        self.assertIn("subject_preprocessing", msdf.df.columns)
+        self.assertNotIn("subject_preprocessing", msdf.metadata)
+
+        propagated_slots = msdf.propagate()
+        # Set has been propagated already, no further propagation possible
+        self.assertEqual(0, len(propagated_slots))
+
+        condensed_slots = msdf.condense()
+        # mapping_tool has not a unique value and should not be condensed
+        self.assertNotIn("mapping_tool", condensed_slots)
+        self.assertIn("mapping_tool", msdf.df.columns)
+        # mapping_provider should be condensed back
+        self.assertIn("mapping_provider", condensed_slots)
+        self.assertNotIn("mapping_provider", msdf.df.columns)
+        self.assertIn("mapping_provider", msdf.metadata)
+        # Ditto for subject_preprocessing
+        self.assertIn("subject_preprocessing", condensed_slots)
+        self.assertNotIn("subject_preprocessing", msdf.df.columns)
+        self.assertIn("subject_preprocessing", msdf.metadata)
+
+        condensed_slots = msdf.condense()
+        # Set has been condensed already, no further condensation possible
+        self.assertEqual(0, len(condensed_slots))


### PR DESCRIPTION
This PR adds partial support for condensation and propagation of slot values (#584).

“Partial” because

(1) It is only supported for a mapping set represented with the `MappingSetDataFrame` class. This seems to be _the_ standard object to represent a mapping set across SSSOM-Py (in particular, that is the object returned by all the parsers, and consumed by all the writers). In fact it’s unclear to me what the `MappingSet` and `MappingSetDocument` classes are for.

So for now, if you have a mapping set as `MappingSet` object, it still cannot be propagated or condensed directly, it needs to be converted into a `MappingSetDataFrame` first (and converted back to a `MappingSet` afterwards), as in:

```python
msdf = MappingSetDataFrame.from_mapping_set(ms)
msdf.propagate()
ms = msdf.to_mapping_set()
```

(2) Condensation/propagation is not (yet?) wired into the `sssom` command-line tool, the feature is only available from Python code.

FWIW, my opinion is that propagation should be _systematically_ performed when reading a SSSOM file, and conversely condensation should be _systematically_ performed when writing a SSSOM file. That’s what the spec recommends, and what SSSOM-Java does. But I acknowledge this would be a breaking change compared to what has always been SSSOM-Py’s behaviour (since it has never supported either operation), so I’ll let others to decide if and how propagation/condensation should be enabled directly in the SSSOM parsers and readers.