### PR TITLE
Require RDFLib 7.1.3 at a minimum.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "validators>=0.20.0",
     "deprecation>=2.1.0",
     "pyyaml>=6.0.1",
-    "rdflib>=6.0.0",
+    "rdflib>=7.1.3",
 ]
 
 # see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#dependencies-optional-dependencies


### PR DESCRIPTION
Since commit 7f86813, SSSOM-Py requires at least RDFLib 7.1.2, because prior versions do not export a `Node` class in the `rdflib` package.

Here, we require 7.1.3 because release 7.1.2 was apparently deleted by RDFLib developers for some reason.

closes #622