### PR TITLE
Fix RDF serialization bug

### DIFF
--- a/src/sssom/rdf_internal.py
+++ b/src/sssom/rdf_internal.py
@@ -615,7 +615,7 @@ class ObjectConverter:
 
         :returns: True if the value is empty.
         """
-        return value is None or (hasattr(value, "__len__") and len(value) == 0)
+        return value is None or pd.isna(value) or (hasattr(value, "__len__") and len(value) == 0)
 
     def _init_dict_to_rdf(self, graph: Graph, obj: DictOrSeries) -> Node:
         """Create the root node representing a SSSOM object.


### PR DESCRIPTION
If there are rows that contain pandas `nan`, then this line exploded. This PR does a pandas-flavored empty check