### PR TITLE
Add option to print prettier validation reports

### DIFF
--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -15,6 +15,7 @@ import curies
 import pandas as pd
 import yaml
 from curies import Converter
+from linkml.validator.report import Severity
 from rdflib import Graph, URIRef
 from typing_extensions import ParamSpec
 
@@ -39,9 +40,6 @@ from .io import (
 from .parsers import PARSING_FUNCTIONS, SplitMethod, parse_sssom_table
 from .rdf_util import rewire_graph
 from .sparql_util import EndpointConfig, query_mappings
-from linkml.validator.report import Severity
-
-from .validators import format_report, print_linkml_report
 from .util import (
     MappingSetDataFrame,
     compare_dataframes,
@@ -55,6 +53,7 @@ from .util import (
     sort_df_rows_columns,
     to_mapping_set_dataframe,
 )
+from .validators import format_report, print_linkml_report
 from .writers import WRITER_FUNCTIONS, get_rdflib_endpoint_app, write_table
 
 logging = _logging.getLogger(__name__)

--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -39,6 +39,9 @@ from .io import (
 from .parsers import PARSING_FUNCTIONS, SplitMethod, parse_sssom_table
 from .rdf_util import rewire_graph
 from .sparql_util import EndpointConfig, query_mappings
+from linkml.validator.report import Severity
+
+from .validators import format_report, print_linkml_report
 from .util import (
     MappingSetDataFrame,
     compare_dataframes,
@@ -250,11 +253,43 @@ def parse(
     multiple=True,
     default=DEFAULT_VALIDATION_TYPES,
 )
+@click.option(
+    "--report-format",
+    "-r",
+    type=click.Choice(["pretty", "raw"]),
+    default="pretty",
+    show_default=True,
+    help="How to render the validation report. 'pretty' prints one line per unique problem; 'raw' uses LinkML's default per-error logging.",
+)
 @propagate_option
-def validate(input: str, validation_types: List[SchemaValidationType], propagate: bool) -> None:
+def validate(
+    input: str,
+    validation_types: List[SchemaValidationType],
+    propagate: bool,
+    report_format: str,
+) -> None:
     """Produce an error report for an SSSOM file."""
     validation_type_list = [t for t in validation_types]
-    validate_file(input_path=input, validation_types=validation_type_list, propagate=propagate)
+    reports = validate_file(
+        input_path=input,
+        validation_types=validation_type_list,
+        fail_on_error=False,
+        propagate=propagate,
+    )
+    has_errors = False
+    for vt, report in reports.items():
+        if any(r.severity in (Severity.FATAL, Severity.ERROR) for r in report.results):
+            has_errors = True
+        if report_format == "raw":
+            print_linkml_report(report, fail_on_error=False)
+            continue
+        formatted = format_report(report, label=vt.name)
+        if formatted:
+            click.echo(formatted)
+    if not has_errors:
+        click.echo("No issues found.")
+    else:
+        sys.exit(1)
 
 
 @main.command()

--- a/src/sssom/validators.py
+++ b/src/sssom/validators.py
@@ -44,7 +44,7 @@ def format_report(report: ValidationReport, label: str = "") -> str:
     """Format a ValidationReport as one line per unique JSON path, dropping the instance blob."""
     prefix = f"[{label}] " if label else ""
     lines: list[str] = []
-    seen: set[tuple] = set()
+    seen: set[tuple[Any, ...]] = set()
     for r in report.results:
         src = r.source
         if src is not None:

--- a/src/sssom/validators.py
+++ b/src/sssom/validators.py
@@ -40,29 +40,49 @@ def validate(
     return {vt: VALIDATION_METHODS[vt](msdf, fail_on_error) for vt in validation_types}
 
 
+def format_report(report: ValidationReport, label: str = "") -> str:
+    """Format a ValidationReport as one line per unique JSON path, dropping the instance blob."""
+    prefix = f"[{label}] " if label else ""
+    lines: list[str] = []
+    seen: set[tuple] = set()
+    for r in report.results:
+        src = r.source
+        if src is not None:
+            path = tuple(src.absolute_path)
+            if path in seen:
+                continue
+            seen.add(path)
+            path_str = "/".join(str(p) for p in path) or "<root>"
+            lines.append(f"{prefix}{path_str}: {src.message}")
+        else:
+            lines.append(f"{prefix}{r.message}")
+    return "\n".join(lines)
+
+
+_FAILING_SEVERITIES = (Severity.FATAL, Severity.ERROR)
+
+
+def _raise_if_errors(report: ValidationReport, fail_on_error: bool) -> None:
+    """Raise a ValidationError summarising ERROR/FATAL results, if ``fail_on_error``."""
+    n = sum(1 for r in report.results if r.severity in _FAILING_SEVERITIES)
+    if fail_on_error and n:
+        raise ValidationError(f"You mapping set has {n} validation errors!")
+
+
 def print_linkml_report(report: ValidationReport, fail_on_error: bool = True) -> None:
-    """Print the error messages in the report. Optionally throw exception.
+    """Log each result in the report and optionally raise on errors.
 
-    :param report: A LinkML validation report
-    :param fail_on_error: if true, the function will throw an ValidationError exception when there
-        are errors
+    Retained for callers that want logging-style output; the built-in validators no longer
+    invoke it themselves so that callers can choose their own rendering (e.g. ``format_report``).
     """
-    validation_errors = 0
-
+    for result in report.results:
+        if result.severity in (Severity.FATAL, Severity.ERROR, Severity.WARN):
+            logging.error(result.message)
+        else:
+            logging.info(result.message)
     if not report.results:
         logging.info("The instance is valid!")
-    else:
-        for result in report.results:
-            validation_errors += 1
-            if (result.severity == Severity.FATAL) or (result.severity == Severity.ERROR):
-                logging.error(result.message)
-            elif result.severity == Severity.WARN:
-                logging.error(result.message)
-            elif result.severity == Severity.INFO:
-                logging.info(result.message)
-
-    if fail_on_error and validation_errors:
-        raise ValidationError(f"You mapping set has {validation_errors} validation errors!")
+    _raise_if_errors(report, fail_on_error)
 
 
 # TODO This should not be necessary: https://github.com/linkml/linkml/issues/2117,
@@ -115,7 +135,7 @@ def validate_json_schema(msdf: MappingSetDataFrame, fail_on_error: bool = True) 
     mapping_set_dict = json_dumper.to_dict(mapping_set)
 
     report = validator.validate(mapping_set_dict, "mapping set")
-    print_linkml_report(report, fail_on_error)
+    _raise_if_errors(report, fail_on_error)
     return report
 
 
@@ -172,7 +192,7 @@ def check_all_prefixes_in_curie_map(
             )
         )
     report = ValidationReport(results=validation_results)
-    print_linkml_report(report, fail_on_error)
+    _raise_if_errors(report, fail_on_error)
     return report
 
 
@@ -222,7 +242,7 @@ def check_strict_curie_format(
                     )
 
     report = ValidationReport(results=validation_results)
-    print_linkml_report(report, fail_on_error)
+    _raise_if_errors(report, fail_on_error)
     return report
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -3,10 +3,11 @@
 import unittest
 
 from jsonschema import ValidationError
+from linkml.validator.report import Severity, ValidationReport, ValidationResult
 
 from sssom.constants import DEFAULT_VALIDATION_TYPES, SchemaValidationType
 from sssom.parsers import parse_sssom_table
-from sssom.validators import validate
+from sssom.validators import _raise_if_errors, format_report, validate
 from tests.constants import data_dir
 
 
@@ -78,3 +79,38 @@ class TestValidate(unittest.TestCase):
     def test_validate_nando(self) -> None:
         """Test Shacl validation (Not implemented)."""
         self.assertRaises(ValidationError, validate, self.bad_nando, self.validation_types)
+
+    def test_format_report_bad(self) -> None:
+        """format_report dedupes per JSON path and emits non-empty output for a bad file."""
+        reports = validate(self.bad_msdf1, self.validation_types, fail_on_error=False)
+        json_lines = format_report(
+            reports[SchemaValidationType.JsonSchema], label="JsonSchema"
+        ).splitlines()
+        # 11 bad mapping_justification rows in bad_basic.tsv; deduped by path
+        self.assertEqual(11, len(json_lines))
+        self.assertTrue(all(line.startswith("[JsonSchema] mappings/") for line in json_lines))
+        prefix_out = format_report(
+            reports[SchemaValidationType.PrefixMapCompleteness], label="PrefixMapCompleteness"
+        )
+        self.assertEqual("[PrefixMapCompleteness] Missing prefix: orcid", prefix_out)
+
+    def test_format_report_clean(self) -> None:
+        """format_report returns the empty string when there are no results."""
+        reports = validate(self.correct_msdf1, self.validation_types, fail_on_error=False)
+        for report in reports.values():
+            self.assertEqual("", format_report(report))
+
+    def test_raise_if_errors_respects_severity(self) -> None:
+        """_raise_if_errors raises only on FATAL/ERROR, never on WARN/INFO."""
+        info = ValidationReport(
+            results=[ValidationResult(type="t", severity=Severity.INFO, message="just fyi")]
+        )
+        warn = ValidationReport(
+            results=[ValidationResult(type="t", severity=Severity.WARN, message="watch out")]
+        )
+        error = ValidationReport(
+            results=[ValidationResult(type="t", severity=Severity.ERROR, message="broken")]
+        )
+        _raise_if_errors(info, fail_on_error=True)  # no raise
+        _raise_if_errors(warn, fail_on_error=True)  # no raise
+        self.assertRaises(ValidationError, _raise_if_errors, error, True)


### PR DESCRIPTION
Replaces #387

@cthoyt I think the pretty rendering makes more sense because the default linkml is to bulky for normal humans to read..

- Add `format_report()`: one line per unique JSON path, drops the verbose
  `instance` blob, collapses paired pattern/anyOf errors from LinkML.
- Stop validators from logging as a side effect; extract `_raise_if_errors`
  so callers choose their own rendering. `print_linkml_report` retained
  for log-style output.
- Respect severity: only FATAL/ERROR cause raises and non-zero CLI exit.
- CLI: add `--report-format/-r {pretty,raw}`, default `pretty`.