### PR TITLE
Split dataframe optimization

### DIFF
--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -9,7 +9,19 @@ import os.path
 import typing
 from collections import ChainMap, Counter
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Optional, TextIO, Tuple, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    TextIO,
+    Tuple,
+    Union,
+    cast,
+)
 from xml.dom import Node, minidom
 from xml.dom.minidom import Document
 
@@ -979,16 +991,20 @@ def split_dataframe(
 
 class SSSOMSplitGroup(NamedTuple):
     """A tuple to identify the boundary where a mapping set should be split."""
+
     subject_prefix: str
     object_prefix: str
     relation_curie: ReferenceTuple
 
     def as_identifier(self):
-        return "_".join([
-            self.subject_prefix.lower(),
-            self.relation_curie.identifier.lower(),
-            self.object_prefix.lower(),
-        ])
+        return "_".join(
+            [
+                self.subject_prefix.lower(),
+                self.relation_curie.identifier.lower(),
+                self.object_prefix.lower(),
+            ]
+        )
+
 
 def split_dataframe_by_prefix(
     msdf: MappingSetDataFrame,

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -1032,26 +1032,27 @@ def split_dataframe_by_prefix(
         mapping = cast(NamedTuple, _mapping)._asdict()
         subject_curie = msdf.converter.parse_curie(mapping[SUBJECT_ID], strict=True)
         object_curie = msdf.converter.parse_curie(mapping[OBJECT_ID], strict=True)
+        relation_curie = msdf.converter.parse_curie(mapping[PREDICATE_ID], strict=True)
         group = SSSOMSplitGroup(
             subject_curie.prefix,
             object_curie.prefix,
-            msdf.converter.parse_curie(mapping[PREDICATE_ID], strict=True),
+            relation_curie,
         )
         if group in mappings_by_group:
             mappings_by_group[group].append(mapping)
 
     # Convert the mappings in each group to a MappingSetDataFrame and index them
     # by a string identifier.
-    for group, values in mappings_by_group.items():
+    for group, mappings in mappings_by_group.items():
         split_id = group.as_identifier()
-        if len(values) == 0:
+        if len(mappings) == 0:
             logging.debug(f"{split_id} - No matches (0 matches found)")
             continue
         subconverter = msdf.converter.get_subconverter(
             [group.subject_prefix, group.object_prefix, group.relation_curie.prefix]
         )
         split_to_msdf[split_id] = from_sssom_dataframe(
-            pd.DataFrame(values), prefix_map=dict(subconverter.bimap), meta=meta
+            pd.DataFrame(mappings), prefix_map=dict(subconverter.bimap), meta=meta
         )
 
     return split_to_msdf

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -1036,12 +1036,12 @@ def split_dataframe_by_prefix(
             object_prefix,
             msdf.converter.parse_curie(relation, strict=True),
         )
-        split_id = group.as_identifier()
+        split = group.as_identifier()
         if subject_prefix not in msdf.converter.bimap:
-            logging.warning(f"{split_id} - missing subject prefix - {subject_prefix}")
+            logging.warning(f"{split} - missing subject prefix - {subject_prefix}")
             continue
         if object_prefix not in msdf.converter.bimap:
-            logging.warning(f"{split_id} - missing object prefix - {object_prefix}")
+            logging.warning(f"{split} - missing object prefix - {object_prefix}")
             continue
         mappings_by_group[group] = []
 
@@ -1062,14 +1062,14 @@ def split_dataframe_by_prefix(
     # Convert the mappings in each group to a MappingSetDataFrame and index them
     # by a string identifier.
     for group, mappings in mappings_by_group.items():
-        split_id = group.as_identifier()
+        split = group.as_identifier()
         if len(mappings) == 0:
-            logging.debug(f"{split_id} - No matches (0 matches found)")
+            logging.debug(f"{split} - No matches (0 matches found)")
             continue
         subconverter = msdf.converter.get_subconverter(
             [group.subject_prefix, group.object_prefix, group.relation_curie.prefix]
         )
-        split_to_msdf[split_id] = from_sssom_dataframe(
+        split_to_msdf[split] = from_sssom_dataframe(
             pd.DataFrame(mappings), prefix_map=dict(subconverter.bimap), meta=meta
         )
 

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -8,7 +8,6 @@ import logging as _logging
 import os.path
 import typing
 from collections import ChainMap, Counter
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Optional, TextIO, Tuple, Union, cast
 from xml.dom import Node, minidom
@@ -978,8 +977,7 @@ def split_dataframe(
     )
 
 
-@dataclass(frozen=True, eq=True)
-class SSSOMSplitTriple:
+class SSSOMSplitTriple(NamedTuple):
     subject_prefix: str
     object_prefix: str
     relation: str

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -286,7 +286,7 @@ class TestParse(unittest.TestCase):
         self.assertEqual(
             sum([len(msdf.df) for msdf in splitted.values()]),
             len(msdf.df),
-            f"{self.df_file} did not include all mappings when being split."
+            f"{self.df_file} did not include all mappings when being split.",
         )
 
     # * "mapping_justification" is no longer multivalued.

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -28,6 +28,7 @@ from sssom.parsers import (
     from_sssom_json,
     from_sssom_rdf,
     parse_sssom_table,
+    split_dataframe,
 )
 from sssom.util import MappingSetDataFrame, sort_df_rows_columns
 from sssom.writers import WRITER_FUNCTIONS, write_table
@@ -271,6 +272,21 @@ class TestParse(unittest.TestCase):
             len(msdf.df),
             141,
             f"{self.json_file} has the wrong number of mappings.",
+        )
+
+    def test_split_msdf(self):
+        """Test splitting a mapping set dataframe"""
+        msdf = from_sssom_dataframe(df=self.df, prefix_map=self.df_converter, meta=self.df_meta)
+        splitted = split_dataframe(msdf)
+        self.assertEqual(
+            len(splitted.keys()),
+            11,
+            f"{self.df_file} was split into the wrong number of files.",
+        )
+        self.assertEqual(
+            sum([len(msdf.df) for msdf in splitted.values()]),
+            len(msdf.df),
+            f"{self.df_file} did not include all mappings when being split."
         )
 
     # * "mapping_justification" is no longer multivalued.


### PR DESCRIPTION
There was too much iteration going on in `parsers.split_dataframe_by_prefix`-- for every combination of prefixes\*relations\*objects, the entire input dataframe was being iterated over. This was a lot of overhead, when it only needs to be gone through once.

This is basically the [same approach used in sssom-java](https://github.com/gouttegd/sssom-java/blob/main/cli/src/main/java/org/incenp/obofoundry/sssom/cli/SimpleCLI.java#L646-L670), but there is some more work being done to keep logging consistent with the previous approach. If there were no logging, the dataclass included here (which reduces repetition), would not be necessary.

In testing splitting `mondo.sssom.tsv` (a 25mb file), the time to split went from ~5 minutes to ~50 seconds. Nearly all of the time spent is on calling `parsers.from_sssom_dataframe`, which is slow but inevitable.

Fixes #607