### PR TITLE
Preserve metadata-only prefixes when splitting

### DIFF
--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -86,6 +86,7 @@ from .util import (
     ExtensionLiteral,
     MappingSetDataFrame,
     get_file_extension,
+    get_prefixes_used_in_metadata,
     is_multivalued_slot,
     propagate_condensed_slots,
     raise_for_bad_path,
@@ -1075,10 +1076,11 @@ def split_dataframe_by_prefix(
         object_prefixes=object_prefixes,
         method=method,
     )
+    metadata_prefixes = get_prefixes_used_in_metadata(msdf.metadata) & msdf.converter.get_prefixes()
     rv = {}
     for (subject_prefix, relation_t, object_prefix), df in rr:
         subconverter = msdf.converter.get_subconverter(
-            [subject_prefix, object_prefix, relation_t.prefix]
+            [subject_prefix, object_prefix, relation_t.prefix, *metadata_prefixes]
         )
         split = _get_split_key(subject_prefix, relation_t.identifier, object_prefix)
         rv[split] = from_sssom_dataframe(df, prefix_map=subconverter, meta=msdf.metadata)
@@ -1093,6 +1095,7 @@ def _split_dataframe_by_prefix_old(
 ) -> Dict[str, MappingSetDataFrame]:
     df = msdf.df
     meta = msdf.metadata
+    metadata_prefixes = get_prefixes_used_in_metadata(meta) & msdf.converter.get_prefixes()
     split_to_msdf: Dict[str, MappingSetDataFrame] = {}
     for subject_prefix, object_prefix, relation in itt.product(
         subject_prefixes, object_prefixes, relations
@@ -1114,7 +1117,7 @@ def _split_dataframe_by_prefix_old(
             logging.debug(f"No matches ({len(df_subset)} matches found)")
             continue
         subconverter = msdf.converter.get_subconverter(
-            [subject_prefix, object_prefix, relation_prefix]
+            [subject_prefix, object_prefix, relation_prefix, *metadata_prefixes]
         )
         split_to_msdf[split] = from_sssom_dataframe(
             df_subset, prefix_map=dict(subconverter.bimap), meta=meta

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -1076,6 +1076,8 @@ def split_dataframe_by_prefix(
         object_prefixes=object_prefixes,
         method=method,
     )
+    # Intersect with the converter's prefixes so any garbage CURIE-shaped value
+    # in the metadata doesn't propagate as an unknown prefix to the subconverter.
     metadata_prefixes = get_prefixes_used_in_metadata(msdf.metadata) & msdf.converter.get_prefixes()
     rv = {}
     for (subject_prefix, relation_t, object_prefix), df in rr:
@@ -1095,6 +1097,8 @@ def _split_dataframe_by_prefix_old(
 ) -> Dict[str, MappingSetDataFrame]:
     df = msdf.df
     meta = msdf.metadata
+    # Intersect with the converter's prefixes so any garbage CURIE-shaped value
+    # in the metadata doesn't propagate as an unknown prefix to the subconverter.
     metadata_prefixes = get_prefixes_used_in_metadata(meta) & msdf.converter.get_prefixes()
     split_to_msdf: Dict[str, MappingSetDataFrame] = {}
     for subject_prefix, object_prefix, relation in itt.product(

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -710,3 +710,42 @@ class TestSplit(unittest.TestCase):
         self.assertIn("p1_exactmatch_p2", rv)
         self.assertIn("p1_exactmatch_p3", rv)
         self.assertEqual(sdf.values.tolist(), rv["p1_exactmatch_p2"].df.values.tolist())
+
+    def test_split_preserves_metadata_prefixes(self) -> None:
+        """Regression test for https://github.com/mapping-commons/sssom-py/issues/573.
+
+        Prefixes that appear only in metadata values (e.g. ``subject_source: infores:mondo``)
+        must be carried over to each split's converter, otherwise ``write_table`` silently
+        drops them from the emitted ``# curie_map``.
+        """
+        converter = Converter.from_prefix_map(
+            {
+                "p1": "https://example.org/p1/",
+                "p2": "https://example.org/p2/",
+                "skos": "http://www.w3.org/2004/02/skos/core#",
+                "semapv": "https://w3id.org/semapv/vocab/",
+                "infores": "https://w3id.org/information-resource-registry/",
+            }
+        )
+        df = pd.DataFrame(
+            [("p1:1", "skos:exactMatch", "p2:1", "semapv:ManualMappingCuration")],
+            columns=["subject_id", "predicate_id", "object_id", "mapping_justification"],
+        )
+        meta = {
+            "mapping_set_id": "https://example.org/test",
+            "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "subject_source": "infores:p1",
+        }
+        msdf = from_sssom_dataframe(df, converter, meta=meta)
+
+        for method in [None, *get_args(SplitMethod)]:
+            with self.subTest(method=method):
+                rv = split_dataframe_by_prefix(
+                    msdf, ["p1"], ["p2"], ["skos:exactMatch"], method=method
+                )
+                self.assertIn("p1_exactmatch_p2", rv)
+                self.assertIn(
+                    "infores",
+                    rv["p1_exactmatch_p2"].converter.bimap,
+                    msg="metadata-only prefix dropped from split converter",
+                )


### PR DESCRIPTION
Fixes #573 

@cthoyt problem was actually ONLY in the split dataframe by prefix method. Would appreciate review.