### PR TITLE
Add function and CLI command for serving SSSOM from SPARQL

### DIFF
--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -62,7 +62,7 @@ from .util import (
     sort_df_rows_columns,
     to_mapping_set_dataframe,
 )
-from .writers import WRITER_FUNCTIONS, write_table
+from .writers import WRITER_FUNCTIONS, to_rdf_endpoint, write_table
 
 logging = _logging.getLogger(__name__)
 

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -816,5 +816,17 @@ def invert(
     write_table(msdf, output)
 
 
+@main.command(name="serve-rdf")
+@input_argument
+def serve_rdf(input: str) -> None:
+    """Serve the SSSOM file as an RDF SPARQL endpoint."""
+    import uvicorn
+    from rdflib_endpoint import SparqlEndpoint
+
+    msdf = parse_sssom_table(input)
+    app = to_rdf_endpoint(msdf)
+    uvicorn.run(app)
+
+
 if __name__ == "__main__":
     main()

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -818,14 +818,15 @@ def invert(
 
 @main.command(name="serve-rdf")
 @input_argument
-def serve_rdf(input: str) -> None:
+@click.option("--host", default="127.0.0.1")
+@click.option("--port", type=int, default=8000)
+def serve_rdf(input: str, host: str, port: int) -> None:
     """Serve the SSSOM file as an RDF SPARQL endpoint."""
     import uvicorn
-    from rdflib_endpoint import SparqlEndpoint
 
     msdf = parse_sssom_table(input)
-    app = to_rdf_endpoint(msdf)
-    uvicorn.run(app)
+    app = to_rdf_endpoint(msdf, host=host, port=port)
+    uvicorn.run(app, host=host, port=port)
 
 
 if __name__ == "__main__":

--- a/src/sssom/writers.py
+++ b/src/sssom/writers.py
@@ -1,10 +1,13 @@
 """Serialization functions for SSSOM."""
 
+from __future__ import annotations
+
 import json
 import logging as _logging
 from contextlib import contextmanager
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Collection,
@@ -43,6 +46,9 @@ from .util import (
     invert_mappings,
     sort_df_rows_columns,
 )
+
+if TYPE_CHECKING:
+    import rdflib_endpoint
 
 logging = _logging.getLogger(__name__)
 
@@ -317,6 +323,41 @@ def to_rdf_graph(msdf: MappingSetDataFrame) -> Graph:
         prefix_map=msdf.converter.bimap,
     )
     return cast(Graph, graph)
+
+
+def to_rdf_endpoint(msdf: MappingSetDataFrame) -> rdflib_endpoint.SparqlEndpoint:
+    """Get a FastAPI app that serves the mappings from a SPARQL endpoint."""
+    from rdflib_endpoint import SparqlEndpoint
+
+    graph = to_rdf_graph(msdf)
+    app = SparqlEndpoint(
+        graph=graph,
+        cors_enabled=True,
+        title=f"SSSOM SPARQL Endpoint for {msdf.metadata['mapping_set_id']}",
+        description=msdf.metadata.get("mapping_set_description"),
+        example_query="""\
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+            PREFIX owl: <http://www.w3.org/2002/07/owl#>
+            PREFIX sssom: <https://w3id.org/sssom/>
+            PREFIX obo: <http://purl.obolibrary.org/obo/>
+            PREFIX semapv: <https://w3id.org/semapv/vocab/>
+            PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+            PREFIX pav: <http://purl.org/pav/>
+            PREFIX orcid: <https://orcid.org/>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+            SELECT ?s ?p ?o ?justification ?ap ?ao {
+              [] a owl:Axiom ;
+                owl:annotatedSource ?s ;
+                owl:annotatedProperty ?p ;
+                owl:annotatedTarget ?o ;
+                sssom:mapping_justification ?justification ;
+                ?ap ?ao .
+            }
+            LIMIT 50
+        """,
+    )
+    return app
 
 
 def to_fhir_json(msdf: MappingSetDataFrame) -> Dict[str, Any]:


### PR DESCRIPTION
This PR builds on @vemonet's https://github.com/vemonet/rdflib-endpoint, which turns an `rdflib.Graph` into a FastAPI app that runs a SPARQL endpoint and has a minimal web-based UI.

```console
$ sssom serve-rdf https://w3id.org/biopragmatics/biomappings/sssom/biomappings.sssom.tsv
```

You can pass `--host` and `--port` to tell it where to serve locally.