### PR TITLE
Add flag to `write_rdf` for outputting triples

### DIFF
--- a/src/sssom/writers.py
+++ b/src/sssom/writers.py
@@ -57,8 +57,10 @@ OWL_EQUIV_OBJECTPROPERTY = "http://www.w3.org/2002/07/owl#equivalentProperty"
 SSSOM_NS = SSSOM_URI_PREFIX
 
 NO_TERM_REF = rdflib.URIRef("https://w3id.org/sssom/NoTermFound")
-NEGATED = rdflib.URIRef("https://w3id.org/sssom/predicate_modifier")
+PREDICATE_MODIFIER = rdflib.URIRef("https://w3id.org/sssom/predicate_modifier")
+OBJECT_NOT = rdflib.URIRef("https://w3id.org/sssom/NegatedPredicate")
 LITERAL_NOT = rdflib.Literal(PREDICATE_MODIFIER_NOT)
+NEGATED_NODES: set[rdflib.Node] = {OBJECT_NOT, LITERAL_NOT}
 
 # Writers
 
@@ -241,7 +243,9 @@ def _is_no_term_found(s: rdflib.Node, o: rdflib.Node) -> bool:
 
 
 def _is_negated(graph: rdflib.Graph, axiom: rdflib.Node) -> bool:
-    return any(obj == LITERAL_NOT for obj in graph.objects(subject=axiom, predicate=NEGATED))
+    return any(
+        obj in NEGATED_NODES for obj in graph.objects(subject=axiom, predicate=PREDICATE_MODIFIER)
+    )
 
 
 def to_owl_graph(msdf: MappingSetDataFrame) -> Graph:

--- a/src/sssom/writers.py
+++ b/src/sssom/writers.py
@@ -257,7 +257,8 @@ def to_owl_graph(msdf: MappingSetDataFrame) -> Graph:
     for _s, _p, o in graph.triples((None, URIRef(URI_SSSOM_MAPPINGS), None)):
         graph.add((o, URIRef(RDF_TYPE), OWL.Axiom))
 
-    _hydrate_axioms(graph)
+    # TODO consider making this not add negative or term not found
+    _hydrate_axioms(graph, add_negative=True, add_no_term_found=True)
 
     sparql_prefixes = """
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>

--- a/src/sssom/writers.py
+++ b/src/sssom/writers.py
@@ -120,7 +120,15 @@ def write_rdf(
     *,
     hydrate: bool = False,
 ) -> None:
-    """Write a mapping set dataframe to the file as RDF."""
+    """Write a mapping set dataframe to the file as RDF.
+
+    :param msdf: A mapping set dataframe
+    :param file: The path or file object to write to
+    :param serialisation: The RDF format to serialize to, see :data:`RDF_FORMATS`.
+        Defaults to turtle.
+    :param hydrate: If true, will add subject-predicate-objects directly representing
+        mappings. This is opt-in behavior.
+    """
     if serialisation is None:
         serialisation = SSSOM_DEFAULT_RDF_SERIALISATION
     elif serialisation not in RDF_FORMATS:

--- a/src/sssom/writers.py
+++ b/src/sssom/writers.py
@@ -236,7 +236,7 @@ def _hydrate_axioms(
 
 
 def _is_no_term_found(s: rdflib.Node, o: rdflib.Node) -> bool:
-    return s == NO_TERM_FOUND_URI or o == NO_TERM_FOUND_URI
+    return s == NO_TERM_REF or o == NO_TERM_REF
 
 
 def _is_negated(graph: rdflib.Graph, axiom: rdflib.Node) -> bool:

--- a/src/sssom/writers.py
+++ b/src/sssom/writers.py
@@ -32,7 +32,7 @@ from sssom_schema import slots
 
 from sssom.validators import check_all_prefixes_in_curie_map
 
-from .constants import CURIE_MAP, SCHEMA_YAML, SSSOM_URI_PREFIX, PathOrIO
+from .constants import CURIE_MAP, PREDICATE_MODIFIER_NOT, SCHEMA_YAML, SSSOM_URI_PREFIX, PathOrIO
 from .context import _load_sssom_context
 from .parsers import to_mapping_set_document
 from .util import (
@@ -58,6 +58,7 @@ SSSOM_NS = SSSOM_URI_PREFIX
 
 NO_TERM_REF = rdflib.URIRef("https://w3id.org/sssom/NoTermFound")
 NEGATED = rdflib.URIRef("https://w3id.org/sssom/predicate_modifier")
+LITERAL_NOT = rdflib.Literal(PREDICATE_MODIFIER_NOT)
 
 # Writers
 
@@ -240,9 +241,7 @@ def _is_no_term_found(s: rdflib.Node, o: rdflib.Node) -> bool:
 
 
 def _is_negated(graph: rdflib.Graph, axiom: rdflib.Node) -> bool:
-    return any(
-        obj == rdflib.Literal("NOT") for obj in graph.objects(subject=axiom, predicate=NEGATED)
-    )
+    return any(obj == LITERAL_NOT for obj in graph.objects(subject=axiom, predicate=NEGATED))
 
 
 def to_owl_graph(msdf: MappingSetDataFrame) -> Graph:

--- a/src/sssom/writers.py
+++ b/src/sssom/writers.py
@@ -2,7 +2,6 @@
 
 import json
 import logging as _logging
-import rdflib
 from contextlib import contextmanager
 from pathlib import Path
 from typing import (
@@ -20,6 +19,7 @@ from typing import (
 )
 
 import pandas as pd
+import rdflib
 import yaml
 from curies import Converter
 from deprecation import deprecated

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -161,7 +161,11 @@ class TestConvert(unittest.TestCase):
         msdf = MappingSetDataFrame(df, converter=converter)
         graph = to_rdf_graph(msdf, hydrate=False)
         self.assertIn("sssom", {p for p, _ in graph.namespaces()})
-        self.assert_not_ask(graph, "ASK { DOID:0050601 skos:exactMatch UMLS:C1863204 }")
+        self.assert_not_ask(
+            graph,
+            "ASK { DOID:0050601 skos:exactMatch UMLS:C1863204 }",
+            msg="hydration should not have occurred",
+        )
         self.assert_not_ask(graph, "ASK { mesh:C562684 skos:exactMatch HP:0003348 }")
         self.assert_not_ask(graph, "ASK { mesh:C563052 skos:exactMatch sssom:NoTermFound }")
         self.assert_not_ask(graph, "ASK { sssom:NoTermFound skos:exactMatch mesh:C564625 }")
@@ -195,4 +199,4 @@ class TestConvert(unittest.TestCase):
 
     def assert_not_ask(self, graph: rdflib.Graph, query: str, *, msg: str | None = None) -> None:
         """Assert that the query returns a false answer."""
-        self.assertTrue(graph.query(query).askAnswer, msg=msg)
+        self.assertFalse(graph.query(query).askAnswer, msg=msg)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,5 +1,7 @@
 """Tests for conversion utilities."""
 
+from __future__ import annotations
+
 import unittest
 
 import curies

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -4,9 +4,17 @@ import unittest
 
 import curies
 import pandas as pd
+import rdflib
 
 from sssom import MappingSetDataFrame
-from sssom.constants import OBJECT_ID, PREDICATE_ID, SEMAPV, SUBJECT_ID
+from sssom.constants import (
+    MAPPING_JUSTIFICATION,
+    OBJECT_ID,
+    PREDICATE_ID,
+    PREDICATE_MODIFIER,
+    SEMAPV,
+    SUBJECT_ID,
+)
 from sssom.parsers import parse_sssom_table
 from sssom.writers import to_json, to_owl_graph, to_rdf_graph
 from tests.constants import data_dir
@@ -109,24 +117,82 @@ class TestConvert(unittest.TestCase):
                 "skos:exactMatch",
                 "UMLS:C1863204",
                 SEMAPV.ManualMappingCuration.value,
-            )
+                "",
+            ),
+            (
+                "mesh:C562684",
+                "skos:exactMatch",
+                "HP:0003348",
+                SEMAPV.ManualMappingCuration.value,
+                "NOT",
+            ),
+            (
+                "mesh:C563052",
+                "skos:exactMatch",
+                "sssom:NoTermFound",
+                SEMAPV.ManualMappingCuration.value,
+                "",
+            ),
+            (
+                "sssom:NoTermFound",
+                "skos:exactMatch",
+                "mesh:C562684",
+                SEMAPV.ManualMappingCuration.value,
+                "",
+            ),
         ]
         columns = [
             SUBJECT_ID,
             PREDICATE_ID,
             OBJECT_ID,
-            SEMAPV.ManualMappingCuration.value,
+            MAPPING_JUSTIFICATION,
+            PREDICATE_MODIFIER,
         ]
         df = pd.DataFrame(rows, columns=columns)
         converter = curies.Converter.from_prefix_map(
             {
                 "DOID": "http://purl.obolibrary.org/obo/DOID_",
+                "HP": "http://purl.obolibrary.org/obo/HP_",
                 "UMLS": "https://uts.nlm.nih.gov/uts/umls/concept/",
+                "mesh": "http://id.nlm.nih.gov/mesh/",
+                "sssom": "https://w3id.org/sssom/",
             }
         )
         msdf = MappingSetDataFrame(df, converter=converter)
         graph = to_rdf_graph(msdf, hydrate=False)
-        self.assertFalse(graph.query("ASK { DOID:0050601 skos:exactMatch UMLS:C1863204 }"))
+        self.assertIn("sssom", {p for p, _ in graph.namespaces()})
+        self.assert_not_ask(graph, "ASK { DOID:0050601 skos:exactMatch UMLS:C1863204 }")
+        self.assert_not_ask(graph, "ASK { mesh:C562684 skos:exactMatch HP:0003348 }")
+        self.assert_not_ask(graph, "ASK { mesh:C563052 skos:exactMatch sssom:NoTermFound }")
+        self.assert_not_ask(graph, "ASK { sssom:NoTermFound skos:exactMatch mesh:C564625 }")
 
         graph = to_rdf_graph(msdf, hydrate=True)
-        self.assertTrue(graph.query("ASK { DOID:0050601 skos:exactMatch UMLS:C1863204 }"))
+        self.assertIn("sssom", {p for p, _ in graph.namespaces()})
+        self.assert_ask(
+            graph,
+            "ASK { DOID:0050601 skos:exactMatch UMLS:C1863204 }",
+            msg="regular triple should be hydrated",
+        )
+        self.assert_not_ask(
+            graph,
+            "ASK { mesh:C562684 skos:exactMatch HP:0003348 }",
+            msg="triple with NOT modifier should not be hydrated",
+        )
+        self.assert_not_ask(
+            graph,
+            "ASK { mesh:C563052 skos:exactMatch sssom:NoTermFound }",
+            msg="triple with NoTermFound as object should not be hydrated",
+        )
+        self.assert_not_ask(
+            graph,
+            "ASK { sssom:NoTermFound skos:exactMatch mesh:C564625 }",
+            msg="triple with NoTermFound as subject should not be hydrated",
+        )
+
+    def assert_ask(self, graph: rdflib.Graph, query: str, *, msg: str | None = None) -> None:
+        """Assert that the query returns a true answer."""
+        self.assertTrue(graph.query(query).askAnswer, msg=msg)
+
+    def assert_not_ask(self, graph: rdflib.Graph, query: str, *, msg: str | None = None) -> None:
+        """Assert that the query returns a false answer."""
+        self.assertTrue(graph.query(query).askAnswer, msg=msg)


### PR DESCRIPTION
Currently, the RDF exporter doesn't create actual triples, but just ones hidden inside axioms. This PR adds opt-in functionality to do that.

There is currently code that hydrates triples in the OWL export. This PR pulls that out into a reusable function. 

It then adds options for skipping triples where there's a NOT modifier and for which there's a `sssom:TermNotFound` in either the subject or object. These are both gated with separate flags. Existing functionality in the OWL exporter stays the same (for now) and the RDF export always will enable these filters.

There are tests for all possibilities.