### PR TITLE
Fix msdf_merge util function.

### DIFF
--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -21,7 +21,7 @@ class TestMerge(unittest.TestCase):
     def test_merge_multiple_inputs(self) -> None:
         """Test merging of multiple msdfs."""
         merged_msdf = merge_msdf(*self.msdfs)
-        self.assertEqual(275, len(merged_msdf.df))
+        self.assertEqual(200, len(merged_msdf.df))
 
     def test_merge_single_input(self) -> None:
         """Test merging when a single msdf is provided."""

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -41,7 +41,7 @@ class TestReconcile(unittest.TestCase):
         msdf3 = parse_sssom_table(data_dir / "basic.tsv")
         merged_msdf1 = merge_msdf(self.msdf1, msdf3)
 
-        self.assertEqual(152, len(merged_msdf1.df))
+        self.assertEqual(149, len(merged_msdf1.df))
 
         merged_msdf2 = merge_msdf(self.msdf2, msdf3)
         self.assertEqual(174, len(merged_msdf2.df))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,7 +38,6 @@ from sssom.util import (
     get_dict_from_mapping,
     get_file_extension,
     get_prefixes_used_in_table,
-    inject_metadata_into_df,
     invert_mappings,
     is_multivalued_slot,
 )
@@ -212,14 +211,6 @@ class TestIO(unittest.TestCase):
         original_subject_labels = msdf.df["subject_label"].values
         inverted_object_labels = inverted_df["object_label"].values
         self.assertNotIn(False, original_subject_labels == inverted_object_labels)
-
-    def test_inject_metadata_into_df(self) -> None:
-        """Test injecting metadata into DataFrame is as expected."""
-        expected_creators = "orcid:0000-0001-5839-2535|orcid:0000-0001-5839-2532"
-        msdf = parse_sssom_table(f"{data_dir}/test_inject_metadata_msdf.tsv")
-        msdf_with_meta = inject_metadata_into_df(msdf)
-        creator_ids = msdf_with_meta.df["creator_id"].drop_duplicates().values.item()
-        self.assertEqual(creator_ids, expected_creators)
 
 
 class TestUtils(unittest.TestCase):


### PR DESCRIPTION
The `msdf_merge` function attempts to "propagate" slots before merging the sets, but is doing so without any regard for which slots should actually be propagated.

In addition, it attempts to inject in every individual mapping a `mapping_set_source` slot pointing to the ID of the original set that contained the mapping, but this is invalid as there is _no_ `mapping_set_source` slot on indivdual mapping records – the slot intended to capture the set from which a record came from is `mapping_source`.

Lastly, the function also attempts to drop duplicates after the sets have been merged, but the detection of duplicates is prevented by (1) the incorrect propagation of non-propagatable slots (which can cause two otherwise identical records in two different sets to appear different, if the metadata of the sets contain different wrongly propagated slots), and (2) the injection of the `mapping_set_source` slot.

This PR fixes all those issues by deleting the bogus `inject_metadata_into_df` function and replacing it by a call to `msdf.propagate()`, which implements propagation correctly. It then manually injects the correct `mapping_source` slot if possible, and if so ignores the injected slot when attempting to drop duplicates.

closes #626