### PR TITLE
Enable running tests when pansql isn't installed

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for the command line interface."""
 
+import importlib.util
 import os
 import subprocess  # noqa
 import unittest
@@ -67,9 +68,10 @@ class SSSOMCLITestSuite(unittest.TestCase):
                     self.run_crosstab(runner, test)
                     self.run_correlations(runner, test)
                     self.run_reconcile_prefix(runner, test)
-                    self.run_dosql(runner, test)
+                    if importlib.util.find_spec("pansql"):
+                        self.run_dosql(runner, test)
+                        self.run_filter(runner, test)
                     self.run_sort_rows_columns(runner, test)
-                    self.run_filter(runner, test)
                     self.run_annotate(runner, test)
                     self.run_remove(runner, test)
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,5 +1,6 @@
 """Test for filtering MappingSetDataFrame columns."""
 
+import importlib.util
 import unittest
 from os.path import join
 from typing import Any
@@ -10,6 +11,7 @@ from sssom.parsers import parse_sssom_table
 from tests.constants import data_dir
 
 
+@unittest.skipUnless(importlib.util.find_spec("pansql"), "pansql not installed")
 class TestSort(unittest.TestCase):
     """A test case for filtering msdf columns."""
 


### PR DESCRIPTION
If pansql isn't installed, tests would fail. This adds some guard rails to skip the tests for pansql if it's not installed, since it's an optional dependency