### PR TITLE
Fix support for literal mappings.

### DIFF
--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -42,7 +42,7 @@ from linkml_runtime.loaders.json_loader import JSONLoader
 from linkml_runtime.loaders.rdflib_loader import RDFLibLoader
 from pandas.errors import EmptyDataError
 from rdflib import Graph
-from sssom_schema import Mapping, MappingSet
+from sssom_schema import EntityTypeEnum, Mapping, MappingSet
 from typing_extensions import Literal, TypeAlias
 
 from sssom.constants import (
@@ -1187,12 +1187,12 @@ def _ensure_valid_mapping_from_dict(mdict: Dict[str, Any]) -> Optional[Mapping]:
 
     try:
         m = Mapping(**mdict)
-        if m.subject_type == "rdfs literal":
+        if m.subject_type == EntityTypeEnum(EntityTypeEnum["rdfs literal"]):
             if m.subject_label is None:
                 raise ValueError("Missing subject_label")
         elif m.subject_id is None:
             raise ValueError("Missing subject_id")
-        if m.object_type == "rdfs literal":
+        if m.object_type == EntityTypeEnum(EntityTypeEnum["rdfs literal"]):
             if m.object_label is None:
                 raise ValueError("Missing object_label")
         elif m.object_id is None:

--- a/tests/data/literals.sssom.tsv
+++ b/tests/data/literals.sssom.tsv
@@ -1,0 +1,19 @@
+#curie_map:
+#  FBcv: http://purl.obolibrary.org/obo/FBcv_
+#  ORCID: https://orcid.org/
+#  obo: http://purl.obolibrary.org/obo/
+#mapping_set_id: http://purl.obolibrary.org/obo/fbcv/agr-vocabs.sssom.tsv
+#mapping_set_description: Mappings between the FlyBase Controlled Vocabulary (FBcv) and vocabulary terms from the Alliance of Genome Resources.
+#creator_id:
+#  - ORCID:0000-0002-6095-8718
+#license: https://creativecommons.org/licenses/by/4.0/
+subject_id	subject_label	predicate_id	object_label	object_category	mapping_justification	subject_source	object_type
+FBcv:0000222	male	skos:exactMatch	male	Genetic Sex	semapv:ManualMappingCuration	obo:fbcv.owl	rdfs literal
+FBcv:0000334	female	skos:exactMatch	female	Genetic Sex	semapv:ManualMappingCuration	obo:fbcv.owl	rdfs literal
+FBcv:0003124	species study	skos:exactMatch	species	Data Set Category Tags	semapv:ManualMappingCuration	obo:fbcv.owl	rdfs literal
+FBcv:0003125	strain study	skos:exactMatch	genome variation	Data Set Category Tags	semapv:ManualMappingCuration	obo:fbcv.owl	rdfs literal
+FBcv:0003127	developmental stage study	skos:exactMatch	developmental stage	Data Set Category Tags	semapv:ManualMappingCuration	obo:fbcv.owl	rdfs literal
+FBcv:0003128	circadian rhythm study	skos:narrowMatch	time of day	Data Set Category Tags	semapv:ManualMappingCuration	obo:fbcv.owl	rdfs literal
+FBcv:0003129	cell cycle study	skos:exactMatch	cell cycle	Data Set Category Tags	semapv:ManualMappingCuration	obo:fbcv.owl	rdfs literal
+FBcv:0003130	tissue type study	skos:narrowMatch	anatomical structure	Data Set Category Tags	semapv:ManualMappingCuration	obo:fbcv.owl	rdfs literal
+FBcv:0003131	cell type study	skos:exactMatch	cell type	Data Set Category Tags	semapv:ManualMappingCuration	obo:fbcv.owl	rdfs literal

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -147,6 +147,11 @@ class TestParse(unittest.TestCase):
             f"{self.df_file} has the wrong number of mappings.",
         )
 
+    def test_parse_tsv_with_literal_mappings(self) -> None:
+        """Test parsing a SSSOM/TSV file containing literal mappings."""
+        msdf = parse_sssom_table(f"{test_data_dir}/literals.sssom.tsv")
+        self.assertEqual(len(msdf.df), 9, "literals.sssom.tsv has the wrong number of mappings.")
+
     def test_parse_alignment_minidom(self) -> None:
         """Test parsing an alignment XML."""
         msdf = from_alignment_minidom(


### PR DESCRIPTION
Since the LinkML-generated `Mapping` class does not, in itself, validates the post-conditions specified in the schema, it cannot validate that a Mapping object is created with either a `subject_id` or (if `subject_type` is `rdfs literal`) a `subject_label` (likewise for the object side).

Instead, that validation is performed by custom code executed as part of the parser (after the parsing proper has been done, but before return a `MappingSetDataFrame` to the caller).

However, the present validation is bogus because the check on the value of `subject_type` and `object_type` is trying to compare the value of the slot to a literal string, instead of a EntityTypeEnum object. We fix that comparison here.