### PR TITLE
Cleanup docs

### DIFF
--- a/docs/cli_usage.rst
+++ b/docs/cli_usage.rst
@@ -8,7 +8,7 @@ The main one is `convert`
 .. code-block:: bash
 
     sssom convert -i tests/data/basic.tsv -o basic.ttl
-    
+
 .. click:: sssom.cli:main
     :prog: sssom
     :nested: full

--- a/docs/developer_docs/api.rst
+++ b/docs/developer_docs/api.rst
@@ -7,17 +7,16 @@ Datamodel
 Top-level Document object
 
 .. automodule:: sssom.sssom_document
-   :members:
-   :inherited-members:
-   :show-inheritance:
+    :members:
+    :inherited-members:
+    :show-inheritance:
 
 A Document holds a MappingSet which is a collection of mappings
 
 .. automodule:: sssom.sssom_datamodel
-   :members:
-   :inherited-members:
-   :show-inheritance:
-
+    :members:
+    :inherited-members:
+    :show-inheritance:
 
 I/O
 ---
@@ -25,10 +24,9 @@ I/O
 Conversion between TSV/pandas, internal datamodel and RDF
 
 .. automodule:: sssom.io
-   :members:
-   :inherited-members:
-   :show-inheritance:
-      
+    :members:
+    :inherited-members:
+    :show-inheritance:
 
 Utils
 -----
@@ -36,7 +34,6 @@ Utils
 Utils - currently boomer-specific
 
 .. automodule:: sssom.util
-   :members:
-   :inherited-members:
-   :show-inheritance:
-      
+    :members:
+    :inherited-members:
+    :show-inheritance:

--- a/docs/developer_docs/modules.rst
+++ b/docs/developer_docs/modules.rst
@@ -1,9 +1,9 @@
 Technical Documentation
-========
+=======================
 
 .. toctree::
-   :maxdepth: 4
+    :maxdepth: 4
 
-   api
-   sssom
-   sphinx
+    api
+    sssom
+    sphinx

--- a/docs/developer_docs/sphinx.rst
+++ b/docs/developer_docs/sphinx.rst
@@ -10,12 +10,12 @@ Using your terminal, ``cd`` to the 'docs' directory within the project.
 New page
 --------
 
-If you need to add a new page create a new file in this directory (docs/*filename*.rst). Update the content 
-within *filename*.rst to the documentation you wish to add using the guidance provided by the 
-`Sphinx <https://www.sphinx-doc.org/en/master/contents.html>`_ web page.
+If you need to add a new page create a new file in this directory (docs/*filename*.rst). Update the
+content within *filename*.rst to the documentation you wish to add using the guidance provided by
+the `Sphinx <https://www.sphinx-doc.org/en/master/contents.html>`_ web page.
 
 Update and page deployment
------------
+--------------------------
 
-This is done automatically by GitHub Actions through a workflow as soon as the 
-pull request is merged to the ``master`` branch.
+This is done automatically by GitHub Actions through a workflow as soon as the pull request is
+merged to the ``master`` branch.

--- a/docs/developer_docs/sssom.rst
+++ b/docs/developer_docs/sssom.rst
@@ -5,92 +5,91 @@ sssom.cli module
 ----------------
 
 .. automodule:: sssom.cli
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.cliques module
 --------------------
 
 .. automodule:: sssom.cliques
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.context module
 --------------------
 
 .. automodule:: sssom.context
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.io module
 ---------------
 
 .. automodule:: sssom.io
-   :members:
-   :undoc-members:
-   :show-inheritance:
-   :noindex:
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :noindex:
 
 sssom.parsers module
 --------------------
 
 .. automodule:: sssom.parsers
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.sparql\_util module
 -------------------------
 
 .. automodule:: sssom.sparql_util
-   :members:
-   :undoc-members:
-   :show-inheritance:
-   :noindex:
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :noindex:
 
 sssom.sssom\_datamodel module
 -----------------------------
 
 .. automodule:: sssom.sssom_datamodel
-   :members:
-   :undoc-members:
-   :show-inheritance:
-   :noindex:
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :noindex:
 
 sssom.sssom\_document module
 ----------------------------
 
 .. automodule:: sssom.sssom_document
-   :members:
-   :undoc-members:
-   :show-inheritance:
-   :noindex:
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :noindex:
 
 sssom.util module
 -----------------
 
 .. automodule:: sssom.util
-   :members:
-   :undoc-members:
-   :show-inheritance:
-   :noindex:
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :noindex:
 
 sssom.writers module
 --------------------
 
 .. automodule:: sssom.writers
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 Module contents
 ---------------
 
 .. automodule:: sssom
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -2,18 +2,19 @@ Examples
 ========
 
 ``parse`` command
-------------------
+-----------------
 
-The ``parse`` command is a way to import a mapping file. In this example, the file `basic.tsv <https://github.com/mapping-commons/sssom-py/blob/master/tests/data/basic.tsv>`_
-will be parsed. The CLI command is as follows:
+The ``parse`` command is a way to import a mapping file. In this example, the file `basic.tsv
+<https://github.com/mapping-commons/sssom-py/blob/master/tests/data/basic.tsv>`_ will be parsed. The
+CLI command is as follows:
 
 .. code-block:: bash
 
     sssom parse basic.tsv
 
-This results in the contents of the file displayed on the terminal.
-If the result is needed to be exported into another tsv, an ``--output`` 
-parameter could be passed and the command will look like this:
+This results in the contents of the file displayed on the terminal. If the result is needed to be
+exported into another tsv, an ``--output`` parameter could be passed and the command will look like
+this:
 
 .. code-block:: bash
 
@@ -22,20 +23,18 @@ parameter could be passed and the command will look like this:
 ``convert`` command
 -------------------
 
-The ``convert`` command converts files from one format to another. In this example,
-we convert a tsv file into an owl format.
+The ``convert`` command converts files from one format to another. In this example, we convert a tsv
+file into an owl format.
 
 .. code-block:: bash
 
     sssom convert basic.tsv --output basic.owl --output-format owl
 
-
 ``diff`` command
--------------------
+----------------
 
 Mapping files can be compared and differences highlighted using the ``diff`` command.
 
 .. code-block:: bash
 
     sssom diff basic.tsv basic2.tsv -o diff_output.tsv
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,42 +1,39 @@
-.. sssom-py documentation master file, created by
-   sphinx-quickstart on Fri Aug 12 08:35:01 2022.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+..
+    sssom-py documentation master file, created by
+    sphinx-quickstart on Fri Aug 12 08:35:01 2022.
+    You can adapt this file completely to your liking, but it should at least
+    contain the root `toctree` directive.
 
 SSSOM Mapping Format Python Utilities
 =====================================
 
-SSSOM (Simple Standard for Sharing Ontology Mappings) is a TSV format
-for representing ontology mappings, or mappings between pairs of
-entities in general:
+SSSOM (Simple Standard for Sharing Ontology Mappings) is a TSV format for representing ontology
+mappings, or mappings between pairs of entities in general:
 
-GitHub: https://github.com/mapping-commons/sssom
-Documentation: https://mapping-commons.github.io/sssom/
-Publication: https://arxiv.org/abs/2112.07051
-Tutorials: https://mapping-commons.github.io/sssom/tutorial/
+GitHub: https://github.com/mapping-commons/sssom Documentation:
+https://mapping-commons.github.io/sssom/ Publication: https://arxiv.org/abs/2112.07051 Tutorials:
+https://mapping-commons.github.io/sssom/tutorial/
 
-sssom-py is a Python library and command line toolkit for working with
-SSSOM:
+sssom-py is a Python library and command line toolkit for working with SSSOM:
 
 GitHub: https://github.com/mapping-commons/sssom-py
-
 
 Contents
 --------
 
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents:
+    :maxdepth: 2
+    :caption: Contents:
 
-   installation
-   cli_usage
-   examples
-   sphinx
-   developer_docs/modules
+    installation
+    cli_usage
+    examples
+    sphinx
+    developer_docs/modules
 
 Indices and tables
 ==================
 
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+- :ref:`genindex`
+- :ref:`modindex`
+- :ref:`search`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,9 +10,10 @@ SSSOM Mapping Format Python Utilities
 SSSOM (Simple Standard for Sharing Ontology Mappings) is a TSV format for representing ontology
 mappings, or mappings between pairs of entities in general:
 
-GitHub: https://github.com/mapping-commons/sssom Documentation:
-https://mapping-commons.github.io/sssom/ Publication: https://arxiv.org/abs/2112.07051 Tutorials:
-https://mapping-commons.github.io/sssom/tutorial/
+- GitHub: https://github.com/mapping-commons/sssom
+- Documentation: https://mapping-commons.github.io/sssom/
+- Publication: https://arxiv.org/abs/2112.07051
+- Tutorials: https://mapping-commons.github.io/sssom/tutorial/
 
 sssom-py is a Python library and command line toolkit for working with SSSOM:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,22 +4,23 @@ Quick Install Guide
 Install Python
 --------------
 
-Get the latest version of Python at https://www.python.org/downloads/ or with your operating system’s package manager.
+Get the latest version of Python at https://www.python.org/downloads/ or with your operating
+system’s package manager.
 
-You can verify that Python is installed by typing ``python`` from your shell; you should see something like:
+You can verify that Python is installed by typing ``python`` from your shell; you should see
+something like:
 
 .. code-block:: bash
 
-    Python 3.9.7 (default, Sep 16 2021, 08:50:36) 
+    Python 3.9.7 (default, Sep 16 2021, 08:50:36)
     [Clang 10.0.0 ] :: Anaconda, Inc. on darwin
     Type "help", "copyright", "credits" or "license" for more information.
-    >>> 
-
+    >>>
 
 The installation for requires Python 3.7 or greater.
 
 Install SSSOM-Py for users
-----------------------
+--------------------------
 
 Install using ``pip``
 
@@ -27,10 +28,8 @@ Install using ``pip``
 
     pip install sssom
 
-
 Install SSSOM-Py for developers
----------------------------
-
+-------------------------------
 
 To build directly from source, first clone the GitHub repository,
 
@@ -39,19 +38,17 @@ To build directly from source, first clone the GitHub repository,
     git clone https://github.com/mapping-commons/sssom-py
     cd sssom-py
 
-
 Then install the necessary dependencies listed in ``setup.cfg``.
 
 .. code-block:: bash
 
     python setup.py install
 
-
-
-For convenience, make use of the ``venv`` module in Python 3 to create a lightweight virtual environment:
+For convenience, make use of the ``venv`` module in Python 3 to create a lightweight virtual
+environment:
 
 .. code-block:: bash
 
-   . environment.sh
+    . environment.sh
 
-   python setup.py install
+    python setup.py install

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -2,6 +2,6 @@ sssom
 =====
 
 .. toctree::
-   :maxdepth: 4
+    :maxdepth: 4
 
-   sssom
+    sssom

--- a/docs/sphinx.rst
+++ b/docs/sphinx.rst
@@ -10,12 +10,12 @@ Using your terminal, ``cd`` to the 'docs' directory within the project.
 New page
 --------
 
-If you need to add a new page create a new file in this directory (docs/*filename*.rst). Update the content 
-within *filename*.rst to the documentation you wish to add using the guidance provided by the 
-`Sphinx <https://www.sphinx-doc.org/en/master/contents.html>`_ web page.
+If you need to add a new page create a new file in this directory (docs/*filename*.rst). Update the
+content within *filename*.rst to the documentation you wish to add using the guidance provided by
+the `Sphinx <https://www.sphinx-doc.org/en/master/contents.html>`_ web page.
 
 Update and page deployment
------------
+--------------------------
 
-This is done automatically by GitHub Actions through a workflow as soon as the 
-pull request is merged to the ``master`` branch.
+This is done automatically by GitHub Actions through a workflow as soon as the pull request is
+merged to the ``master`` branch.

--- a/docs/sssom.rst
+++ b/docs/sssom.rst
@@ -8,126 +8,126 @@ sssom.cli module
 ----------------
 
 .. automodule:: sssom.cli
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.cliques module
 --------------------
 
 .. automodule:: sssom.cliques
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.cliquesummary module
 --------------------------
 
 .. automodule:: sssom.cliquesummary
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.constants module
 ----------------------
 
 .. automodule:: sssom.constants
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.context module
 --------------------
 
 .. automodule:: sssom.context
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.external\_context module
 ------------------------------
 
 .. automodule:: sssom.external_context
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.io module
 ---------------
 
 .. automodule:: sssom.io
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.parsers module
 --------------------
 
 .. automodule:: sssom.parsers
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.rdf\_util module
 ----------------------
 
 .. automodule:: sssom.rdf_util
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.sparql\_util module
 -------------------------
 
 .. automodule:: sssom.sparql_util
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.sssom\_document module
 ----------------------------
 
 .. automodule:: sssom.sssom_document
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.typehints module
 ----------------------
 
 .. automodule:: sssom.typehints
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.util module
 -----------------
 
 .. automodule:: sssom.util
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.validators module
 -----------------------
 
 .. automodule:: sssom.validators
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 sssom.writers module
 --------------------
 
 .. automodule:: sssom.writers
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 Module contents
 ---------------
 
 .. automodule:: sssom
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -1,15 +1,4 @@
-"""Command line interface for SSSOM.
-
-Why does this file exist, and why not put this in ``__main__``? You might be tempted to import things from ``__main__``
-later, but that will cause problems--the code will get executed twice:
-
-- When you run ``python3 -m sssom`` python will execute``__main__.py`` as a script. That means there won't be any
-  ``sssom.__main__`` in ``sys.modules``.
-- When you import __main__ it will get executed again (as a module) because
-  there's no ``sssom.__main__`` in ``sys.modules`` .
-
-.. seealso:: https://click.palletsprojects.com/en/8.0.x/setuptools/
-"""
+"""Command line interface for SSSOM."""
 
 from __future__ import annotations
 
@@ -159,11 +148,7 @@ def help(ctx: click.Context, subcommand: str) -> None:
 @output_option
 @output_format_option
 def convert(input: str, output: TextIO, output_format: str) -> None:
-    """Convert a file.
-
-    Example:
-        sssom convert my.sssom.tsv --output-format rdfxml --output my.sssom.owl
-    """  # noqa: DAR101
+    """Convert a file."""
     convert_file(input_path=input, output=output, output_format=output_format)
 
 
@@ -300,14 +285,19 @@ def dosql(query: str, inputs: List[str], output: TextIO) -> None:
     Each of the N inputs is assigned a table name df1, df2, ..., dfN
 
     Alternatively, the filenames can be used as table names - these are first stemmed
-    E.g. ~/dir/my.sssom.tsv becomes a table called 'my'
+    E.g. ``~/dir/my.sssom.tsv`` becomes a table called 'my'
 
     Example:
-        sssom dosql -Q "SELECT * FROM df1 WHERE confidence>0.5 ORDER BY confidence" my.sssom.tsv
+
+    .. code-block:: console
+
+        $ sssom dosql -Q "SELECT * FROM df1 WHERE confidence>0.5 ORDER BY confidence" my.sssom.tsv
 
     Example:
-        `sssom dosql -Q "SELECT file1.*,file2.object_id AS ext_object_id, file2.object_label AS ext_object_label \
-        FROM file1 INNER JOIN file2 WHERE file1.object_id = file2.subject_id" FROM file1.sssom.tsv file2.sssom.tsv`
+
+    .. code-block:: console
+    
+        $ sssom dosql -Q "SELECT file1.*,file2.object_id AS ext_object_id, file2.object_label AS ext_object_label FROM file1 INNER JOIN file2 WHERE file1.object_id = file2.subject_id" FROM file1.sssom.tsv file2.sssom.tsv
     """  # noqa: DAR101
     # should start with from_tsv and MOST should return write_sssom
     try:
@@ -532,17 +522,11 @@ def correlations(input: str, output: TextIO, transpose: bool, fields: Tuple[str,
     "-R",
     "--reconcile",
     default=False,
-    help="Boolean indicating the need for reconciliation of the SSSOM tsv file.",
+    help="If true, the deduplicate (i.e., remove redundant lower confidence mappings) and reconcile (if msdf contains a higher confidence _negative_ mapping, then remove lower confidence positive one. If confidence is the same, prefer HumanCurated. If both HumanCurated, prefer negative mapping)"
 )
 @output_option
 def merge(inputs: str, output: TextIO, reconcile: bool = False) -> None:
-    """Merge multiple MappingSetDataFrames into one .
-
-    if reconcile=True, then dedupe(remove redundant lower confidence mappings) and
-    reconcile (if msdf contains a higher confidence _negative_ mapping,
-    then remove lower confidence positive one. If confidence is the same,
-    prefer HumanCurated. If both HumanCurated, prefer negative mapping).
-    """  # noqa: DAR101
+    """Merge multiple MappingSetDataFrames into one."""  # noqa: DAR101
     msdfs = [parse_sssom_table(i) for i in inputs]
     merged_msdf = merge_msdf(*msdfs, reconcile=reconcile)
     write_table(merged_msdf, output)
@@ -570,7 +554,10 @@ def rewire(
     """Rewire an ontology using equivalent classes/properties from a mapping file.
 
     Example:
-        sssom rewire -I xml  -i tests/data/cob.owl -m tests/data/cob-to-external.tsv --precedence PR
+
+    .. code-block:: console
+
+        $ sssom rewire -I xml  -i tests/data/cob.owl -m tests/data/cob-to-external.tsv --precedence PR
 
     # noqa: DAR101
     """
@@ -591,13 +578,7 @@ def rewire(
 )
 @output_option
 def reconcile_prefixes(input: str, reconcile_prefix_file: Path, output: TextIO) -> None:
-    """
-    Reconcile prefix_map based on provided YAML file.
-
-    :param input: MappingSetDataFrame filename
-    :param reconcile_prefix_file: YAML file containing the prefix reconcilation rules.
-    :param output: Target file path.
-    """
+    """Reconcile prefix_map based on provided YAML file."""
     msdf = parse_sssom_table(input)
     with open(reconcile_prefix_file, "rb") as rp_file:
         rp_dict = yaml.safe_load(rp_file)
@@ -621,44 +602,10 @@ def reconcile_prefixes(input: str, reconcile_prefix_file: Path, output: TextIO) 
     help="Sort rows by DataFrame column #1 (ascending).",
 )
 def sort(input: str, output: TextIO, by_columns: bool, by_rows: bool) -> None:
-    """
-    Sort DataFrame columns canonically.
-
-    :param input: SSSOM TSV file.
-    :param by_columns: Boolean flag to sort columns canonically.
-    :param by_rows: Boolean flag to sort rows by column #1 (ascending order).
-    :param output: SSSOM TSV file with columns sorted.
-    """
+    """Sort DataFrame columns canonically."""
     msdf = parse_sssom_table(input)
     msdf.df = sort_df_rows_columns(msdf.df, by_columns, by_rows)
     write_table(msdf, output)
-
-
-# @main.command()
-# @input_argument
-# @click.option(
-#     "-P",
-#     "--prefix",
-#     multiple=True,
-#     help="Prefixes that need to be filtered.",
-# )
-# @click.option(
-#     "-D",
-#     "--predicate",
-#     multiple=True,
-#     help="Predicates that need to be filtered.",
-# )
-# @output_option
-# def filter(input: str, output: TextIO, prefix: tuple, predicate: tuple):
-#     """Filter mapping file based on prefix and predicates provided.
-
-#     :param input: Input mapping file (tsv)
-#     :param output: SSSOM TSV file.
-#     :param prefix: Prefixes to be retained.
-#     :param predicate: Predicates to be retained.
-#     """
-#     filtered_msdf = filter_file(input=input, prefix=prefix, predicate=predicate)
-#     write_table(msdf=filtered_msdf, file=output)
 
 
 P = ParamSpec("P")
@@ -719,19 +666,12 @@ def filter(input: str, output: TextIO, **kwargs: Any) -> None:
     "--replace-multivalued",
     default=False,
     type=bool,
-    help="Multivalued slots should be replaced or not. [default: False]",
+    show_default=True,
+    help="Multivalued slots should be replaced or not.",
 )
 @dynamically_generate_sssom_options(SSSOM_SV_OBJECT.mapping_set_slots)
 def annotate(input: str, output: TextIO, replace_multivalued: bool, **kwargs: Any) -> None:
-    """Annotate metadata of a mapping set.
-
-    :param input: Input path of the SSSOM tsv file.
-    :param output: Output location.
-    :param replace_multivalued: Multivalued slots should be
-        replaced or not, defaults to False
-    :param kwargs: Options provided by user
-        which are added to the metadata (e.g.: --mapping_set_id http://example.org/abcd)
-    """
+    """Annotate metadata of a mapping set."""
     annotate_file(input=input, output=output, replace_multivalued=replace_multivalued, **kwargs)
 
 
@@ -744,12 +684,7 @@ def annotate(input: str, output: TextIO, replace_multivalued: bool, **kwargs: An
 )
 @output_option
 def remove(input: str, output: TextIO, remove_map: str) -> None:
-    """Remove mappings from an input mapping.
-
-    :param input: Input SSSOM tsv file.
-    :param output: Output path.
-    :param remove_map: Mapping to be removed.
-    """
+    """Remove mappings from an input mapping."""
     input_msdf = parse_sssom_table(input)
     remove_msdf = parse_sssom_table(remove_map)
     input_msdf.remove_mappings(remove_msdf)

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -275,30 +275,25 @@ def dedupe(input: str, output: TextIO) -> None:
     write_table(msdf_out, output)
 
 
-@main.command()
+@main.command(
+    help="""\
+Each of the N inputs is assigned a table name df1, df2, ..., dfN
+
+Alternatively, the filenames can be used as table names - these are first stemmed
+E.g. ``~/dir/my.sssom.tsv`` becomes a table called 'my'
+
+Examples:
+
+$ sssom dosql -Q "SELECT * FROM df1 WHERE confidence>0.5 ORDER BY confidence" my.sssom.tsv
+
+$ sssom dosql -Q "SELECT file1.*,file2.object_id AS ext_object_id, file2.object_label AS ext_object_label FROM file1 INNER JOIN file2 WHERE file1.object_id = file2.subject_id" FROM file1.sssom.tsv file2.sssom.tsv
+"""
+)
 @click.option("-Q", "--query", help='SQL query. Use "df" as table name.')
 @click.argument("inputs", nargs=-1)
 @output_option
 def dosql(query: str, inputs: List[str], output: TextIO) -> None:
-    """Run a SQL query over one or more SSSOM files.
-
-    Each of the N inputs is assigned a table name df1, df2, ..., dfN
-
-    Alternatively, the filenames can be used as table names - these are first stemmed
-    E.g. ``~/dir/my.sssom.tsv`` becomes a table called 'my'
-
-    Example
-
-    .. code-block:: console
-
-        $ sssom dosql -Q "SELECT * FROM df1 WHERE confidence>0.5 ORDER BY confidence" my.sssom.tsv
-
-    Example
-
-    .. code-block:: console
-
-        $ sssom dosql -Q "SELECT file1.*,file2.object_id AS ext_object_id, file2.object_label AS ext_object_label FROM file1 INNER JOIN file2 WHERE file1.object_id = file2.subject_id" FROM file1.sssom.tsv file2.sssom.tsv
-    """  # noqa: DAR101
+    """Run a SQL query over one or more SSSOM files."""
     # should start with from_tsv and MOST should return write_sssom
     try:
         run_sql_query(query=query, inputs=inputs, output=output)
@@ -532,7 +527,13 @@ def merge(inputs: str, output: TextIO, reconcile: bool = False) -> None:
     write_table(merged_msdf, output)
 
 
-@main.command()
+@main.command(
+    help="""\
+Example:
+
+$ sssom rewire -I xml  -i tests/data/cob.owl -m tests/data/cob-to-external.tsv --precedence PR
+"""
+)
 @input_argument
 @click.option("-m", "--mapping-file", help="Path to SSSOM file.")
 @click.option("-I", "--input-format", default="turtle", help="Ontology input format.")
@@ -551,16 +552,7 @@ def rewire(
     input_format: str,
     output_format: str,
 ) -> None:
-    """Rewire an ontology using equivalent classes/properties from a mapping file.
-
-    Example
-
-    .. code-block:: console
-
-        $ sssom rewire -I xml  -i tests/data/cob.owl -m tests/data/cob-to-external.tsv --precedence PR
-
-    # noqa: DAR101
-    """
+    """Rewire an ontology using equivalent classes/properties from a mapping file."""
     msdf = parse_sssom_table(mapping_file)
     g = Graph()
     g.parse(input, format=input_format)

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -296,7 +296,7 @@ def dosql(query: str, inputs: List[str], output: TextIO) -> None:
     Example:
 
     .. code-block:: console
-    
+
         $ sssom dosql -Q "SELECT file1.*,file2.object_id AS ext_object_id, file2.object_label AS ext_object_label FROM file1 INNER JOIN file2 WHERE file1.object_id = file2.subject_id" FROM file1.sssom.tsv file2.sssom.tsv
     """  # noqa: DAR101
     # should start with from_tsv and MOST should return write_sssom
@@ -522,7 +522,7 @@ def correlations(input: str, output: TextIO, transpose: bool, fields: Tuple[str,
     "-R",
     "--reconcile",
     default=False,
-    help="If true, the deduplicate (i.e., remove redundant lower confidence mappings) and reconcile (if msdf contains a higher confidence _negative_ mapping, then remove lower confidence positive one. If confidence is the same, prefer HumanCurated. If both HumanCurated, prefer negative mapping)"
+    help="If true, the deduplicate (i.e., remove redundant lower confidence mappings) and reconcile (if msdf contains a higher confidence _negative_ mapping, then remove lower confidence positive one. If confidence is the same, prefer HumanCurated. If both HumanCurated, prefer negative mapping)",
 )
 @output_option
 def merge(inputs: str, output: TextIO, reconcile: bool = False) -> None:

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -287,13 +287,13 @@ def dosql(query: str, inputs: List[str], output: TextIO) -> None:
     Alternatively, the filenames can be used as table names - these are first stemmed
     E.g. ``~/dir/my.sssom.tsv`` becomes a table called 'my'
 
-    Example:
+    Example
 
     .. code-block:: console
 
         $ sssom dosql -Q "SELECT * FROM df1 WHERE confidence>0.5 ORDER BY confidence" my.sssom.tsv
 
-    Example:
+    Example
 
     .. code-block:: console
 
@@ -553,7 +553,7 @@ def rewire(
 ) -> None:
     """Rewire an ontology using equivalent classes/properties from a mapping file.
 
-    Example:
+    Example
 
     .. code-block:: console
 

--- a/src/sssom/cliques.py
+++ b/src/sssom/cliques.py
@@ -79,10 +79,12 @@ def split_into_cliques(msdf: MappingSetDataFrame) -> List[MappingSetDocument]:
     """Split a MappingSetDataFrames documents corresponding to a strongly connected components of the associated graph.
 
     :param msdf: MappingSetDataFrame object
+
+    :returns: List of MappingSetDocument objects
+
     :raises TypeError: If Mappings is not of type List
     :raises TypeError: If each mapping is not of type Mapping
     :raises TypeError: If Mappings is not of type List
-    :return: List of MappingSetDocument objects
     """
     import networkx as nx
 
@@ -131,7 +133,8 @@ def get_src(src: Optional[str], curie: str) -> str:
 
     :param src: Source
     :param curie: CURIE
-    :return: Source
+
+    :returns: Source
     """
     if src is None:
         return curie.split(":")[0]

--- a/src/sssom/cliquesummary.py
+++ b/src/sssom/cliquesummary.py
@@ -1,10 +1,6 @@
-"""
-Auto generated from cliquesummary.yaml by pythongen.py version: 0.9.0
-Generation date: 2021-08-19 18:02
-Schema: sssom-cliquesummary
+"""Auto generated from cliquesummary.yaml by pythongen.py version: 0.9.0 Generation date: 2021-08-19 18:02 Schema: sssom-cliquesummary
 
-id: https://w3id.org/sssom/schema/cliquesummary/
-description: Data dictionary for clique summaries
+id: https://w3id.org/sssom/schema/cliquesummary/ description: Data dictionary for clique summaries
 license: https://creativecommons.org/publicdomain/zero/1.0/
 """
 
@@ -198,9 +194,7 @@ class CliqueId(extended_str):
 
 @dataclass
 class Clique(YAMLRoot):
-    """
-    A clique
-    """
+    """A clique"""
 
     _inherited_slots: ClassVar[List[str]] = []
 

--- a/src/sssom/constants.py
+++ b/src/sssom/constants.py
@@ -218,11 +218,10 @@ DEFAULT_VALIDATION_TYPES: List[SchemaValidationType] = [
 
 
 class SSSOMSchemaView(object):
-    """
-    SchemaView class from linkml which is instantiated when necessary.
+    """SchemaView class from linkml which is instantiated when necessary.
 
-    Reason for this: https://github.com/mapping-commons/sssom-py/issues/322
-    Implemented via PR: https://github.com/mapping-commons/sssom-py/pull/323
+    Reason for this: https://github.com/mapping-commons/sssom-py/issues/322 Implemented via PR:
+    https://github.com/mapping-commons/sssom-py/pull/323
     """
 
     instance: ClassVar[SSSOMSchemaView]
@@ -313,14 +312,11 @@ def generate_mapping_set_id() -> str:
 def get_default_metadata() -> MetadataType:
     """Get default metadata.
 
-    :returns: A metadata dictionary containing a default
-        license with value :data:`DEFAULT_LICENSE` and an
-        auto-generated mapping set ID
+    :returns: A metadata dictionary containing a default license with value :data:`DEFAULT_LICENSE`
+        and an auto-generated mapping set ID
 
-    If you want to combine some metadata you loaded
-    but ensure that there is also default metadata,
-    the best tool is :class:`collections.ChainMap`.
-    You can do:
+    If you want to combine some metadata you loaded but ensure that there is also default metadata,
+    the best tool is :class:`collections.ChainMap`. You can do:
 
     .. code-block:: python
 
@@ -329,10 +325,7 @@ def get_default_metadata() -> MetadataType:
         from collections import ChainMap
         from sssom import get_default_metadata
 
-        metadata = dict(ChainMap(
-            my_metadata or {},
-            get_default_metadata()
-        ))
+        metadata = dict(ChainMap(my_metadata or {}, get_default_metadata()))
     """
     return {
         "mapping_set_id": generate_mapping_set_id(),

--- a/src/sssom/context.py
+++ b/src/sssom/context.py
@@ -76,20 +76,19 @@ def ensure_converter(prefix_map: ConverterHint = None, *, use_defaults: bool = T
 
     :param prefix_map: One of the following:
 
-        1. An empty dictionary or ``None``. This results in using the default
-           extended prefix map (currently based on a variant of the Bioregistry)
-           if ``use_defaults`` is set to true, otherwise just the builtin prefix
-           map including the prefixes in :data:`SSSOM_BUILT_IN_PREFIXES`
-        2. A non-empty dictionary representing a prefix map. This is loaded as a
-           converter with :meth:`Converter.from_prefix_map`. It is chained
-           behind the builtin prefix map to ensure none of the
-           :data:`SSSOM_BUILT_IN_PREFIXES` are overwritten with non-default values
-        3. A pre-instantiated :class:`curies.Converter`. Similarly to a prefix
-           map passed into this function, this is chained behind the builtin prefix
-           map
-    :param use_defaults: If an empty dictionary or None is passed to this function,
-        this parameter chooses if the extended prefix map (currently based on a
-        variant of the Bioregistry) gets loaded.
+        1. An empty dictionary or ``None``. This results in using the default extended prefix map
+           (currently based on a variant of the Bioregistry) if ``use_defaults`` is set to true,
+           otherwise just the builtin prefix map including the prefixes in
+           :data:`SSSOM_BUILT_IN_PREFIXES`
+        2. A non-empty dictionary representing a prefix map. This is loaded as a converter with
+           :meth:`Converter.from_prefix_map`. It is chained behind the builtin prefix map to ensure
+           none of the :data:`SSSOM_BUILT_IN_PREFIXES` are overwritten with non-default values
+        3. A pre-instantiated :class:`curies.Converter`. Similarly to a prefix map passed into this
+           function, this is chained behind the builtin prefix map
+    :param use_defaults: If an empty dictionary or None is passed to this function, this parameter
+        chooses if the extended prefix map (currently based on a variant of the Bioregistry) gets
+        loaded.
+
     :returns: A re-usable converter
     """
     if not prefix_map:

--- a/src/sssom/io.py
+++ b/src/sssom/io.py
@@ -71,17 +71,21 @@ def parse_file(
 ) -> None:
     """Parse an SSSOM metadata file and write to a table.
 
-    :param input_path: The path to the input file in one of the legal formats, eg obographs, aligmentapi-xml
+    :param input_path: The path to the input file in one of the legal formats, eg obographs,
+        aligmentapi-xml
     :param output: The path to the output file.
     :param input_format: The string denoting the input format.
-    :param metadata_path: The path to a file containing the sssom metadata (including prefix_map)
-        to be used during parse.
-    :param prefix_map_mode: Defines whether the prefix map in the metadata should be extended or replaced with
-        the SSSOM default prefix map derived from the :mod:`bioregistry`.
-    :param clean_prefixes: If True (default), records with unknown prefixes are removed from the SSSOM file.
+    :param metadata_path: The path to a file containing the sssom metadata (including prefix_map) to
+        be used during parse.
+    :param prefix_map_mode: Defines whether the prefix map in the metadata should be extended or
+        replaced with the SSSOM default prefix map derived from the :mod:`bioregistry`.
+    :param clean_prefixes: If True (default), records with unknown prefixes are removed from the
+        SSSOM file.
     :param strict_clean_prefixes: If True (default), clean_prefixes() will be in strict mode.
-    :param embedded_mode:If True (default), the dataframe and metadata are exported in one file (tsv), else two separate files (tsv and yaml).
-    :param mapping_predicate_filter: Optional list of mapping predicates or filepath containing the same.
+    :param embedded_mode: If True (default), the dataframe and metadata are exported in one file
+        (tsv), else two separate files (tsv and yaml).
+    :param mapping_predicate_filter: Optional list of mapping predicates or filepath containing the
+        same.
     """
     raise_for_bad_path(input_path)
     converter, meta = _get_converter_and_metadata(
@@ -112,9 +116,11 @@ def validate_file(
 ) -> dict[SchemaValidationType, ValidationReport]:
     """Validate the incoming SSSOM TSV according to the SSSOM specification.
 
-    :param input_path: The path to the input file in one of the legal formats, eg obographs, aligmentapi-xml
+    :param input_path: The path to the input file in one of the legal formats, eg obographs,
+        aligmentapi-xml
     :param validation_types: A list of validation types to run.
     :param fail_on_error: Should an exception be raised on error of _any_ validator?
+
     :returns: A dictionary from validation types to validation reports
     """
     # Two things to check:
@@ -127,7 +133,8 @@ def validate_file(
 def split_file(input_path: str, output_directory: Union[str, Path]) -> None:
     """Split an SSSOM TSV by prefixes and relations.
 
-    :param  input_path: The path to the input file in one of the legal formats, eg obographs, aligmentapi-xml
+    :param input_path: The path to the input file in one of the legal formats, eg obographs,
+        aligmentapi-xml
     :param output_directory: The directory to which the split file should be exported.
     """
     raise_for_bad_path(input_path)
@@ -151,12 +158,12 @@ def get_metadata_and_prefix_map(
 def _get_converter_and_metadata(
     metadata_path: Union[None, str, Path] = None, *, prefix_map_mode: Optional[MergeMode] = None
 ) -> Tuple[Converter, MetadataType]:
-    """
-    Load SSSOM metadata from a YAML file, and then augment it with default prefixes.
+    """Load SSSOM metadata from a YAML file, and then augment it with default prefixes.
 
     :param metadata_path: The metadata file in YAML format
     :param prefix_map_mode: one of metadata_only, sssom_default_only, merged
-    :return: A converter and remaining metadata from the YAML file
+
+    :returns: A converter and remaining metadata from the YAML file
     """
     if metadata_path is None:
         return get_converter(), get_default_metadata()
@@ -184,12 +191,12 @@ def _merge_converter(
 
 
 def extract_iris(input: RecursivePathList, converter: Converter) -> List[str]:
-    """
-    Recursively extracts a list of IRIs from a string or file.
+    """Recursively extracts a list of IRIs from a string or file.
 
     :param input: CURIE OR list of CURIEs OR file path containing the same.
     :param converter: Prefix map of mapping set (possibly) containing custom prefix:IRI combination.
-    :return: A list of IRIs.
+
+    :returns: A list of IRIs.
     """
     if isinstance(input, (str, Path)) and os.path.isfile(input):
         pred_list = Path(input).read_text().splitlines()
@@ -264,20 +271,22 @@ def run_sql_query(
 
     Each of the N inputs is assigned a table name df1, df2, ..., dfN
 
-    Alternatively, the filenames can be used as table names - these are first stemmed
-    E.g. ~/dir/my.sssom.tsv becomes a table called 'my'
+    Alternatively, the filenames can be used as table names - these are first stemmed E.g.
+    ~/dir/my.sssom.tsv becomes a table called 'my'
 
     Example:
         sssom dosql -Q "SELECT * FROM df1 WHERE confidence>0.5 ORDER BY confidence" my.sssom.tsv
 
     Example:
-        `sssom dosql -Q "SELECT file1.*,file2.object_id AS ext_object_id, file2.object_label AS ext_object_label \
-        FROM file1 INNER JOIN file2 WHERE file1.object_id = file2.subject_id" FROM file1.sssom.tsv file2.sssom.tsv`
+        `sssom dosql -Q "SELECT file1.*,file2.object_id AS ext_object_id, file2.object_label AS
+        ext_object_label FROM file1 INNER JOIN file2 WHERE file1.object_id = file2.subject_id" FROM
+        file1.sssom.tsv file2.sssom.tsv`
 
     :param query: Query to be executed over a pandas DataFrame (msdf.df).
     :param inputs: Input files that form the source tables for query.
     :param output: Output.
-    :return: Filtered MappingSetDataFrame object.
+
+    :returns: Filtered MappingSetDataFrame object.
     """
     from pansql import sqldf
 
@@ -306,18 +315,21 @@ def run_sql_query(
 def filter_file(input: str, output: Optional[TextIO] = None, **kwargs: Any) -> MappingSetDataFrame:
     """Filter a dataframe by dynamically generating queries based on user input.
 
-    e.g. sssom filter --subject_id x:% --subject_id y:% --object_id y:% --object_id z:% tests/data/basic.tsv
+    e.g. sssom filter --subject_id x:% --subject_id y:% --object_id y:% --object_id z:%
+    tests/data/basic.tsv
 
     yields the query:
 
-    "SELECT * FROM df WHERE (subject_id LIKE 'x:%'  OR subject_id LIKE 'y:%')
-     AND (object_id LIKE 'y:%'  OR object_id LIKE 'z:%') " and displays the output.
+    "SELECT * FROM df WHERE (subject_id LIKE 'x:%' OR subject_id LIKE 'y:%')
+        AND (object_id LIKE 'y:%' OR object_id LIKE 'z:%') " and displays the output.
 
     :param input: DataFrame to be queried over.
     :param output: Output location.
     :param kwargs: Filter options provided by user which generate queries (e.g.: --subject_id x:%).
+
+    :returns: Filtered MappingSetDataFrame object.
+
     :raises ValueError: If parameter provided is invalid.
-    :return: Filtered MappingSetDataFrame object.
     """
     params = {k: v for k, v in kwargs.items() if v}
     query = "SELECT * FROM df WHERE ("
@@ -356,11 +368,11 @@ def annotate_file(
 
     :param input: SSSOM tsv file to be queried over.
     :param output: Output location.
-    :param replace_multivalued: Multivalued slots should be
-        replaced or not, defaults to False
-    :param kwargs: Options provided by user
-        which are added to the metadata (e.g.: --mapping_set_id http://example.org/abcd)
-    :return: Annotated MappingSetDataFrame object.
+    :param replace_multivalued: Multivalued slots should be replaced or not, defaults to False
+    :param kwargs: Options provided by user which are added to the metadata (e.g. ``--mapping_set_id
+        http://example.org/abcd``)
+
+    :returns: Annotated MappingSetDataFrame object.
     """
     params = {k: v for k, v in kwargs.items() if v}
     are_params_slots(params)

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -84,9 +84,10 @@ logging = _logging.getLogger(__name__)
 def _open_input(p: PathOrIO) -> TextIO:
     """Transform a URL, a filepath (from pathlib), or a string (with file contents) to a StringIO object.
 
-    :param p:
-        A string representing a URL, a filepath, or file contents, or a Path object representing a filepath.
-    :return: A StringIO object containing the input data.
+    :param p: A string representing a URL, a filepath, or file contents, or a Path object
+        representing a filepath.
+
+    :returns: A StringIO object containing the input data.
     """
     # if we passed an IO object, return it back directly
     if not isinstance(p, (str, Path)):
@@ -127,7 +128,8 @@ def _read_pandas_and_metadata(
 
     :param file_path: The file path or stream to read
     :param sep: File separator for pandas
-    :return: A pair of a dataframe and metadata dictionary
+
+    :returns: A pair of a dataframe and metadata dictionary
     """
     if sep is None:
         sep = _infer_separator(file_path) or "\t"
@@ -178,7 +180,8 @@ def _infer_separator(file: PathOrIO) -> Optional[str]:
     r"""Infer the CSV separator from a file path or IO object.
 
     :param file: the file path
-    :return: the separator symbols as a string, e.g. '\t'
+
+    :returns: the separator symbols as a string, e.g. '\t'
     """
     extension = get_file_extension(file)
     if extension is None:
@@ -258,14 +261,11 @@ def _fail_in_strict_parsing_mode(is_valid_built_in_prefixes: bool, is_valid_meta
 
 
 def _get_converter_pop_replace_curie_map(sssom_metadata: MetadataType) -> curies.Converter:
-    """
-    Pop CURIE_MAP from sssom_metadata, process it, and restore it if it existed.
+    """Pop CURIE_MAP from sssom_metadata, process it, and restore it if it existed.
 
-    Args:
-        sssom_metadata: The metadata dictionary.
+    :param sssom_metadata: The metadata dictionary.
 
-    Returns:
-        Converter: A Converter object created from the CURIE_MAP.
+    :returns: A Converter object created from the CURIE_MAP.
     """
     curie_map = sssom_metadata.pop(CURIE_MAP, {})
 
@@ -290,23 +290,16 @@ def parse_sssom_table(
 ) -> MappingSetDataFrame:
     """Parse a SSSOM CSV or TSV file.
 
-    :param file_path:
-        A file path, URL, or I/O object that contains SSSOM encoded in TSV
-    :param prefix_map:
-        A prefix map or :class:`curies.Converter` used to validate prefixes,
-        CURIEs, and IRIs appearing in the SSSOM TSV
-    :param meta:
-        Additional document-level metadata for the SSSOM TSV document that is not
-        contained within the document itself. For example, this may come from a
-        companion SSSOM YAML file.
-    :param strict:
-        If true, will fail parsing for undefined prefixes, CURIEs, or IRIs
-    :param sep:
-        The seperator. If not given, inferred from file name
-    :param kwargs:
-        Additional keyword arguments (unhandled)
-    :returns:
-        A parsed dataframe wrapper object
+    :param file_path: A file path, URL, or I/O object that contains SSSOM encoded in TSV
+    :param prefix_map: A prefix map or :class:`curies.Converter` used to validate prefixes, CURIEs,
+        and IRIs appearing in the SSSOM TSV
+    :param meta: Additional document-level metadata for the SSSOM TSV document that is not contained
+        within the document itself. For example, this may come from a companion SSSOM YAML file.
+    :param strict: If true, will fail parsing for undefined prefixes, CURIEs, or IRIs
+    :param sep: The seperator. If not given, inferred from file name
+    :param kwargs: Additional keyword arguments (unhandled)
+
+    :returns: A parsed dataframe wrapper object
     """
     if kwargs:
         logging.warning("unhandled keyword arguments passed: %s", kwargs)
@@ -450,7 +443,8 @@ def parse_obographs_json(
     :param prefix_map: an optional prefix map
     :param meta: an optional dictionary of metadata elements
     :param mapping_predicates: an optional list of mapping predicates that should be extracted
-    :return: A SSSOM MappingSetDataFrame
+
+    :returns: A SSSOM MappingSetDataFrame
     """
     raise_for_bad_path(file_path)
 
@@ -502,8 +496,8 @@ def _get_mapping_dict(
 ) -> Dict[str, Any]:
     """Generate a mapping dictionary from a given row of data.
 
-    It also updates the 'bad_attrs' counter for keys that are not present
-    in the sssom_schema_object's mapping_slots.
+    It also updates the 'bad_attrs' counter for keys that are not present in the
+    sssom_schema_object's mapping_slots.
     """
     # Populate the mapping dictionary with key-value pairs from the row,
     # only if the value exists, is not NaN, and the key is in the schema's mapping slots.
@@ -556,7 +550,8 @@ def from_sssom_dataframe(
     :param df: A mappings dataframe
     :param prefix_map: A prefix map
     :param meta: A metadata dictionary
-    :return: MappingSetDataFrame
+
+    :returns: MappingSetDataFrame
     """
     converter = ensure_converter(prefix_map)
 
@@ -580,7 +575,8 @@ def from_sssom_rdf(
     :param g: the Graph (rdflib)
     :param prefix_map: A dictionary containing the prefix map, defaults to None
     :param meta: Potentially additional metadata, defaults to None
-    :return: MappingSetDataFrame object
+
+    :returns: MappingSetDataFrame object
     """
     converter = ensure_converter(prefix_map)
     mapping_set = cast(
@@ -623,7 +619,8 @@ def from_sssom_json(
     :param jsondoc: JSON document
     :param prefix_map: Prefix map
     :param meta: metadata used to augment the metadata existing in the mapping set
-    :return: MappingSetDataFrame object
+
+    :returns: MappingSetDataFrame object
     """
     converter = ensure_converter(prefix_map)
 
@@ -660,8 +657,11 @@ def from_alignment_minidom(
     :param prefix_map: A prefix map
     :param meta: Optional meta data
     :param mapping_predicates: Optional list of mapping predicates to extract
-    :return: MappingSetDocument
-    :raises ValueError: for alignment format: xml element said, but not set to yes. Only XML is supported!
+
+    :returns: MappingSetDocument
+
+    :raises ValueError: for alignment format: xml element said, but not set to yes. Only XML is
+        supported!
     """
     converter = ensure_converter(prefix_map)
     ms = _init_mapping_set(meta)
@@ -719,10 +719,13 @@ def from_obographs(
 
     :param jsondoc: The JSON object representing the ontology in obographs format
     :param prefix_map: The prefix map to be used
-    :param meta: Any additional metadata that needs to be added to the resulting SSSOM data frame, defaults to None
+    :param meta: Any additional metadata that needs to be added to the resulting SSSOM data frame,
+        defaults to None
     :param mapping_predicates: Optional list of mapping predicates to extract
+
+    :returns: An SSSOM data frame (MappingSetDataFrame)
+
     :raises Exception: When there is no CURIE
-    :return: An SSSOM data frame (MappingSetDataFrame)
     """
     converter = ensure_converter(prefix_map)
     ms = _init_mapping_set(meta)
@@ -848,8 +851,10 @@ def get_parsing_function(
 
     :param input_format: File format
     :param filename: Filename
+
+    :returns: Appropriate 'read' function
+
     :raises ValueError: Unknown file format
-    :return: Appropriate 'read' function
     """
     if input_format is None:
         input_format = get_file_extension(filename) or "tsv"
@@ -977,8 +982,10 @@ def split_dataframe(
     """Group the mapping set dataframe into several subdataframes by prefix.
 
     :param msdf: MappingSetDataFrame object
+
+    :returns: Mapping object
+
     :raises RuntimeError: DataFrame object within MappingSetDataFrame is None
-    :return: Mapping object
     """
     subject_prefixes = set(msdf.df[SUBJECT_ID].str.split(":", n=1, expand=True)[0])
     object_prefixes = set(msdf.df[OBJECT_ID].str.split(":", n=1, expand=True)[0])
@@ -1008,7 +1015,8 @@ def split_dataframe_by_prefix(
     :param subject_prefixes: a list of prefixes pertaining to the subject
     :param object_prefixes: a list of prefixes pertaining to the object
     :param relations: a list of relations of interest
-    :return: a dict of SSSOM data frame names to MappingSetDataFrame
+
+    :returns: a dict of SSSOM data frame names to MappingSetDataFrame
     """
     df = msdf.df
     meta = msdf.metadata
@@ -1042,11 +1050,11 @@ def split_dataframe_by_prefix(
 
 
 def _ensure_valid_mapping_from_dict(mdict: Dict[str, Any]) -> Optional[Mapping]:
-    """
-    Return a valid mapping object if it can be constructed, else None.
+    """Return a valid mapping object if it can be constructed, else None.
 
     :param mdict: A dictionary containing the mapping metadata.
-    :return: A valid Mapping object, or None.
+
+    :returns: A valid Mapping object, or None.
     """
     mdict.setdefault(MAPPING_JUSTIFICATION, MAPPING_JUSTIFICATION_UNSPECIFIED)
 
@@ -1075,13 +1083,11 @@ def _ensure_valid_mapping_from_dict(mdict: Dict[str, Any]) -> Optional[Mapping]:
 def _add_valid_mapping_to_list(
     mdict: Dict[str, Any], mlist: List[Mapping], *, flip_superclass_assertions: bool = False
 ) -> None:
-    """
-    Validate the mapping and append to the list if valid.
+    """Validate the mapping and append to the list if valid.
 
-    Parameters:
-    - mdict (dict): A dictionary containing the mapping metadata.
-    - mlist (list): The list to which the valid mapping should be appended.
-    - flip_superclass_assertions (bool): an optional paramter that flips sssom:superClassOf to rdfs:subClassOf
+    Parameters: - mdict (dict): A dictionary containing the mapping metadata. - mlist (list): The
+    list to which the valid mapping should be appended. - flip_superclass_assertions (bool): an
+    optional paramter that flips sssom:superClassOf to rdfs:subClassOf
     """
     mapping = _ensure_valid_mapping_from_dict(mdict)
     if not mapping:

--- a/src/sssom/sssom_document.py
+++ b/src/sssom/sssom_document.py
@@ -13,16 +13,13 @@ __all__ = [
 
 @dataclass()
 class MappingSetDocument:
-    """
-    Represents a single SSSOM document.
+    """Represents a single SSSOM document.
 
     A document is simply a holder for a MappingSet object plus a CURIE map
     """
 
     mapping_set: MappingSet
-    """
-    The main part of the document: a set of mappings plus metadata
-    """
+    """The main part of the document: a set of mappings plus metadata"""
 
     converter: Converter
 

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -167,6 +167,7 @@ class MappingSetDataFrame:
         :param mapping_set: A mapping set
         :param converter: A prefix map or pre-instantiated converter. If none given, uses a default
             prefix map derived from the Bioregistry.
+
         :returns: A mapping set dataframe
         """
         doc = MappingSetDocument(converter=ensure_converter(converter), mapping_set=mapping_set)
@@ -248,9 +249,10 @@ class MappingSetDataFrame:
         """Merge two MappingSetDataframes.
 
         :param msdfs: Multiple/Single MappingSetDataFrame(s) to merge with self
-        :param inplace: If true, msdf2 is merged into the calling MappingSetDataFrame,
-                        if false, it simply return the merged data frame.
-        :return: Merged MappingSetDataFrame
+        :param inplace: If true, msdf2 is merged into the calling MappingSetDataFrame, if false, it
+            simply return the merged data frame.
+
+        :returns: Merged MappingSetDataFrame
         """
         msdf = merge_msdf(self, *msdfs)
         if inplace:
@@ -273,11 +275,11 @@ class MappingSetDataFrame:
         return description
 
     def clean_prefix_map(self, strict: bool = True) -> None:
-        """
-        Remove unused prefixes from the internal prefix map based on the internal dataframe.
+        """Remove unused prefixes from the internal prefix map based on the internal dataframe.
 
-        :param strict: Boolean if True, errors out if all prefixes in dataframe are not
-                       listed in the 'curie_map'.
+        :param strict: Boolean if True, errors out if all prefixes in dataframe are not listed in
+            the 'curie_map'.
+
         :raises ValueError: If prefixes absent in 'curie_map' and strict flag = True
         """
         prefixes_in_table = get_prefixes_used_in_table(self.df)
@@ -325,22 +327,19 @@ class MappingSetDataFrame:
     def propagate(self, fill_empty: bool = False) -> List[str]:
         """Propagate slot values from the set level down to individual records.
 
-        Propagation, as defined by the SSSOM specification, is the process by
-        which the values of so-called "propagatable slots" in the set metadata
-        are moved to the corresponding slots in each individual mapping
-        records.
+        Propagation, as defined by the SSSOM specification, is the process by which the values of
+        so-called "propagatable slots" in the set metadata are moved to the corresponding slots in
+        each individual mapping records.
 
-        Propagation of a slot is only allowed iff no individual records
-        already have a value for that slot.
+        Propagation of a slot is only allowed iff no individual records already have a value for
+        that slot.
 
-        :param fill_empty: If True, propagation of a slot is allowed even if
-                           some individual records already have a value for
-                           that slot. The set-level value will be propagated to
-                           all the records for which the slot is empty. Note
-                           that (1) this is not spec-compliant behaviour, and
-                           (2) this makes the operation non-reversible by a
-                           subsequent condensation.
-        :return: The list of slots that were effectively propagated.
+        :param fill_empty: If True, propagation of a slot is allowed even if some individual records
+            already have a value for that slot. The set-level value will be propagated to all the
+            records for which the slot is empty. Note that (1) this is not spec-compliant behaviour,
+            and (2) this makes the operation non-reversible by a subsequent condensation.
+
+        :returns: The list of slots that were effectively propagated.
         """
         schema = SSSOMSchemaView()
         propagated = []
@@ -371,16 +370,14 @@ class MappingSetDataFrame:
     def condense(self) -> List[str]:
         """Condense record-level slot values to the set whenever possible.
 
-        Condensation is the opposite of propagation. It is the process by
-        which the values of so-called "propagatable" slots found in individual
-        mapping records are moved to the corresponding slots in the set
-        metadata.
+        Condensation is the opposite of propagation. It is the process by which the values of
+        so-called "propagatable" slots found in individual mapping records are moved to the
+        corresponding slots in the set metadata.
 
-        Condensation of a slot is only allowed iff (1) all records have the
-        same value for that slot and (2) the slot does not already have a
-        different value in the set metadata.
+        Condensation of a slot is only allowed iff (1) all records have the same value for that slot
+        and (2) the slot does not already have a different value in the set metadata.
 
-        :return: The list of slots that were effectively condensed.
+        :returns: The list of slots that were effectively condensed.
         """
         schema = SSSOMSchemaView()
         condensed = []
@@ -418,23 +415,22 @@ class MappingSetDataFrame:
     def infer_cardinality(self, scope: Optional[List[str]] = None) -> None:
         """Infer cardinality values in the set.
 
-        This method will automatically fill the `mapping_cardinality` slot for
-        all records in the set, overwriting any pre-existing values.
+        This method will automatically fill the `mapping_cardinality` slot for all records in the
+        set, overwriting any pre-existing values.
 
-        See <https://mapping-commons.github.io/sssom/spec-model/#mapping-cardinality-and-cardinality-scope>
+        See
+        <https://mapping-commons.github.io/sssom/spec-model/#mapping-cardinality-and-cardinality-scope>
         for more information about cardinality computation,
-        <https://mapping-commons.github.io/sssom/spec-model/#literal-mappings>
-        for how to deal with literal mapping records, and
-        <https://mapping-commons.github.io/sssom/spec-model/#representing-unmapped-entities>
-        for how to deal with mapping records involving `sssom:NoTermFound`.
+        <https://mapping-commons.github.io/sssom/spec-model/#literal-mappings> for how to deal with
+        literal mapping records, and
+        <https://mapping-commons.github.io/sssom/spec-model/#representing-unmapped-entities> for how
+        to deal with mapping records involving `sssom:NoTermFound`.
 
-        :param scope: A list of slot names that defines the subset of the
-                      records in which cardinality will be computed. For
-                      example, with a scope of `['predicate_id']`, for any
-                      given record the cardinality will be computed relatively
-                      to the subset of records that have the same predicate.
-                      The default is an empty list, meaning that cardinality is
-                      computed relatively to the entire set of records.
+        :param scope: A list of slot names that defines the subset of the records in which
+            cardinality will be computed. For example, with a scope of `['predicate_id']`, for any
+            given record the cardinality will be computed relatively to the subset of records that
+            have the same predicate. The default is an empty list, meaning that cardinality is
+            computed relatively to the entire set of records.
         """
         if scope is None:
             scope = []
@@ -520,9 +516,13 @@ def _standardize_curie_or_iri(curie_or_iri: str, *, converter: Converter) -> str
     """Standardize a CURIE or IRI, returning the original if not possible.
 
     :param curie_or_iri: Either a string representing a CURIE or an IRI
-    :returns:
-        - If the string represents an IRI, tries to standardize it. If not possible, returns the original value
-        - If the string represents a CURIE, tries to standardize it. If not possible, returns the original value
+
+    :returns: A standardized CURIE or IRI
+
+        - If the string represents an IRI, tries to standardize it. If not possible, returns the
+          original value
+        - If the string represents a CURIE, tries to standardize it. If not possible, returns the
+          original value
         - Otherwise, return the original value
     """
     return converter.compress_or_standardize(curie_or_iri, passthrough=True)
@@ -577,8 +577,7 @@ def _standardize_metadata(
 
 @dataclass
 class EntityPair:
-    """
-    A tuple of entities.
+    """A tuple of entities.
 
     Note that (e1,e2) == (e2,e1)
     """
@@ -596,12 +595,11 @@ class EntityPair:
 
 @dataclass
 class MappingSetDiff:
-    """
-    Represents a difference between two mapping sets.
+    """Represents a difference between two mapping sets.
 
-    Currently this is limited to diffs at the level of entity-pairs.
-    For example, if file1 has A owl:equivalentClass B, and file2 has A skos:closeMatch B,
-    this is considered a mapping in common.
+    Currently this is limited to diffs at the level of entity-pairs. For example, if file1 has A
+    owl:equivalentClass B, and file2 has A skos:closeMatch B, this is considered a mapping in
+    common.
     """
 
     unique_tuples1: Set[EntityPair]
@@ -609,10 +607,7 @@ class MappingSetDiff:
     common_tuples: Set[EntityPair]
 
     combined_dataframe: pd.DataFrame
-    """
-    Dataframe that combines with left and right dataframes with information injected into
-    the comment column
-    """
+    """Dataframe that combines with left and right dataframes with information injected into the comment column"""
 
 
 def collapse(df: pd.DataFrame) -> pd.DataFrame:
@@ -625,7 +620,8 @@ def sort_sssom(df: pd.DataFrame) -> pd.DataFrame:
     """Sort SSSOM by columns.
 
     :param df: SSSOM DataFrame to be sorted.
-    :return: Sorted SSSOM DataFrame
+
+    :returns: Sorted SSSOM DataFrame
     """
     df.sort_values(by=sorted(df.columns), ascending=False, inplace=True)
     return df
@@ -636,7 +632,8 @@ def filter_redundant_rows(df: pd.DataFrame, ignore_predicate: bool = False) -> p
 
     :param df: Pandas DataFrame to filter
     :param ignore_predicate: If true, the predicate_id column is ignored, defaults to False
-    :return: Filtered pandas DataFrame
+
+    :returns: Filtered pandas DataFrame
     """
     # tie-breaker
     # create a 'sort' method and then replce the following line by sort()
@@ -724,21 +721,24 @@ def get_row_based_on_hierarchy(df: pd.DataFrame) -> pd.DataFrame:
     """Get row based on hierarchy of predicates.
 
     The hierarchy is as follows:
-    # owl:equivalentClass
-    # owl:equivalentProperty
-    # rdfs:subClassOf
-    # rdfs:subPropertyOf
-    # owl:sameAs
-    # skos:exactMatch
-    # skos:closeMatch
-    # skos:broadMatch
-    # skos:narrowMatch
-    # oboInOwl:hasDbXref
-    # skos:relatedMatch
-    # rdfs:seeAlso
+
+    1. owl:equivalentClass
+    2. owl:equivalentProperty
+    3. rdfs:subClassOf
+    4. rdfs:subPropertyOf
+    5. owl:sameAs
+    6. skos:exactMatch
+    7. skos:closeMatch
+    8. skos:broadMatch
+    9. skos:narrowMatch
+    10. oboInOwl:hasDbXref
+    11. skos:relatedMatch
+    12. rdfs:seeAlso
 
     :param df: Dataframe containing multiple predicates for same subject and object.
-    :return: Dataframe with a single row which ranks higher in the hierarchy.
+
+    :returns: Dataframe with a single row which ranks higher in the hierarchy.
+
     :raises KeyError: if no rows are available
     """
     for pred in PREDICATE_LIST:
@@ -754,7 +754,9 @@ def assign_default_confidence(
     """Assign :data:`numpy.nan` to confidence that are blank.
 
     :param df: SSSOM DataFrame
-    :return: A Tuple consisting of the original DataFrame and dataframe consisting of empty confidence values.
+
+    :returns: A Tuple consisting of the original DataFrame and dataframe consisting of empty
+        confidence values.
     """
     # Get rows having numpy.NaN as confidence
     if df is None:
@@ -772,20 +774,22 @@ def assign_default_confidence(
 def remove_unmatched(df: pd.DataFrame) -> pd.DataFrame:
     """Remove rows where no match is found.
 
-    TODO: https://github.com/OBOFoundry/SSSOM/issues/28
     :param df: Pandas DataFrame
-    :return: Pandas DataFrame with 'PREDICATE_ID' not 'noMatch'.
+
+    :returns: Pandas DataFrame with 'PREDICATE_ID' not 'noMatch'.
+
+    .. todo:: https://github.com/OBOFoundry/SSSOM/issues/28
     """
     return df[df[PREDICATE_ID] != "noMatch"]
 
 
 def create_entity(identifier: str, mappings: Dict[str, Any]) -> Uriorcurie:
-    """
-    Create an Entity object.
+    """Create an Entity object.
 
     :param identifier: Entity Id
     :param mappings: Mapping dictionary
-    :return: An Entity object
+
+    :returns: An Entity object
     """
     entity = Uriorcurie(identifier)  # Entity(id=identifier)
     for key, value in mappings.items():
@@ -823,9 +827,12 @@ def compare_dataframes(df1: pd.DataFrame, df2: pd.DataFrame) -> MappingSetDiff:
 
     :param df1: A mapping dataframe
     :param df2: A mapping dataframe
+
     :returns: A mapping set diff
 
-    .. warning:: currently does not discriminate between mappings with different predicates
+    .. warning::
+
+        currently does not discriminate between mappings with different predicates
     """
     mappings1 = group_mappings(df1.copy())
     mappings2 = group_mappings(df2.copy())
@@ -869,7 +876,8 @@ def add_default_confidence(df: pd.DataFrame, confidence: float = np.nan) -> pd.D
     If `confidence` column already exists, only fill in the None ones by 0.95.
 
     :param df: DataFrame whose `confidence` column needs to be filled.
-    :return: DataFrame with a complete `confidence` column.
+
+    :returns: DataFrame with a complete `confidence` column.
     """
     if CONFIDENCE in df.columns:
         df[CONFIDENCE] = df[CONFIDENCE].apply(lambda x: confidence * x if x is not None else x)
@@ -891,9 +899,11 @@ def dataframe_to_ptable(
     :param df: Pandas DataFrame
     :param inverse_factor: Multiplier to (1 - confidence), defaults to 0.5
     :param default_confidence: Default confidence to be assigned if absent.
+
+    :returns: List of rows
+
     :raises ValueError: Predicate value error
     :raises ValueError: Predicate type value error
-    :return: List of rows
     """
     if not inverse_factor:
         inverse_factor = 0.5
@@ -1008,11 +1018,11 @@ def merge_msdf(
     """Merge multiple MappingSetDataFrames into one.
 
     :param msdfs: A Tuple of MappingSetDataFrames to be merged
-    :param reconcile: If reconcile=True, then dedupe(remove redundant lower confidence mappings)
-        and reconcile (if msdf contains a higher confidence _negative_ mapping,
-        then remove lower confidence positive one. If confidence is the same,
-        prefer HumanCurated. If both HumanCurated, prefer negative mapping).
-        Defaults to True.
+    :param reconcile: If reconcile=True, then dedupe(remove redundant lower confidence mappings) and
+        reconcile (if msdf contains a higher confidence _negative_ mapping, then remove lower
+        confidence positive one. If confidence is the same, prefer HumanCurated. If both
+        HumanCurated, prefer negative mapping). Defaults to True.
+
     :returns: Merged MappingSetDataFrame.
     """
     # Inject metadata of msdf into df
@@ -1049,25 +1059,25 @@ def deal_with_negation(df: pd.DataFrame) -> pd.DataFrame:
     Rule: negative trumps positive if modulus of confidence values are equal.
 
     :param df: Merged Pandas DataFrame
-    :return: Pandas DataFrame with negations addressed
+
+    :returns: Pandas DataFrame with negations addressed
+
     :raises ValueError: If the dataframe is none after assigning default confidence
     """
-    """
-        1. Mappings in mapping1 trump mappings in mapping2 (if mapping2 contains a conflicting mapping in mapping1,
-            the one in mapping1 is preserved).
-        2. Reconciling means two things
-            [i] if the same s,p,o (subject_id, object_id, predicate_id) is present multiple times,
-                only preserve the highest confidence one. If confidence is same, rule 1 (above) applies.
-            [ii] If s,!p,o and s,p,o , then prefer higher confidence and remove the other.
-                    If same confidence prefer "HumanCurated" .If same again prefer negative.
-        3. Prefixes:
-            [i] if there is the same prefix in mapping1 as in mapping2, and the prefix URL is different,
-            throw an error and fail hard
-                else just merge the two prefix maps
-        4. Metadata: same as rule 1.
-
-        #1; #2(i) #3 and $4 are taken care of by 'filtered_merged_df' Only #2(ii) should be performed here.
-    """
+    # 1. Mappings in mapping1 trump mappings in mapping2 (if mapping2 contains a conflicting mapping in mapping1,
+    #     the one in mapping1 is preserved).
+    # 2. Reconciling means two things
+    #     [i] if the same s,p,o (subject_id, object_id, predicate_id) is present multiple times,
+    #         only preserve the highest confidence one. If confidence is same, rule 1 (above) applies.
+    #     [ii] If s,!p,o and s,p,o , then prefer higher confidence and remove the other.
+    #             If same confidence prefer "HumanCurated" .If same again prefer negative.
+    # 3. Prefixes:
+    #     [i] if there is the same prefix in mapping1 as in mapping2, and the prefix URL is different,
+    #     throw an error and fail hard
+    #         else just merge the two prefix maps
+    # 4. Metadata: same as rule 1.
+    #
+    # #1; #2(i) #3 and $4 are taken care of by 'filtered_merged_df' Only #2(ii) should be performed here.
 
     # Handle DataFrames with no 'confidence' column (basically adding a np.nan to all non-numeric confidences)
     confidence_in_original = CONFIDENCE in df.columns
@@ -1194,7 +1204,7 @@ def inject_metadata_into_df(msdf: MappingSetDataFrame) -> MappingSetDataFrame:
 
     :param msdf: MappingSetDataFrame with metadata separate.
 
-    :return: MappingSetDataFrame with metadata as columns
+    :returns: MappingSetDataFrame with metadata as columns
     """
     # TODO add this into the "standardize" function introduced in
     #  https://github.com/mapping-commons/sssom-py/pull/438
@@ -1219,7 +1229,8 @@ def get_file_extension(file: PathOrIO) -> Optional[ExtensionLiteral]:
     """Get file extension.
 
     :param file: File path
-    :return: format of the file passed, default tsv
+
+    :returns: format of the file passed, default tsv
     """
     if not isinstance(file, (str, Path)):
         if not hasattr(file, "name"):
@@ -1243,7 +1254,8 @@ def _extract_global_metadata(msdoc: MappingSetDocument) -> MetadataType:
     """Extract metadata.
 
     :param msdoc: MappingSetDocument object
-    :return: Dictionary containing metadata
+
+    :returns: Dictionary containing metadata
     """
     meta = {}
     ms_meta = msdoc.mapping_set
@@ -1264,17 +1276,18 @@ def to_mapping_set_dataframe(doc: MappingSetDocument) -> MappingSetDataFrame:
     """Convert MappingSetDocument into MappingSetDataFrame.
 
     :param doc: MappingSetDocument object
-    :return: MappingSetDataFrame object
+
+    :returns: MappingSetDataFrame object
     """
     return MappingSetDataFrame.from_mapping_set_document(doc)
 
 
 def get_dict_from_mapping(map_obj: Union[Any, Dict[str, Any], SSSOM_Mapping]) -> dict[str, Any]:
-    """
-    Get information for linkml objects (MatchTypeEnum, PredicateModifierEnum) from the Mapping object and return the dictionary form of the object.
+    """Get information for linkml objects (MatchTypeEnum, PredicateModifierEnum) from the Mapping object and return the dictionary form of the object.
 
     :param map_obj: Mapping object
-    :return: Dictionary
+
+    :returns: Dictionary
     """
     map_dict = {}
     sssom_schema_object = _get_sssom_schema_object()
@@ -1386,7 +1399,8 @@ def filter_out_prefixes(
     :param filter_prefixes: List of prefixes
     :param features: List of dataframe column names dataframe to consider
     :param require_all_prefixes: If True, all prefixes must be present in a row to be filtered out
-    :return: Pandas Dataframe
+
+    :returns: Pandas Dataframe
     """
     if features is None:
         features = KEY_FEATURES
@@ -1414,7 +1428,8 @@ def filter_prefixes(
     :param filter_prefixes: List of prefixes
     :param features: List of dataframe column names dataframe to consider
     :param require_all_prefixes: If True, all prefixes must be present in a row to be filtered out
-    :return: Pandas Dataframe
+
+    :returns: Pandas Dataframe
     """
     if features is None:
         features = KEY_FEATURES
@@ -1434,6 +1449,7 @@ def raise_for_bad_path(file_path: Union[str, Path]) -> None:
     """Raise exception if file path is invalid.
 
     :param file_path: File path
+
     :raises FileNotFoundError: Invalid file path
     """
     if isinstance(file_path, Path):
@@ -1449,7 +1465,8 @@ def is_multivalued_slot(slot: str) -> bool:
     """Check whether the slot is multivalued according to the SSSOM specification.
 
     :param slot: Slot name
-    :return: Slot is multivalued or no
+
+    :returns: Slot is multivalued or no
     """
     return slot in _get_sssom_schema_object().multivalued_slots
 
@@ -1468,13 +1485,13 @@ def reconcile_prefix_and_data(
 
     :param msdf: Mapping Set DataFrame.
     :param prefix_reconciliation: Prefix reconcilation dictionary from a YAML file
-    :return: Mapping Set DataFrame with reconciled prefix_map and data.
 
-    This method is build on :func:`curies.remap_curie_prefixes` and
-    :func:`curies.rewire`. Note that if you want to overwrite a CURIE prefix in the Bioregistry
-    extended prefix map, you need to provide a place for the old one to go as in
-    ``{"geo": "ncbi.geo", "geogeo": "geo"}``.
-    Just doing ``{"geogeo": "geo"}`` would not work since `geo` already exists.
+    :returns: Mapping Set DataFrame with reconciled prefix_map and data.
+
+    This method is build on :func:`curies.remap_curie_prefixes` and :func:`curies.rewire`. Note that
+    if you want to overwrite a CURIE prefix in the Bioregistry extended prefix map, you need to
+    provide a place for the old one to go as in ``{"geo": "ncbi.geo", "geogeo": "geo"}``. Just doing
+    ``{"geogeo": "geo"}`` would not work since `geo` already exists.
     """
     # Discussion about this found here:
     # https://github.com/mapping-commons/sssom-py/issues/216#issue-1171701052
@@ -1489,13 +1506,13 @@ def reconcile_prefix_and_data(
 def sort_df_rows_columns(
     df: pd.DataFrame, by_columns: bool = True, by_rows: bool = True
 ) -> pd.DataFrame:
-    """
-    Canonical sorting of DataFrame columns.
+    """Canonical sorting of DataFrame columns.
 
     :param df: Pandas DataFrame with random column sequence.
     :param by_columns: Boolean flag to sort columns canonically.
     :param by_rows: Boolean flag to sort rows by column #1 (ascending order).
-    :return: Pandas DataFrame columns sorted canonically.
+
+    :returns: Pandas DataFrame columns sorted canonically.
     """
     if by_columns and len(df.columns) > 0:
         column_sequence = [
@@ -1511,9 +1528,11 @@ def get_all_prefixes(msdf: MappingSetDataFrame) -> Set[str]:
     """Fetch all prefixes in the MappingSetDataFrame.
 
     :param msdf: MappingSetDataFrame
+
+    :returns: List of all prefixes.
+
     :raises ValidationError: If slot is wrong.
     :raises ValidationError: If slot is wrong.
-    :return:  List of all prefixes.
     """
     # FIXME investigate the logic for this function -
     #  some of the falsy checks don't make sense
@@ -1559,10 +1578,11 @@ def augment_metadata(
 
     :param msdf: MappingSetDataFrame (MSDF) object.
     :param meta: Dictionary that needs to be added/updated to the metadata of the MSDF.
-    :param replace_multivalued: Multivalued slots should be
-        replaced or not, defaults to False.
+    :param replace_multivalued: Multivalued slots should be replaced or not, defaults to False.
+
+    :returns: MSDF with updated metadata.
+
     :raises ValueError: If type of slot is neither str nor list.
-    :return: MSDF with updated metadata.
     """
     # TODO this now partially redundant of the MSDF built-in standardize functionality
     are_params_slots(meta)
@@ -1594,8 +1614,10 @@ def are_params_slots(params: dict[str, Any]) -> bool:
     """Check if parameters conform to the slots in MAPPING_SET_SLOTS.
 
     :param params: Dictionary of parameters.
+
+    :returns: True/False
+
     :raises ValueError: If params are not slots.
-    :return: True/False
     """
     empty_params = {k for k, v in params.items() if v is None or v == ""}
     if len(empty_params) > 0:
@@ -1621,12 +1643,13 @@ def invert_mappings(
 
     :param df: Pandas dataframe.
     :param subject_prefix: Prefix of subjects desired.
-    :param merge_inverted: If True (default), add inverted dataframe to input else,
-                          just return inverted data.
-    :param update_justification: If True (default), the justification is updated to "sempav:MappingInversion",
-                          else it is left as it is.
+    :param merge_inverted: If True (default), add inverted dataframe to input else, just return
+        inverted data.
+    :param update_justification: If True (default), the justification is updated to
+        "sempav:MappingInversion", else it is left as it is.
     :param predicate_invert_dictionary: YAML file providing the inverse mapping for predicates.
-    :return: Pandas dataframe with all subject IDs having the same prefix.
+
+    :returns: Pandas dataframe with all subject IDs having the same prefix.
     """
     if predicate_invert_dictionary:
         predicate_invert_map = predicate_invert_dictionary
@@ -1707,7 +1730,8 @@ def safe_compress(uri: str, converter: Converter) -> str:
 
     :param uri: The URI to parse. If this is already a CURIE, return directly.
     :param converter: Converter used for compression
-    :return: A CURIE
+
+    :returns: A CURIE
     """
     return converter.compress_or_standardize(uri, strict=True)
 

--- a/src/sssom/validators.py
+++ b/src/sssom/validators.py
@@ -32,6 +32,7 @@ def validate(
     :param msdf: MappingSetDataFrame.
     :param validation_types: SchemaValidationType
     :param fail_on_error: If true, throw an error when execution of a method has failed
+
     :returns: A dictionary from validation types to validation reports
     """
     if validation_types is None:
@@ -43,7 +44,8 @@ def print_linkml_report(report: ValidationReport, fail_on_error: bool = True) ->
     """Print the error messages in the report. Optionally throw exception.
 
     :param report: A LinkML validation report
-    :param fail_on_error: if true, the function will throw an ValidationError exception when there are errors
+    :param fail_on_error: if true, the function will throw an ValidationError exception when there
+        are errors
     """
     validation_errors = 0
 
@@ -68,11 +70,9 @@ def print_linkml_report(report: ValidationReport, fail_on_error: bool = True) ->
 def _clean_dict(d: dict[str, Any]) -> dict[str, Any]:
     """Recursively removes key-value pairs from a dictionary where the value is None, "null", or an empty string.
 
-    Args:
-    d (dict): The dictionary to clean.
+    :param d: The dictionary to clean.
 
-    Returns:
-    dict: A cleaned dictionary with unwanted values removed.
+    :returns: A cleaned dictionary with unwanted values removed.
     """
     if not isinstance(d, dict):
         return d
@@ -101,7 +101,8 @@ def validate_json_schema(msdf: MappingSetDataFrame, fail_on_error: bool = True) 
     """Validate JSON Schema using linkml's JsonSchemaDataValidator.
 
     :param msdf: MappingSetDataFrame to eb validated.
-    :param fail_on_error: if true, the function will throw an ValidationError exception when there are errors
+    :param fail_on_error: if true, the function will throw an ValidationError exception when there
+        are errors
     """
     validator = Validator(
         schema=SCHEMA_YAML,
@@ -122,7 +123,9 @@ def validate_shacl(msdf: MappingSetDataFrame, fail_on_error: bool = True) -> Val
     """Validate SCHACL file.
 
     :param msdf: TODO: https://github.com/linkml/linkml/issues/850 .
-    :param fail_on_error: if true, the function will throw an ValidationError exception when there are errors
+    :param fail_on_error: if true, the function will throw an ValidationError exception when there
+        are errors
+
     :raises NotImplementedError: Not yet implemented.
     """
     raise NotImplementedError
@@ -132,7 +135,9 @@ def validate_sparql(msdf: MappingSetDataFrame, fail_on_error: bool = True) -> Va
     """Validate SPARQL file.
 
     :param msdf: MappingSetDataFrame
-    :param fail_on_error: if true, the function will throw an ValidationError exception when there are errors
+    :param fail_on_error: if true, the function will throw an ValidationError exception when there
+        are errors
+
     :raises NotImplementedError: Not yet implemented.
     """
     # queries = {}
@@ -148,7 +153,9 @@ def check_all_prefixes_in_curie_map(
     """Check all `EntityReference` slots are mentioned in 'curie_map'.
 
     :param msdf: MappingSetDataFrame
-    :param fail_on_error: if true, the function will throw an ValidationError exception when there are errors
+    :param fail_on_error: if true, the function will throw an ValidationError exception when there
+        are errors
+
     :raises ValidationError: If all prefixes not in curie_map.
     """
     msdf.clean_context()
@@ -175,9 +182,14 @@ def check_strict_curie_format(
     """Check all `EntityReference` slots are formatted as unambiguous curies.
 
     Implemented rules:
-      - CURIE does not contain pipe "|" character to ensure that multivalued processing of in TSV works correctly.
+
+    1. CURIE does not contain pipe "|" character to ensure that multivalued processing of in TSV
+       works correctly.
+
     :param msdf: MappingSetDataFrame
-    :param fail_on_error: if true, the function will throw an ValidationError exception when there are errors
+    :param fail_on_error: if true, the function will throw an ValidationError exception when there
+        are errors
+
     :raises ValidationError: If any entity reference does not follow the strict CURIE format
     """
     import itertools as itt

--- a/src/sssom/writers.py
+++ b/src/sssom/writers.py
@@ -136,10 +136,10 @@ def write_rdf(
 
     :param msdf: A mapping set dataframe
     :param file: The path or file object to write to
-    :param serialisation: The RDF format to serialize to, see :data:`RDF_FORMATS`.
-        Defaults to turtle.
-    :param hydrate: If true, will add subject-predicate-objects directly representing
-        mappings. This is opt-in behavior.
+    :param serialisation: The RDF format to serialize to, see :data:`RDF_FORMATS`. Defaults to
+        turtle.
+    :param hydrate: If true, will add subject-predicate-objects directly representing mappings. This
+        is opt-in behavior.
     """
     if serialisation is None:
         serialisation = SSSOM_DEFAULT_RDF_SERIALISATION
@@ -164,11 +164,13 @@ def write_json(msdf: MappingSetDataFrame, output: PathOrIO, serialisation: str =
     :param output: A path or write-supported file object to write JSON to
     :param serialisation: The JSON format to use. Supported formats are:
 
-     - ``fhir_json``: Outputs JSON in FHIR ConceptMap format (https://fhir-ru.github.io/conceptmap.html)
-       https://mapping-commons.github.io/sssom-py/sssom.html#sssom.writers.to_fhir_json
-     - ``json``: Outputs to SSSOM JSON https://mapping-commons.github.io/sssom-py/sssom.html#sssom.writers.to_json
-     - ``ontoportal_json``: Outputs JSON in Ontoportal format (https://ontoportal.org/)
-       https://mapping-commons.github.io/sssom-py/sssom.html#sssom.writers.to_ontoportal_json
+        - ``fhir_json``: Outputs JSON in FHIR ConceptMap format
+          (https://fhir-ru.github.io/conceptmap.html)
+          https://mapping-commons.github.io/sssom-py/sssom.html#sssom.writers.to_fhir_json
+        - ``json``: Outputs to SSSOM JSON
+          https://mapping-commons.github.io/sssom-py/sssom.html#sssom.writers.to_json
+        - ``ontoportal_json``: Outputs JSON in Ontoportal format (https://ontoportal.org/)
+          https://mapping-commons.github.io/sssom-py/sssom.html#sssom.writers.to_ontoportal_json
     """
     if serialisation not in JSON_CONVERTERS:
         raise ValueError(
@@ -410,20 +412,25 @@ def get_rdflib_endpoint_app(
 def to_fhir_json(msdf: MappingSetDataFrame) -> Dict[str, Any]:
     """Convert a mapping set dataframe to a JSON object.
 
-    :param msdf: MappingSetDataFrame: Collection of mappings represented as DataFrame, together w/ additional metadata.
-    :return: Dict: A Dictionary serializable as JSON.
+    :param msdf: MappingSetDataFrame: Collection of mappings represented as DataFrame, together w/
+        additional metadata.
 
-    Resources:
-      - ConceptMap::SSSOM mapping spreadsheet:
-      https://docs.google.com/spreadsheets/d/1J19foBAYO8PCHwOfksaIGjNu-q5ILUKFh2HpOCgYle0/edit#gid=1389897118
+    :returns: Dict: A Dictionary serializable as JSON.
 
-    TODO: add to CLI & to these functions: r4 vs r5 param
-    TODO: What if the msdf doesn't have everything we need? (i) metadata, e.g. yml, (ii) what if we need to override?
-     - todo: later: allow any nested arbitrary override: (get in kwargs, else metadata.get(key, None))
+    .. seealso::
 
-    Minor todos
-    todo: mapping_justification: consider `ValueString` -> `ValueCoding` https://github.com/timsbiomed/issues/issues/152
-    todo: when/how to conform to R5 instead of R4?: https://build.fhir.org/conceptmap.html
+        ConceptMap=SSSOM mapping spreadsheet
+        https://docs.google.com/spreadsheets/d/1J19foBAYO8PCHwOfksaIGjNu-q5ILUKFh2HpOCgYle0/edit#gid=1389897118
+
+    .. todo:: add to CLI & to these functions: r4 vs r5 param
+
+    .. todo:: What if the msdf doesn't have everything we need? (i) metadata, e.g. yml, (ii) what if we need to override?
+
+    .. todo:: allow any nested arbitrary override: (get in kwargs, else metadata.get(key, None))
+
+    .. todo:: mapping_justification consider `ValueString` -> `ValueCoding` https://github.com/timsbiomed/issues/issues/152
+
+    .. todo:: when/how to conform to R5 instead of R4? https://build.fhir.org/conceptmap.html
     """
     # Constants
     df: pd.DataFrame = msdf.df
@@ -667,8 +674,10 @@ def get_writer_function(
 
     :param output: Output file
     :param output_format: Output file format, defaults to None
+
+    :returns: Type of writer function
+
     :raises ValueError: Unknown output format
-    :return: Type of writer function
     """
     if output_format is None:
         output_format = get_file_extension(output) or "tsv"

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -164,8 +164,7 @@ class TestParse(unittest.TestCase):
     def test_parse_alignment_xml(self) -> None:
         """Test parsing an alignment XML.
 
-        This issue should fail because entity 1 of the second mapping
-        is not in prefix map.
+        This issue should fail because entity 1 of the second mapping is not in prefix map.
         """
         alignment_api_xml = dedent(
             """\

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -299,7 +299,7 @@ class TestUtils(unittest.TestCase):
         )
 
     def test_standardize_metadata_multivalued_type_error(self) -> None:
-        """Test raising on a  non-string, non-list object given to a multivalued slot."""
+        """Test raising on a non-string, non-list object given to a multivalued slot."""
         metadata = {"creator_id": object()}
         msdf = MappingSetDataFrame(df=pd.DataFrame(), converter=Converter([]), metadata=metadata)
         with self.assertRaises(TypeError):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -22,11 +22,9 @@ class TestValidate(unittest.TestCase):
         self.shacl_validation_types = [SchemaValidationType.Shacl]
 
     def test_validate_json(self) -> None:
-        """
-        Test JSONSchemaValidation.
+        """Test JSONSchemaValidation.
 
-        Validate of the incoming file (basic.tsv) abides
-        by the rules set by `sssom-schema`.
+        Validate of the incoming file (basic.tsv) abides by the rules set by `sssom-schema`.
         """
         rv = validate(self.correct_msdf1, self.validation_types)
         self.assertIsNotNone(rv)
@@ -51,17 +49,15 @@ class TestValidate(unittest.TestCase):
     """
     )
     def test_validate_json_fail(self) -> None:
-        """
-        Test if JSONSchemaValidation fail is as expected.
+        """Test if JSONSchemaValidation fail is as expected.
 
-        In this particular test case, the 'mapping_justification' slot
-        does not have EntityReference objects, but strings.
+        In this particular test case, the 'mapping_justification' slot does not have EntityReference
+        objects, but strings.
         """
         self.assertRaises(ValidationError, validate, self.bad_msdf1, self.validation_types)
 
     def test_validate_shacl(self) -> None:
-        """
-        Test Shacl validation (Not implemented).
+        """Test Shacl validation (Not implemented).
 
         Validate shacl based on `sssom-schema`.
         """


### PR DESCRIPTION
This PR applies `uvx docstrfmt src/ tests/ docs --no-docstring-trailing-line -vvv --exclude docs/source/api/` to automatically format docstrings, and makes some manual fixes in places where it was janky