### PR TITLE
Remove `sssom:superClassOf`.

### DIFF
--- a/src/sssom/cliques.py
+++ b/src/sssom/cliques.py
@@ -18,7 +18,6 @@ from sssom.constants import (
     SKOS_CLOSE_MATCH,
     SKOS_EXACT_MATCH,
     SKOS_NARROW_MATCH,
-    SSSOM_SUPERCLASS_OF,
     SSSOM_URI_PREFIX,
 )
 
@@ -58,8 +57,6 @@ def to_digraph(msdf: MappingSetDataFrame) -> "networkx.DiGraph[str]":
                 pi = 0
             elif p == SKOS_BROAD_MATCH:
                 pi = 0
-            elif p == SSSOM_SUPERCLASS_OF:
-                pi = 1
             elif p == SKOS_NARROW_MATCH:
                 pi = 1
             elif p == OWL_DIFFERENT_FROM:

--- a/src/sssom/constants.py
+++ b/src/sssom/constants.py
@@ -37,7 +37,6 @@ EXTENDED_PREFIX_MAP = HERE / "obo.epm.json"
 OWL_EQUIV_CLASS_URI = "http://www.w3.org/2002/07/owl#equivalentClass"
 RDFS_SUBCLASS_OF_URI = "http://www.w3.org/2000/01/rdf-schema#subClassOf"
 RDF_TYPE_URI = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-SSSOM_SUPERCLASS_OF_URI = "http://w3id.org/sssom/superClassOf"
 SKOS_EXACT_MATCH_URI = "http://www.w3.org/2004/02/skos/core#exactMatch"
 SKOS_CLOSE_MATCH_URI = "http://www.w3.org/2004/02/skos/core#closeMatch"
 SKOS_BROAD_MATCH_URI = "http://www.w3.org/2004/02/skos/core#broadMatch"
@@ -158,13 +157,11 @@ CROSS_SPECIES_NARROW_MATCH = "semapv:crossSpeciesNarrowMatch"
 CROSS_SPECIES_BROAD_MATCH = "semapv:crossSpeciesBroadMatch"
 RDF_SEE_ALSO = "rdfs:seeAlso"
 RDF_TYPE = "rdf:type"
-SSSOM_SUPERCLASS_OF = "sssom:superClassOf"
 
 PREDICATE_LIST = [
     OWL_EQUIVALENT_CLASS,
     OWL_EQUIVALENT_PROPERTY,
     RDFS_SUBCLASS_OF,
-    SSSOM_SUPERCLASS_OF,
     RDFS_SUBPROPERTY_OF,
     OWL_SAME_AS,
     SKOS_EXACT_MATCH,

--- a/src/sssom/inverse_map.yaml
+++ b/src/sssom/inverse_map.yaml
@@ -10,6 +10,4 @@ inverse_predicate_map:
   semapv:crossSpeciesCloseMatch: semapv:crossSpeciesCloseMatch
   owl:equivalentClass: owl:equivalentClass
   owl:sameAs: owl:sameAs
-  rdfs:subClassOf: sssom:superClassOf
-  sssom:superClassOf: rdfs:subClassOf
 

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -1216,9 +1216,7 @@ def _ensure_valid_mapping_from_dict(mdict: Dict[str, Any]) -> Optional[Mapping]:
         return m
 
 
-def _add_valid_mapping_to_list(
-    mdict: Dict[str, Any], mlist: List[Mapping]
-) -> None:
+def _add_valid_mapping_to_list(mdict: Dict[str, Any], mlist: List[Mapping]) -> None:
     """Validate the mapping and append to the list if valid.
 
     Parameters: - mdict (dict): A dictionary containing the mapping metadata. - mlist (list): The

--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -710,7 +710,7 @@ def from_alignment_minidom(
                         mdict: Dict[str, Any] = _cell_element_values(
                             c_node, converter, mapping_predicates=mapping_predicates
                         )
-                        _add_valid_mapping_to_list(mdict, mlist, flip_superclass_assertions=True)
+                        _add_valid_mapping_to_list(mdict, mlist)
 
                 elif node_name == "xml":
                     if e.firstChild.nodeValue != "yes":  # type: ignore[union-attr]
@@ -890,13 +890,6 @@ def get_parsing_function(
     if func is None:
         raise ValueError(f"Unknown input format: {input_format}")
     return func
-
-
-def _flip_superclass_assertion(mapping: Mapping) -> Mapping:
-    if mapping.predicate_id != "sssom:superClassOf":
-        return mapping
-    mapping.predicate_id = "rdfs:subClassOf"
-    return _swap_object_subject(mapping)
 
 
 def _swap_object_subject(mapping: Mapping) -> Mapping:
@@ -1224,17 +1217,14 @@ def _ensure_valid_mapping_from_dict(mdict: Dict[str, Any]) -> Optional[Mapping]:
 
 
 def _add_valid_mapping_to_list(
-    mdict: Dict[str, Any], mlist: List[Mapping], *, flip_superclass_assertions: bool = False
+    mdict: Dict[str, Any], mlist: List[Mapping]
 ) -> None:
     """Validate the mapping and append to the list if valid.
 
     Parameters: - mdict (dict): A dictionary containing the mapping metadata. - mlist (list): The
-    list to which the valid mapping should be appended. - flip_superclass_assertions (bool): an
-    optional paramter that flips sssom:superClassOf to rdfs:subClassOf
+    list to which the valid mapping should be appended.
     """
     mapping = _ensure_valid_mapping_from_dict(mdict)
     if not mapping:
         return None
-    if flip_superclass_assertions:
-        mapping = _flip_superclass_assertion(mapping)
     mlist.append(mapping)

--- a/src/sssom/util.py
+++ b/src/sssom/util.py
@@ -68,7 +68,6 @@ from .constants import (
     SKOS_EXACT_MATCH,
     SKOS_NARROW_MATCH,
     SKOS_RELATED_MATCH,
-    SSSOM_SUPERCLASS_OF,
     SSSOM_URI_PREFIX,
     SUBJECT_CATEGORY,
     SUBJECT_ID,
@@ -997,8 +996,6 @@ def dataframe_to_ptable(
             predicate_type = PREDICATE_SUBCLASS
         elif predicate == SKOS_BROAD_MATCH:
             predicate_type = PREDICATE_SUBCLASS
-        elif predicate == SSSOM_SUPERCLASS_OF:
-            predicate_type = PREDICATE_SUPERCLASS
         elif predicate == SKOS_NARROW_MATCH:
             predicate_type = PREDICATE_SUPERCLASS
         elif predicate == OWL_DIFFERENT_FROM:

--- a/src/sssom/writers.py
+++ b/src/sssom/writers.py
@@ -275,7 +275,6 @@ def to_owl_graph(msdf: MappingSetDataFrame) -> Graph:
         df=msdf.df,
         merge_inverted=False,
         update_justification=False,
-        predicate_invert_dictionary={"sssom:superClassOf": "rdfs:subClassOf"},
     )
     graph = to_rdf_graph(msdf=msdf)
 
@@ -456,8 +455,6 @@ def to_fhir_json(msdf: MappingSetDataFrame) -> Dict[str, Any]:
         #   to use these mappings operationally.
         "skos:narrower": "narrower",
         "skos:narrowMatch": "narrower",  # canonical
-        # specializes: The target mapping specializes the meaning of the source concept (e.g. the target is-a source).
-        "sssom:superClassOf": "specializes",
         # inexact: The target mapping overlaps with the source concept, but both source and target cover additional
         # meaning, or the definitions are imprecise and it is uncertain whether they have the same boundaries to their
         # meaning. The sense in which the mapping is inexact SHALL be described in the comments in this case, and

--- a/tests/data/cob-to-external.tsv
+++ b/tests/data/cob-to-external.tsv
@@ -35,9 +35,6 @@ COB:0000003	mass	owl:equivalentClass	PATO:0000125	mass	.	semapv:ManualMappingCur
 COB:0000004	charge	owl:equivalentClass	PATO:0002193	electric	.	semapv:ManualMappingCuration
 COB:0000005	elementary charge	rdfs:subClassOf	owl:Thing	owl:Thing	Making ticket in PATO tracker	semapv:ManualMappingCuration
 COB:0000006	material entity	owl:equivalentClass	BFO:0000040	material entity	.	semapv:ManualMappingCuration
-COB:0000006	material entity	sssom:superClassOf	SO:0000110	sequence_feature	.	semapv:ManualMappingCuration
-COB:0000006	material entity	sssom:superClassOf	SO:0001060	sequence_variant	.	semapv:ManualMappingCuration
-COB:0000006	material entity	sssom:superClassOf	SO:0001260	sequence_collection	.	semapv:ManualMappingCuration
 COB:0000007	subatomic particle	owl:equivalentClass	CHEBI:36342	subatomic particle	.	semapv:ManualMappingCuration
 COB:0000008	proton	owl:equivalentClass	CHEBI:24636	proton	.	semapv:ManualMappingCuration
 COB:0000009	neutron	owl:equivalentClass	CHEBI:30222	neutron	.	semapv:ManualMappingCuration
@@ -49,15 +46,10 @@ COB:0000013	molecular entity	skos:closeMatch	CHEBI:25367	molecule	This is electr
 COB:0000015	protein	owl:equivalentClass	CHEBI:16541	protein polypeptide chain	.	semapv:ManualMappingCuration
 COB:0000015	protein	owl:equivalentClass	PR:000000001	protein	.	semapv:ManualMappingCuration
 COB:0000017	cell	owl:equivalentClass	CL:0000000	cell	.	semapv:ManualMappingCuration
-COB:0000017	cell	sssom:superClassOf	PO:0009002	plant cell	.	semapv:ManualMappingCuration
 COB:0000018	native cell	owl:equivalentClass	CL:0000003	native cell	.	semapv:ManualMappingCuration
-COB:0000018	native cell	sssom:superClassOf	XAO:0003012	xenopus cell	.	semapv:ManualMappingCuration
-COB:0000018	native cell	sssom:superClassOf	ZFA:0009000	zebrafish cell	.	semapv:ManualMappingCuration
-COB:0000018	native cell	sssom:superClassOf	PO:0025606	native plant cell	.	semapv:ManualMappingCuration
 COB:0000019	cell in vitro	owl:equivalentClass	CL:0001034	cell in vitro	.	semapv:ManualMappingCuration
 COB:0000020	subcellular structure	rdfs:subClassOf	owl:Thing	owl:Thing	Chris will follow up	semapv:ManualMappingCuration
 COB:0000021	gross anatomical part	owl:equivalentClass	CARO:0001008	gross anatomical part	.	semapv:ManualMappingCuration
-COB:0000021	gross anatomical part	sssom:superClassOf	UBERON:0010000	multicellular anatomical structure	.	semapv:ManualMappingCuration
 COB:0000022	organism	owl:equivalentClass	NCBITaxon:1	root	.	semapv:ManualMappingCuration
 COB:0000022	organism	owl:equivalentClass	OBI:0100026	organism	.	semapv:ManualMappingCuration
 COB:0000022	organism	owl:equivalentClass	CARO:0001010	organism or virus or viroid	.	semapv:ManualMappingCuration
@@ -74,8 +66,6 @@ COB:0000042	monoatomic ion	owl:equivalentClass	CHEBI:24867	monoatomic ion	.	sema
 COB:0000043	uncharged atom	owl:equivalentClass	CHEBI:33250	atom	"we think our uncharged atom is actually chebi:atom, to be discussed with CHEBI people"	semapv:ManualMappingCuration
 COB:0000049	nucleic acid polymer	owl:equivalentClass	CHEBI:10545	nucleic acid	follow up with CHEBI on nomenclature	semapv:ManualMappingCuration
 COB:0000055	collection of organisms	owl:equivalentClass	PCO:0000000	collection of organisms	.	semapv:ManualMappingCuration
-COB:0000056	immaterial anatomical entity	sssom:superClassOf	UBERON:0000466	immaterial anatomical entity	.	semapv:ManualMappingCuration
-COB:0000056	immaterial anatomical entity	sssom:superClassOf	PO:0025117	plant anatomical space	.	semapv:ManualMappingCuration
 COB:0000057	site	owl:equivalentClass	BFO:0000029	site	.	semapv:ManualMappingCuration
 COB:0000058	conclusion based on data	owl:equivalentClass	OBI:0001909	conclusion based on data	.	semapv:ManualMappingCuration
 COB:0000061	information	owl:equivalentClass	IAO:0000030	information content entity	.	semapv:ManualMappingCuration
@@ -86,7 +76,6 @@ COB:0000065	environmental process	owl:equivalentClass	ENVO:02500000	environmenta
 COB:0000066	physico-chemical process	owl:equivalentClass	MOP:0000543	molecular process	"we are not sure if these are equivalent, or if we even want to retain this. Follow up with Colin"	semapv:ManualMappingCuration
 COB:0000067	ecosystem	owl:equivalentClass	ENVO:01001110	ecosystem	.	semapv:ManualMappingCuration
 COB:0000068	geophysical entity	owl:equivalentClass	ENVO:01000813	astronomical body part	.	semapv:ManualMappingCuration
-COB:0000068	geophysical entity	sssom:superClassOf	GEO:000000370	geographical entity	See https://github.com/OBOFoundry/COB/issues/91	semapv:ManualMappingCuration
 COB:0000069	directive information entity	owl:equivalentClass	IAO:0000033	directive information entity	.	semapv:ManualMappingCuration
 COB:0000073	gene product	rdfs:subClassOf	owl:Thing	owl:Thing		semapv:ManualMappingCuration
 COB:0000075	protein-containing macromolecular complex	owl:equivalentClass	GO:0032991	protein-containing complex	.	semapv:ManualMappingCuration
@@ -106,12 +95,9 @@ COB:0000111	disposition	owl:equivalentClass	BFO:0000016	disposition	.	semapv:Man
 COB:0000112	function	owl:equivalentClass	BFO:0000034	function	.	semapv:ManualMappingCuration
 COB:0000113	plan	owl:equivalentClass	OBI:0000260	plan	.	semapv:ManualMappingCuration
 COB:0000114	role	owl:equivalentClass	BFO:0000023	role	.	semapv:ManualMappingCuration
-COB:0000502	characteristic	sssom:superClassOf	CHEBI:50906	role	The ChEBI notion of a role doesn't strictly follow the BFO sense of either being a role or disposition, meaning that it's hard, if not impossible, to impose BFO order to this branch of ChEBI. See issue #173	semapv:ManualMappingCuration
 COB:0000116	cellular membrane	rdfs:subClassOf	owl:Thing	owl:Thing		semapv:ManualMappingCuration
 COB:0000118	cellular organism	owl:equivalentClass	NCBITaxon:131567	cellular organisms	.	semapv:ManualMappingCuration
 COB:0000118	cellular organism	owl:equivalentClass	CARO:0010004	cellular organism	.	semapv:ManualMappingCuration
-COB:0000118	cellular organism	sssom:superClassOf	UBERON:0000468	multicellular organism	.	semapv:ManualMappingCuration
-COB:0000118	cellular organism	sssom:superClassOf	PO:0000003	whole plant	.	semapv:ManualMappingCuration
 COB:0000036	contains process	owl:equivalentProperty	BFO:0000067	contains process	.	semapv:ManualMappingCuration
 COB:0000047	has part	owl:equivalentProperty	BFO:0000051	has part	.	semapv:ManualMappingCuration
 COB:0000070	has participant	owl:equivalentProperty	RO:0000057	has participant	.	semapv:ManualMappingCuration
@@ -120,7 +106,6 @@ COB:0000072	part of	owl:equivalentProperty	BFO:0000050	part of	.	semapv:ManualMa
 COB:0000074	enabled by	owl:equivalentProperty	RO:0002333	enabled by	.	semapv:ManualMappingCuration
 COB:0000502	characteristic	owl:equivalentClass	PATO:0000001	quality	https://github.com/OBOFoundry/COB/issues/124	semapv:ManualMappingCuration
 COB:0000502	characteristic	owl:equivalentClass	BFO:0000020	specifically dependent continuant	may be revised to be narrower	semapv:ManualMappingCuration
-COB:0000502	characteristic	sssom:superClassOf	SO:0000400	sequence_attribute	.	semapv:ManualMappingCuration
 COB:0000511	has quantity	rdfs:subPropertyOf	owl:topObjectProperty	topObjectProperty	.	semapv:ManualMappingCuration
 COB:0000512	has characteristic	owl:equivalentProperty	RO:0000053	bearer of	.	semapv:ManualMappingCuration
 COB:0000002	is concretized as	owl:equivalentProperty	RO:0000058	is concretized as	.	semapv:ManualMappingCuration
@@ -135,4 +120,3 @@ COB:0000040	has specified output	owl:equivalentProperty	OBI:0000299	has_specifie
 COB:0000029	realized in	owl:equivalentProperty	BFO:0000054	realized in	.	semapv:ManualMappingCuration
 COB:0000513	is about	owl:equivalentProperty	IAO:0000136	is about	There is no inverse for 'is about' in IAO.	semapv:ManualMappingCuration
 COB:0000123	agent role	owl:equivalentClass	SEPIO:0000048	agent role		semapv:ManualMappingCuration
-COB:0000123	agent role	sssom:superClassOf	OBI:0000202	investigation agent role		semapv:ManualMappingCuration

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -21,7 +21,7 @@ tests:
     inputformat: "tsv"
     multiple_input: False
     ct_json_elements: 5
-    ct_data_frame_rows: 105
+    ct_data_frame_rows: 89
     ct_graph_queries_owl:
       query_count_equivalent_classes: 60
     ct_graph_queries_rdf:

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -65,14 +65,7 @@ class TestConvert(unittest.TestCase):
                   ?e1 <http://www.w3.org/2000/01/rdf-schema#subClassOf> ?e2 .
                 }""")
         size = len(results)
-        self.assertEqual(size, 22)
-
-        results = g.query("""SELECT DISTINCT ?e1 ?e2
-                WHERE {
-                  ?e1 <https://w3id.org/sssom/superClassOf> ?e2 .
-                }""")
-        size = len(results)
-        self.assertEqual(size, 0)
+        self.assertEqual(size, 6)
 
     def test_to_rdf(self) -> None:
         """Test converting the basic example to a basic RDF graph."""

--- a/tests/validate_data/cob-to-external.tsv.json
+++ b/tests/validate_data/cob-to-external.tsv.json
@@ -3,848 +3,721 @@
   "license": "https://creativecommons.org/publicdomain/zero/1.0/",
   "mappings": [
     {
-      "subject_id": "COB:0000002",
       "predicate_id": "owl:equivalentProperty",
-      "object_id": "RO:0000058",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000002",
       "subject_label": "is concretized as",
+      "object_id": "RO:0000058",
       "object_label": "is concretized as"
     },
     {
-      "subject_id": "COB:0000003",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "PATO:0000125",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000003",
       "subject_label": "mass",
+      "object_id": "PATO:0000125",
       "object_label": "mass"
     },
     {
-      "subject_id": "COB:0000004",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "PATO:0002193",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000004",
       "subject_label": "charge",
+      "object_id": "PATO:0002193",
       "object_label": "electric"
     },
     {
-      "subject_id": "COB:0000005",
       "predicate_id": "rdfs:subClassOf",
-      "object_id": "owl:Thing",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000005",
       "subject_label": "elementary charge",
+      "object_id": "owl:Thing",
       "object_label": "owl:Thing"
     },
     {
-      "subject_id": "COB:0000006",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "BFO:0000040",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000006",
       "subject_label": "material entity",
+      "object_id": "BFO:0000040",
       "object_label": "material entity"
     },
     {
-      "subject_id": "COB:0000006",
-      "predicate_id": "sssom:superClassOf",
-      "object_id": "SO:0000110",
-      "mapping_justification": "semapv:ManualMappingCuration",
-      "subject_label": "material entity",
-      "object_label": "sequence_feature"
-    },
-    {
-      "subject_id": "COB:0000006",
-      "predicate_id": "sssom:superClassOf",
-      "object_id": "SO:0001060",
-      "mapping_justification": "semapv:ManualMappingCuration",
-      "subject_label": "material entity",
-      "object_label": "sequence_variant"
-    },
-    {
-      "subject_id": "COB:0000006",
-      "predicate_id": "sssom:superClassOf",
-      "object_id": "SO:0001260",
-      "mapping_justification": "semapv:ManualMappingCuration",
-      "subject_label": "material entity",
-      "object_label": "sequence_collection"
-    },
-    {
-      "subject_id": "COB:0000007",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "CHEBI:36342",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000007",
       "subject_label": "subatomic particle",
+      "object_id": "CHEBI:36342",
       "object_label": "subatomic particle"
     },
     {
-      "subject_id": "COB:0000008",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "CHEBI:24636",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000008",
       "subject_label": "proton",
+      "object_id": "CHEBI:24636",
       "object_label": "proton"
     },
     {
-      "subject_id": "COB:0000009",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "CHEBI:30222",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000009",
       "subject_label": "neutron",
+      "object_id": "CHEBI:30222",
       "object_label": "neutron"
     },
     {
-      "subject_id": "COB:0000010",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "CHEBI:10545",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000010",
       "subject_label": "electron",
+      "object_id": "CHEBI:10545",
       "object_label": "electron"
     },
     {
-      "subject_id": "COB:0000011",
       "predicate_id": "skos:closeMatch",
-      "object_id": "CHEBI:33250",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000011",
       "subject_label": "atom",
+      "object_id": "CHEBI:33250",
       "object_label": "atom"
     },
     {
-      "subject_id": "COB:0000012",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "CHEBI:33252",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000012",
       "subject_label": "atomic nucleus",
+      "object_id": "CHEBI:33252",
       "object_label": "atomic nucleus"
     },
     {
-      "subject_id": "COB:0000013",
       "predicate_id": "skos:closeMatch",
-      "object_id": "CHEBI:23367",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000013",
       "subject_label": "molecular entity",
+      "object_id": "CHEBI:23367",
       "object_label": "molecular entity"
     },
     {
-      "subject_id": "COB:0000013",
       "predicate_id": "skos:closeMatch",
-      "object_id": "CHEBI:25367",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000013",
       "subject_label": "molecular entity",
+      "object_id": "CHEBI:25367",
       "object_label": "molecule"
     },
     {
-      "subject_id": "COB:0000015",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "CHEBI:16541",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000015",
       "subject_label": "protein",
+      "object_id": "CHEBI:16541",
       "object_label": "protein polypeptide chain"
     },
     {
-      "subject_id": "COB:0000015",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "PR:000000001",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000015",
       "subject_label": "protein",
+      "object_id": "PR:000000001",
       "object_label": "protein"
     },
     {
-      "subject_id": "COB:0000016",
       "predicate_id": "rdfs:subPropertyOf",
-      "object_id": "owl:topObjectProperty",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000016",
       "subject_label": "executed by",
+      "object_id": "owl:topObjectProperty",
       "object_label": "topObjectProperty"
     },
     {
-      "subject_id": "COB:0000017",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "CL:0000000",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000017",
       "subject_label": "cell",
+      "object_id": "CL:0000000",
       "object_label": "cell"
     },
     {
-      "subject_id": "COB:0000017",
-      "predicate_id": "sssom:superClassOf",
-      "object_id": "PO:0009002",
-      "mapping_justification": "semapv:ManualMappingCuration",
-      "subject_label": "cell",
-      "object_label": "plant cell"
-    },
-    {
-      "subject_id": "COB:0000018",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "CL:0000003",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000018",
       "subject_label": "native cell",
+      "object_id": "CL:0000003",
       "object_label": "native cell"
     },
     {
-      "subject_id": "COB:0000018",
-      "predicate_id": "sssom:superClassOf",
-      "object_id": "PO:0025606",
-      "mapping_justification": "semapv:ManualMappingCuration",
-      "subject_label": "native cell",
-      "object_label": "native plant cell"
-    },
-    {
-      "subject_id": "COB:0000018",
-      "predicate_id": "sssom:superClassOf",
-      "object_id": "XAO:0003012",
-      "mapping_justification": "semapv:ManualMappingCuration",
-      "subject_label": "native cell",
-      "object_label": "xenopus cell"
-    },
-    {
-      "subject_id": "COB:0000018",
-      "predicate_id": "sssom:superClassOf",
-      "object_id": "ZFA:0009000",
-      "mapping_justification": "semapv:ManualMappingCuration",
-      "subject_label": "native cell",
-      "object_label": "zebrafish cell"
-    },
-    {
-      "subject_id": "COB:0000019",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "CL:0001034",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000019",
       "subject_label": "cell in vitro",
+      "object_id": "CL:0001034",
       "object_label": "cell in vitro"
     },
     {
-      "subject_id": "COB:0000020",
       "predicate_id": "rdfs:subClassOf",
-      "object_id": "owl:Thing",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000020",
       "subject_label": "subcellular structure",
+      "object_id": "owl:Thing",
       "object_label": "owl:Thing"
     },
     {
-      "subject_id": "COB:0000021",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "CARO:0001008",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000021",
       "subject_label": "gross anatomical part",
+      "object_id": "CARO:0001008",
       "object_label": "gross anatomical part"
     },
     {
-      "subject_id": "COB:0000021",
-      "predicate_id": "sssom:superClassOf",
-      "object_id": "UBERON:0010000",
-      "mapping_justification": "semapv:ManualMappingCuration",
-      "subject_label": "gross anatomical part",
-      "object_label": "multicellular anatomical structure"
-    },
-    {
-      "subject_id": "COB:0000022",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "CARO:0001010",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000022",
       "subject_label": "organism",
+      "object_id": "CARO:0001010",
       "object_label": "organism or virus or viroid"
     },
     {
-      "subject_id": "COB:0000022",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "NCBITaxon:1",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000022",
       "subject_label": "organism",
+      "object_id": "NCBITaxon:1",
       "object_label": "root"
     },
     {
-      "subject_id": "COB:0000022",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "OBI:0100026",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000022",
       "subject_label": "organism",
+      "object_id": "OBI:0100026",
       "object_label": "organism"
     },
     {
-      "subject_id": "COB:0000023",
       "predicate_id": "owl:equivalentProperty",
-      "object_id": "RO:0000052",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000023",
       "subject_label": "characteristic of",
+      "object_id": "RO:0000052",
       "object_label": "inheres in"
     },
     {
-      "subject_id": "COB:0000024",
       "predicate_id": "owl:equivalentProperty",
-      "object_id": "RO:0000056",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000024",
       "subject_label": "participates in",
+      "object_id": "RO:0000056",
       "object_label": "participates in"
     },
     {
-      "subject_id": "COB:0000025",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "OBI:0000245",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000025",
       "subject_label": "organization",
+      "object_id": "OBI:0000245",
       "object_label": "organization"
     },
     {
-      "subject_id": "COB:0000026",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "OBI:0000047",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000026",
       "subject_label": "processed material entity",
+      "object_id": "OBI:0000047",
       "object_label": "processed material"
     },
     {
-      "subject_id": "COB:0000027",
       "predicate_id": "owl:equivalentProperty",
-      "object_id": "OBI:0000295",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000027",
       "subject_label": "is specified input of",
+      "object_id": "OBI:0000295",
       "object_label": "is_specified_input_of"
     },
     {
-      "subject_id": "COB:0000028",
       "predicate_id": "owl:equivalentProperty",
-      "object_id": "OBI:0000312",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000028",
       "subject_label": "is specified output of",
+      "object_id": "OBI:0000312",
       "object_label": "is_specified_output_of"
     },
     {
-      "subject_id": "COB:0000029",
       "predicate_id": "owl:equivalentProperty",
-      "object_id": "BFO:0000054",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000029",
       "subject_label": "realized in",
+      "object_id": "BFO:0000054",
       "object_label": "realized in"
     },
     {
-      "subject_id": "COB:0000031",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "BFO:0000041",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000031",
       "subject_label": "immaterial entity",
+      "object_id": "BFO:0000041",
       "object_label": "immaterial entity"
     },
     {
-      "subject_id": "COB:0000032",
       "predicate_id": "rdfs:subClassOf",
-      "object_id": "owl:Thing",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000032",
       "subject_label": "geographical location",
+      "object_id": "owl:Thing",
       "object_label": "owl:Thing"
     },
     {
-      "subject_id": "COB:0000033",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "BFO:0000017",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000033",
       "subject_label": "realizable",
+      "object_id": "BFO:0000017",
       "object_label": "realizable entity"
     },
     {
-      "subject_id": "COB:0000034",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "BFO:0000015",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000034",
       "subject_label": "process",
+      "object_id": "BFO:0000015",
       "object_label": "process"
     },
     {
-      "subject_id": "COB:0000035",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "OBI:0000011",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000035",
       "subject_label": "planned process",
+      "object_id": "OBI:0000011",
       "object_label": "planned process"
     },
     {
-      "subject_id": "COB:0000036",
       "predicate_id": "owl:equivalentProperty",
-      "object_id": "BFO:0000067",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000036",
       "subject_label": "contains process",
+      "object_id": "BFO:0000067",
       "object_label": "contains process"
     },
     {
-      "subject_id": "COB:0000037",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "GO:0008150",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000037",
       "subject_label": "biological process",
+      "object_id": "GO:0008150",
       "object_label": "biological process"
     },
     {
-      "subject_id": "COB:0000038",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "GO:0003674",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000038",
       "subject_label": "gene product or complex activity",
+      "object_id": "GO:0003674",
       "object_label": "molecular function"
     },
     {
-      "subject_id": "COB:0000039",
       "predicate_id": "owl:equivalentProperty",
-      "object_id": "OBI:0000293",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000039",
       "subject_label": "has specified input",
+      "object_id": "OBI:0000293",
       "object_label": "has_specified_input"
     },
     {
-      "subject_id": "COB:0000040",
       "predicate_id": "owl:equivalentProperty",
-      "object_id": "OBI:0000299",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000040",
       "subject_label": "has specified output",
+      "object_id": "OBI:0000299",
       "object_label": "has_specified_output"
     },
     {
-      "subject_id": "COB:0000042",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "CHEBI:24867",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000042",
       "subject_label": "monoatomic ion",
+      "object_id": "CHEBI:24867",
       "object_label": "monoatomic ion"
     },
     {
-      "subject_id": "COB:0000043",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "CHEBI:33250",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000043",
       "subject_label": "uncharged atom",
+      "object_id": "CHEBI:33250",
       "object_label": "atom"
     },
     {
-      "subject_id": "COB:0000047",
       "predicate_id": "owl:equivalentProperty",
-      "object_id": "BFO:0000051",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000047",
       "subject_label": "has part",
+      "object_id": "BFO:0000051",
       "object_label": "has part"
     },
     {
-      "subject_id": "COB:0000049",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "CHEBI:10545",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000049",
       "subject_label": "nucleic acid polymer",
+      "object_id": "CHEBI:10545",
       "object_label": "nucleic acid"
     },
     {
-      "subject_id": "COB:0000055",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "PCO:0000000",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000055",
       "subject_label": "collection of organisms",
+      "object_id": "PCO:0000000",
       "object_label": "collection of organisms"
     },
     {
-      "subject_id": "COB:0000056",
-      "predicate_id": "sssom:superClassOf",
-      "object_id": "PO:0025117",
-      "mapping_justification": "semapv:ManualMappingCuration",
-      "subject_label": "immaterial anatomical entity",
-      "object_label": "plant anatomical space"
-    },
-    {
-      "subject_id": "COB:0000056",
-      "predicate_id": "sssom:superClassOf",
-      "object_id": "UBERON:0000466",
-      "mapping_justification": "semapv:ManualMappingCuration",
-      "subject_label": "immaterial anatomical entity",
-      "object_label": "immaterial anatomical entity"
-    },
-    {
-      "subject_id": "COB:0000057",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "BFO:0000029",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000057",
       "subject_label": "site",
+      "object_id": "BFO:0000029",
       "object_label": "site"
     },
     {
-      "subject_id": "COB:0000058",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "OBI:0001909",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000058",
       "subject_label": "conclusion based on data",
+      "object_id": "OBI:0001909",
       "object_label": "conclusion based on data"
     },
     {
-      "subject_id": "COB:0000061",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "IAO:0000030",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000061",
       "subject_label": "information",
+      "object_id": "IAO:0000030",
       "object_label": "information content entity"
     },
     {
-      "subject_id": "COB:0000062",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "OGMS:0000073",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000062",
       "subject_label": "disease diagnosis",
+      "object_id": "OGMS:0000073",
       "object_label": "diagnosis"
     },
     {
-      "subject_id": "COB:0000063",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "OGMS:0000014",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000063",
       "subject_label": "phenotypic finding",
+      "object_id": "OGMS:0000014",
       "object_label": "clinical finding"
     },
     {
-      "subject_id": "COB:0000064",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "OGMS:0000063",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000064",
       "subject_label": "disease course",
+      "object_id": "OGMS:0000063",
       "object_label": "disease course"
     },
     {
-      "subject_id": "COB:0000065",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "ENVO:02500000",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000065",
       "subject_label": "environmental process",
+      "object_id": "ENVO:02500000",
       "object_label": "environmental system process"
     },
     {
-      "subject_id": "COB:0000066",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "MOP:0000543",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000066",
       "subject_label": "physico-chemical process",
+      "object_id": "MOP:0000543",
       "object_label": "molecular process"
     },
     {
-      "subject_id": "COB:0000067",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "ENVO:01001110",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000067",
       "subject_label": "ecosystem",
+      "object_id": "ENVO:01001110",
       "object_label": "ecosystem"
     },
     {
-      "subject_id": "COB:0000068",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "ENVO:01000813",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000068",
       "subject_label": "geophysical entity",
+      "object_id": "ENVO:01000813",
       "object_label": "astronomical body part"
     },
     {
-      "subject_id": "COB:0000068",
-      "predicate_id": "sssom:superClassOf",
-      "object_id": "GEO:000000370",
-      "mapping_justification": "semapv:ManualMappingCuration",
-      "subject_label": "geophysical entity",
-      "object_label": "geographical entity"
-    },
-    {
-      "subject_id": "COB:0000069",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "IAO:0000033",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000069",
       "subject_label": "directive information entity",
+      "object_id": "IAO:0000033",
       "object_label": "directive information entity"
     },
     {
-      "subject_id": "COB:0000070",
       "predicate_id": "owl:equivalentProperty",
-      "object_id": "RO:0000057",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000070",
       "subject_label": "has participant",
+      "object_id": "RO:0000057",
       "object_label": "has participant"
     },
     {
-      "subject_id": "COB:0000071",
       "predicate_id": "owl:equivalentProperty",
-      "object_id": "BFO:0000066",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000071",
       "subject_label": "occurs in",
+      "object_id": "BFO:0000066",
       "object_label": "occurs in"
     },
     {
-      "subject_id": "COB:0000072",
       "predicate_id": "owl:equivalentProperty",
-      "object_id": "BFO:0000050",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000072",
       "subject_label": "part of",
+      "object_id": "BFO:0000050",
       "object_label": "part of"
     },
     {
-      "subject_id": "COB:0000073",
       "predicate_id": "rdfs:subClassOf",
-      "object_id": "owl:Thing",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000073",
       "subject_label": "gene product",
+      "object_id": "owl:Thing",
       "object_label": "owl:Thing"
     },
     {
-      "subject_id": "COB:0000074",
       "predicate_id": "owl:equivalentProperty",
-      "object_id": "RO:0002333",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000074",
       "subject_label": "enabled by",
+      "object_id": "RO:0002333",
       "object_label": "enabled by"
     },
     {
-      "subject_id": "COB:0000075",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "GO:0032991",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000075",
       "subject_label": "protein-containing macromolecular complex",
+      "object_id": "GO:0032991",
       "object_label": "protein-containing complex"
     },
     {
-      "subject_id": "COB:0000076",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "IAO:0000005",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000076",
       "subject_label": "objective specification",
+      "object_id": "IAO:0000005",
       "object_label": "objective specification"
     },
     {
-      "subject_id": "COB:0000079",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "IAO:0000104",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000079",
       "subject_label": "plan specification",
+      "object_id": "IAO:0000104",
       "object_label": "plan specification"
     },
     {
-      "subject_id": "COB:0000080",
       "predicate_id": "rdfs:subClassOf",
-      "object_id": "owl:Thing",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000080",
       "subject_label": "complex of molecular entities",
+      "object_id": "owl:Thing",
       "object_label": "owl:Thing"
     },
     {
-      "subject_id": "COB:0000086",
       "predicate_id": "owl:equivalentProperty",
-      "object_id": "STATO:0000102",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000086",
       "subject_label": "executes",
+      "object_id": "STATO:0000102",
       "object_label": "executes"
     },
     {
-      "subject_id": "COB:0000088",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "DRON:0000005",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000088",
       "subject_label": "drug product",
+      "object_id": "DRON:0000005",
       "object_label": "drug product"
     },
     {
-      "subject_id": "COB:0000088",
       "predicate_id": "rdfs:seeAlso",
-      "object_id": "CHEBI:23888",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000088",
       "subject_label": "drug product",
+      "object_id": "CHEBI:23888",
       "object_label": "drug"
     },
     {
-      "subject_id": "COB:0000101",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "IAO:0000310",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000101",
       "subject_label": "document",
+      "object_id": "IAO:0000310",
       "object_label": "document"
     },
     {
-      "subject_id": "COB:0000102",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "IAO:0000027",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000102",
       "subject_label": "data item",
+      "object_id": "IAO:0000027",
       "object_label": "data item"
     },
     {
-      "subject_id": "COB:0000103",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "GO:0005634",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000103",
       "subject_label": "cell nucleus",
+      "object_id": "GO:0005634",
       "object_label": "nucleus"
     },
     {
-      "subject_id": "COB:0000107",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "OBI:0000070",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000107",
       "subject_label": "assay",
+      "object_id": "OBI:0000070",
       "object_label": "assay"
     },
     {
-      "subject_id": "COB:0000108",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "OBI:0200000",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000108",
       "subject_label": "data transformation",
+      "object_id": "OBI:0200000",
       "object_label": "data transformation"
     },
     {
-      "subject_id": "COB:0000109",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "OBI:0000066",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000109",
       "subject_label": "investigation",
+      "object_id": "OBI:0000066",
       "object_label": "investigation"
     },
     {
-      "subject_id": "COB:0000110",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "OBI:0000094",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000110",
       "subject_label": "material processing",
+      "object_id": "OBI:0000094",
       "object_label": "material processing"
     },
     {
-      "subject_id": "COB:0000111",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "BFO:0000016",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000111",
       "subject_label": "disposition",
+      "object_id": "BFO:0000016",
       "object_label": "disposition"
     },
     {
-      "subject_id": "COB:0000112",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "BFO:0000034",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000112",
       "subject_label": "function",
+      "object_id": "BFO:0000034",
       "object_label": "function"
     },
     {
-      "subject_id": "COB:0000113",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "OBI:0000260",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000113",
       "subject_label": "plan",
+      "object_id": "OBI:0000260",
       "object_label": "plan"
     },
     {
-      "subject_id": "COB:0000114",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "BFO:0000023",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000114",
       "subject_label": "role",
+      "object_id": "BFO:0000023",
       "object_label": "role"
     },
     {
-      "subject_id": "COB:0000116",
       "predicate_id": "rdfs:subClassOf",
-      "object_id": "owl:Thing",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000116",
       "subject_label": "cellular membrane",
+      "object_id": "owl:Thing",
       "object_label": "owl:Thing"
     },
     {
-      "subject_id": "COB:0000118",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "CARO:0010004",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000118",
       "subject_label": "cellular organism",
+      "object_id": "CARO:0010004",
       "object_label": "cellular organism"
     },
     {
-      "subject_id": "COB:0000118",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "NCBITaxon:131567",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000118",
       "subject_label": "cellular organism",
+      "object_id": "NCBITaxon:131567",
       "object_label": "cellular organisms"
     },
     {
-      "subject_id": "COB:0000118",
-      "predicate_id": "sssom:superClassOf",
-      "object_id": "PO:0000003",
-      "mapping_justification": "semapv:ManualMappingCuration",
-      "subject_label": "cellular organism",
-      "object_label": "whole plant"
-    },
-    {
-      "subject_id": "COB:0000118",
-      "predicate_id": "sssom:superClassOf",
-      "object_id": "UBERON:0000468",
-      "mapping_justification": "semapv:ManualMappingCuration",
-      "subject_label": "cellular organism",
-      "object_label": "multicellular organism"
-    },
-    {
-      "subject_id": "COB:0000123",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "SEPIO:0000048",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000123",
       "subject_label": "agent role",
+      "object_id": "SEPIO:0000048",
       "object_label": "agent role"
     },
     {
-      "subject_id": "COB:0000123",
-      "predicate_id": "sssom:superClassOf",
-      "object_id": "OBI:0000202",
-      "mapping_justification": "semapv:ManualMappingCuration",
-      "subject_label": "agent role",
-      "object_label": "investigation agent role"
-    },
-    {
-      "subject_id": "COB:0000502",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "BFO:0000020",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000502",
       "subject_label": "characteristic",
+      "object_id": "BFO:0000020",
       "object_label": "specifically dependent continuant"
     },
     {
-      "subject_id": "COB:0000502",
       "predicate_id": "owl:equivalentClass",
-      "object_id": "PATO:0000001",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000502",
       "subject_label": "characteristic",
+      "object_id": "PATO:0000001",
       "object_label": "quality"
     },
     {
-      "subject_id": "COB:0000502",
-      "predicate_id": "sssom:superClassOf",
-      "object_id": "CHEBI:50906",
-      "mapping_justification": "semapv:ManualMappingCuration",
-      "subject_label": "characteristic",
-      "object_label": "role"
-    },
-    {
-      "subject_id": "COB:0000502",
-      "predicate_id": "sssom:superClassOf",
-      "object_id": "SO:0000400",
-      "mapping_justification": "semapv:ManualMappingCuration",
-      "subject_label": "characteristic",
-      "object_label": "sequence_attribute"
-    },
-    {
-      "subject_id": "COB:0000511",
       "predicate_id": "rdfs:subPropertyOf",
-      "object_id": "owl:topObjectProperty",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000511",
       "subject_label": "has quantity",
+      "object_id": "owl:topObjectProperty",
       "object_label": "topObjectProperty"
     },
     {
-      "subject_id": "COB:0000512",
       "predicate_id": "owl:equivalentProperty",
-      "object_id": "RO:0000053",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000512",
       "subject_label": "has characteristic",
+      "object_id": "RO:0000053",
       "object_label": "bearer of"
     },
     {
-      "subject_id": "COB:0000513",
       "predicate_id": "owl:equivalentProperty",
-      "object_id": "IAO:0000136",
       "mapping_justification": "semapv:ManualMappingCuration",
+      "subject_id": "COB:0000513",
       "subject_label": "is about",
+      "object_id": "IAO:0000136",
       "object_label": "is about"
     }
   ],
   "@type": "MappingSet",
   "@context": {
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
     "dcterms": "http://purl.org/dc/terms/",
     "linkml": "https://w3id.org/linkml/",
     "oboInOwl": "http://www.geneontology.org/formats/oboInOwl#",
@@ -856,95 +729,138 @@
     "semapv": "https://w3id.org/semapv/vocab/",
     "skos": "http://www.w3.org/2004/02/skos/core#",
     "sssom": "https://w3id.org/sssom/",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
     "@vocab": "https://w3id.org/sssom/",
     "author_id": {
       "@type": "rdfs:Resource",
       "@id": "pav:authoredBy"
     },
+    "author_label": {
+      "@id": "author_label"
+    },
+    "cardinality_scope": {
+      "@id": "cardinality_scope"
+    },
     "comment": {
       "@id": "rdfs:comment"
     },
     "confidence": {
-      "@type": "xsd:double"
+      "@type": "xsd:double",
+      "@id": "confidence"
     },
     "creator_id": {
       "@type": "rdfs:Resource",
       "@id": "dcterms:creator"
     },
+    "creator_label": {
+      "@id": "creator_label"
+    },
     "curation_rule": {
-      "@type": "rdfs:Resource"
+      "@type": "rdfs:Resource",
+      "@id": "curation_rule"
+    },
+    "curation_rule_text": {
+      "@id": "curation_rule_text"
     },
     "curie_map": {
-      "@type": "@id"
+      "@type": "@id",
+      "@id": "curie_map"
     },
     "documentation": {
-      "@type": "@id"
+      "@type": "xsd:anyURI",
+      "@id": "documentation"
+    },
+    "extension_definitions": {
+      "@type": "@id",
+      "@id": "extension_definitions"
+    },
+    "property": {
+      "@type": "xsd:anyURI",
+      "@id": "property"
+    },
+    "slot_name": {
+      "@id": "slot_name"
+    },
+    "type_hint": {
+      "@type": "xsd:anyURI",
+      "@id": "type_hint"
     },
     "homepage": {
-      "@type": "@id"
+      "@type": "xsd:anyURI",
+      "@id": "homepage"
     },
     "imports": {
-      "@type": "@id"
+      "@type": "xsd:anyURI",
+      "@id": "imports"
     },
     "issue_tracker": {
-      "@type": "@id"
+      "@type": "xsd:anyURI",
+      "@id": "issue_tracker"
     },
     "issue_tracker_item": {
-      "@type": "rdfs:Resource"
+      "@type": "rdfs:Resource",
+      "@id": "issue_tracker_item"
     },
     "last_updated": {
-      "@type": "xsd:date"
+      "@type": "xsd:date",
+      "@id": "last_updated"
     },
     "license": {
-      "@type": "@id",
+      "@type": "xsd:anyURI",
       "@id": "dcterms:license"
     },
-    "literal": {
-      "@id": "owl:annotatedTarget"
-    },
-    "literal_datatype": {
-      "@type": "@id",
-      "@id": "rdf:datatype"
-    },
-    "literal_preprocessing": {
-      "@type": "rdfs:Resource"
-    },
-    "literal_source": {
-      "@type": "rdfs:Resource"
+    "local_name": {
+      "@id": "local_name"
     },
     "mapping_cardinality": {
       "@context": {
-        "@vocab": "@null",
         "text": "skos:notation",
         "description": "skos:prefLabel",
         "meaning": "@id"
-      }
+      },
+      "@id": "mapping_cardinality"
     },
     "mapping_date": {
       "@type": "xsd:date",
-      "@id": "pav:authoredOn"
+      "@id": "dcterms:created"
     },
     "mapping_justification": {
-      "@type": "rdfs:Resource"
+      "@type": "rdfs:Resource",
+      "@id": "mapping_justification"
     },
     "mapping_provider": {
-      "@type": "@id"
+      "@type": "xsd:anyURI",
+      "@id": "mapping_provider"
+    },
+    "mapping_registry_description": {
+      "@id": "mapping_registry_description"
     },
     "mapping_registry_id": {
-      "@type": "rdfs:Resource"
+      "@type": "rdfs:Resource",
+      "@id": "mapping_registry_id"
+    },
+    "mapping_registry_title": {
+      "@id": "mapping_registry_title"
+    },
+    "mapping_set_confidence": {
+      "@type": "xsd:double",
+      "@id": "mapping_set_confidence"
     },
     "mapping_set_description": {
       "@id": "dcterms:description"
     },
+    "mapping_set_group": {
+      "@id": "mapping_set_group"
+    },
     "mapping_set_id": {
-      "@type": "@id"
+      "@type": "xsd:anyURI",
+      "@id": "mapping_set_id"
     },
     "mapping_set_references": {
-      "@type": "@id"
+      "@type": "@id",
+      "@id": "mapping_set_references"
     },
     "mapping_set_source": {
-      "@type": "@id",
+      "@type": "xsd:anyURI",
       "@id": "prov:wasDerivedFrom"
     },
     "mapping_set_title": {
@@ -954,103 +870,213 @@
       "@id": "owl:versionInfo"
     },
     "mapping_source": {
-      "@type": "rdfs:Resource"
+      "@type": "rdfs:Resource",
+      "@id": "mapping_source"
+    },
+    "mapping_tool": {
+      "@id": "mapping_tool"
+    },
+    "mapping_tool_id": {
+      "@type": "rdfs:Resource",
+      "@id": "mapping_tool_id"
+    },
+    "mapping_tool_version": {
+      "@id": "mapping_tool_version"
     },
     "mappings": {
-      "@type": "@id"
+      "@type": "@id",
+      "@id": "mappings"
+    },
+    "match_string": {
+      "@id": "match_string"
     },
     "mirror_from": {
-      "@type": "@id"
+      "@type": "xsd:anyURI",
+      "@id": "mirror_from"
+    },
+    "object_category": {
+      "@id": "object_category"
     },
     "object_id": {
       "@type": "rdfs:Resource",
       "@id": "owl:annotatedTarget"
     },
+    "object_label": {
+      "@id": "object_label"
+    },
     "object_match_field": {
-      "@type": "rdfs:Resource"
+      "@type": "rdfs:Resource",
+      "@id": "object_match_field"
     },
     "object_preprocessing": {
-      "@type": "rdfs:Resource"
+      "@type": "rdfs:Resource",
+      "@id": "object_preprocessing"
     },
     "object_source": {
-      "@type": "rdfs:Resource"
+      "@type": "rdfs:Resource",
+      "@id": "object_source"
+    },
+    "object_source_version": {
+      "@id": "object_source_version"
     },
     "object_type": {
       "@context": {
-        "@vocab": "@null",
         "text": "skos:notation",
         "description": "skos:prefLabel",
         "meaning": "@id"
-      }
+      },
+      "@id": "object_type"
+    },
+    "other": {
+      "@id": "other"
     },
     "predicate_id": {
       "@type": "rdfs:Resource",
       "@id": "owl:annotatedProperty"
     },
+    "predicate_label": {
+      "@id": "predicate_label"
+    },
     "predicate_modifier": {
       "@context": {
-        "@vocab": "@null",
         "text": "skos:notation",
         "description": "skos:prefLabel",
         "meaning": "@id"
-      }
+      },
+      "@id": "predicate_modifier"
     },
     "predicate_type": {
       "@context": {
-        "@vocab": "@null",
         "text": "skos:notation",
         "description": "skos:prefLabel",
         "meaning": "@id"
-      }
+      },
+      "@id": "predicate_type"
+    },
+    "prefix_name": {
+      "@id": "prefix_name"
     },
     "prefix_url": {
-      "@type": "@id"
+      "@type": "xsd:anyURI",
+      "@id": "prefix_url"
+    },
+    "propagated": {
+      "@type": "xsd:boolean",
+      "@id": "propagated"
     },
     "publication_date": {
       "@type": "xsd:date",
-      "@id": "dcterms:created"
+      "@id": "dcterms:issued"
+    },
+    "record_id": {
+      "@type": "rdfs:Resource",
+      "@id": "record_id"
     },
     "registry_confidence": {
-      "@type": "xsd:double"
+      "@type": "xsd:double",
+      "@id": "registry_confidence"
+    },
+    "review_date": {
+      "@type": "xsd:date",
+      "@id": "review_date"
+    },
+    "reviewer_agreement": {
+      "@type": "xsd:double",
+      "@id": "reviewer_agreement"
     },
     "reviewer_id": {
-      "@type": "rdfs:Resource"
+      "@type": "rdfs:Resource",
+      "@id": "reviewer_id"
+    },
+    "reviewer_label": {
+      "@id": "reviewer_label"
     },
     "see_also": {
+      "@type": "xsd:anyURI",
       "@id": "rdfs:seeAlso"
     },
-    "semantic_similarity_score": {
-      "@type": "xsd:double"
+    "similarity_measure": {
+      "@id": "similarity_measure"
     },
     "similarity_score": {
-      "@type": "xsd:double"
+      "@type": "xsd:double",
+      "@id": "similarity_score"
+    },
+    "sssom_version": {
+      "@context": {
+        "text": "skos:notation",
+        "description": "skos:prefLabel",
+        "meaning": "@id"
+      },
+      "@id": "sssom_version"
+    },
+    "subject_category": {
+      "@id": "subject_category"
     },
     "subject_id": {
       "@type": "rdfs:Resource",
       "@id": "owl:annotatedSource"
     },
+    "subject_label": {
+      "@id": "subject_label"
+    },
     "subject_match_field": {
-      "@type": "rdfs:Resource"
+      "@type": "rdfs:Resource",
+      "@id": "subject_match_field"
     },
     "subject_preprocessing": {
-      "@type": "rdfs:Resource"
+      "@type": "rdfs:Resource",
+      "@id": "subject_preprocessing"
     },
     "subject_source": {
-      "@type": "rdfs:Resource"
+      "@type": "rdfs:Resource",
+      "@id": "subject_source"
+    },
+    "subject_source_version": {
+      "@id": "subject_source_version"
     },
     "subject_type": {
       "@context": {
-        "@vocab": "@null",
         "text": "skos:notation",
         "description": "skos:prefLabel",
         "meaning": "@id"
-      }
+      },
+      "@id": "subject_type"
     },
-    "LiteralMapping": {
-      "@id": "owl:Axiom"
+    "added_in": {
+      "@context": {
+        "text": "skos:notation",
+        "description": "skos:prefLabel",
+        "meaning": "@id"
+      },
+      "@id": "added_in"
+    },
+    "ExtensionDefinition": {
+      "@id": "ExtensionDefinition"
     },
     "Mapping": {
       "@id": "owl:Axiom"
+    },
+    "MappingRegistry": {
+      "@id": "MappingRegistry"
+    },
+    "MappingSet": {
+      "@id": "MappingSet"
+    },
+    "MappingSetReference": {
+      "@id": "MappingSetReference"
+    },
+    "NoTermFound": {
+      "@id": "NoTermFound"
+    },
+    "Prefix": {
+      "@id": "Prefix"
+    },
+    "Propagatable": {
+      "@id": "Propagatable"
+    },
+    "Versionable": {
+      "@id": "Versionable"
     },
     "BFO": "http://purl.obolibrary.org/obo/BFO_",
     "CARO": "http://purl.obolibrary.org/obo/CARO_",

--- a/tests/validate_data/cob-to-external.tsv.owl
+++ b/tests/validate_data/cob-to-external.tsv.owl
@@ -5,7 +5,6 @@
 @prefix COB: <http://purl.obolibrary.org/obo/COB_> .
 @prefix DRON: <http://purl.obolibrary.org/obo/DRON_> .
 @prefix ENVO: <http://purl.obolibrary.org/obo/ENVO_> .
-@prefix GEO: <http://purl.obolibrary.org/obo/GEO_> .
 @prefix GO: <http://purl.obolibrary.org/obo/GO_> .
 @prefix IAO: <http://purl.obolibrary.org/obo/IAO_> .
 @prefix MOP: <http://purl.obolibrary.org/obo/MOP_> .
@@ -14,22 +13,19 @@
 @prefix OGMS: <http://purl.obolibrary.org/obo/OGMS_> .
 @prefix PATO: <http://purl.obolibrary.org/obo/PATO_> .
 @prefix PCO: <http://purl.obolibrary.org/obo/PCO_> .
-@prefix PO: <http://purl.obolibrary.org/obo/PO_> .
 @prefix PR: <http://purl.obolibrary.org/obo/PR_> .
 @prefix RO: <http://purl.obolibrary.org/obo/RO_> .
 @prefix SEPIO: <http://purl.obolibrary.org/obo/SEPIO_> .
-@prefix SO: <http://purl.obolibrary.org/obo/SO_> .
 @prefix STATO: <http://purl.obolibrary.org/obo/STATO_> .
-@prefix UBERON: <http://purl.obolibrary.org/obo/UBERON_> .
-@prefix XAO: <http://purl.obolibrary.org/obo/XAO_> .
-@prefix ZFA: <http://purl.obolibrary.org/obo/ZFA_> .
-@prefix dc1: <http://purl.org/dc/terms/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix semapv: <https://w3id.org/semapv/vocab/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix sssom: <https://w3id.org/sssom/> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://purl.obolibrary.org/obo/cob/components/cob-to-external.tsv> a owl:Ontology ;
+    dcterms:license <https://creativecommons.org/publicdomain/zero/1.0/> .
 
 sssom:mapping_justification a owl:AnnotationProperty .
 
@@ -37,40 +33,79 @@ sssom:object_label a owl:AnnotationProperty .
 
 sssom:subject_label a owl:AnnotationProperty .
 
-CHEBI:50906 rdfs:subClassOf COB:0000502 .
+BFO:0000015 a owl:Class ;
+    owl:equivalentClass COB:0000034 .
+
+BFO:0000016 a owl:Class ;
+    owl:equivalentClass COB:0000111 .
+
+BFO:0000017 a owl:Class ;
+    owl:equivalentClass COB:0000033 .
+
+BFO:0000020 a owl:Class ;
+    owl:equivalentClass COB:0000502 .
+
+BFO:0000023 a owl:Class ;
+    owl:equivalentClass COB:0000114 .
+
+BFO:0000029 a owl:Class ;
+    owl:equivalentClass COB:0000057 .
+
+BFO:0000034 a owl:Class ;
+    owl:equivalentClass COB:0000112 .
+
+BFO:0000040 a owl:Class ;
+    owl:equivalentClass COB:0000006 .
+
+BFO:0000041 a owl:Class ;
+    owl:equivalentClass COB:0000031 .
+
+CARO:0001008 a owl:Class ;
+    owl:equivalentClass COB:0000021 .
+
+CARO:0001010 a owl:Class ;
+    owl:equivalentClass COB:0000022 .
+
+CARO:0010004 a owl:Class ;
+    owl:equivalentClass COB:0000118 .
+
+CHEBI:16541 a owl:Class ;
+    owl:equivalentClass COB:0000015 .
+
+CHEBI:23367 skos:closeMatch COB:0000013 .
+
+CHEBI:24636 a owl:Class ;
+    owl:equivalentClass COB:0000008 .
+
+CHEBI:24867 a owl:Class ;
+    owl:equivalentClass COB:0000042 .
+
+CHEBI:25367 skos:closeMatch COB:0000013 .
+
+CHEBI:30222 a owl:Class ;
+    owl:equivalentClass COB:0000009 .
+
+CHEBI:33252 a owl:Class ;
+    owl:equivalentClass COB:0000012 .
+
+CHEBI:36342 a owl:Class ;
+    owl:equivalentClass COB:0000007 .
+
+CL:0000000 a owl:Class ;
+    owl:equivalentClass COB:0000017 .
+
+CL:0000003 a owl:Class ;
+    owl:equivalentClass COB:0000018 .
+
+CL:0001034 a owl:Class ;
+    owl:equivalentClass COB:0000019 .
 
 COB:0000002 a owl:ObjectProperty ;
     owl:equivalentProperty RO:0000058 .
 
-COB:0000003 a owl:Class ;
-    owl:equivalentClass PATO:0000125 .
-
-COB:0000004 a owl:Class ;
-    owl:equivalentClass PATO:0002193 .
-
 COB:0000005 rdfs:subClassOf owl:Thing .
 
-COB:0000007 a owl:Class ;
-    owl:equivalentClass CHEBI:36342 .
-
-COB:0000008 a owl:Class ;
-    owl:equivalentClass CHEBI:24636 .
-
-COB:0000009 a owl:Class ;
-    owl:equivalentClass CHEBI:30222 .
-
-COB:0000010 a owl:Class ;
-    owl:equivalentClass CHEBI:10545 .
-
-COB:0000011 skos:closeMatch CHEBI:33250 .
-
-COB:0000012 a owl:Class ;
-    owl:equivalentClass CHEBI:33252 .
-
 COB:0000016 rdfs:subPropertyOf owl:topObjectProperty .
-
-COB:0000019 a owl:Class ;
-    owl:equivalentClass CL:0001034 .
 
 COB:0000020 rdfs:subClassOf owl:Thing .
 
@@ -79,12 +114,6 @@ COB:0000023 a owl:ObjectProperty ;
 
 COB:0000024 a owl:ObjectProperty ;
     owl:equivalentProperty RO:0000056 .
-
-COB:0000025 a owl:Class ;
-    owl:equivalentClass OBI:0000245 .
-
-COB:0000026 a owl:Class ;
-    owl:equivalentClass OBI:0000047 .
 
 COB:0000027 a owl:ObjectProperty ;
     owl:equivalentProperty OBI:0000295 .
@@ -95,28 +124,10 @@ COB:0000028 a owl:ObjectProperty ;
 COB:0000029 a owl:ObjectProperty ;
     owl:equivalentProperty BFO:0000054 .
 
-COB:0000031 a owl:Class ;
-    owl:equivalentClass BFO:0000041 .
-
 COB:0000032 rdfs:subClassOf owl:Thing .
-
-COB:0000033 a owl:Class ;
-    owl:equivalentClass BFO:0000017 .
-
-COB:0000034 a owl:Class ;
-    owl:equivalentClass BFO:0000015 .
-
-COB:0000035 a owl:Class ;
-    owl:equivalentClass OBI:0000011 .
 
 COB:0000036 a owl:ObjectProperty ;
     owl:equivalentProperty BFO:0000067 .
-
-COB:0000037 a owl:Class ;
-    owl:equivalentClass GO:0008150 .
-
-COB:0000038 a owl:Class ;
-    owl:equivalentClass GO:0003674 .
 
 COB:0000039 a owl:ObjectProperty ;
     owl:equivalentProperty OBI:0000293 .
@@ -124,50 +135,8 @@ COB:0000039 a owl:ObjectProperty ;
 COB:0000040 a owl:ObjectProperty ;
     owl:equivalentProperty OBI:0000299 .
 
-COB:0000042 a owl:Class ;
-    owl:equivalentClass CHEBI:24867 .
-
-COB:0000043 a owl:Class ;
-    owl:equivalentClass CHEBI:33250 .
-
 COB:0000047 a owl:ObjectProperty ;
     owl:equivalentProperty BFO:0000051 .
-
-COB:0000049 a owl:Class ;
-    owl:equivalentClass CHEBI:10545 .
-
-COB:0000055 a owl:Class ;
-    owl:equivalentClass PCO:0000000 .
-
-COB:0000057 a owl:Class ;
-    owl:equivalentClass BFO:0000029 .
-
-COB:0000058 a owl:Class ;
-    owl:equivalentClass OBI:0001909 .
-
-COB:0000061 a owl:Class ;
-    owl:equivalentClass IAO:0000030 .
-
-COB:0000062 a owl:Class ;
-    owl:equivalentClass OGMS:0000073 .
-
-COB:0000063 a owl:Class ;
-    owl:equivalentClass OGMS:0000014 .
-
-COB:0000064 a owl:Class ;
-    owl:equivalentClass OGMS:0000063 .
-
-COB:0000065 a owl:Class ;
-    owl:equivalentClass ENVO:02500000 .
-
-COB:0000066 a owl:Class ;
-    owl:equivalentClass MOP:0000543 .
-
-COB:0000067 a owl:Class ;
-    owl:equivalentClass ENVO:01001110 .
-
-COB:0000069 a owl:Class ;
-    owl:equivalentClass IAO:0000033 .
 
 COB:0000070 a owl:ObjectProperty ;
     owl:equivalentProperty RO:0000057 .
@@ -183,52 +152,10 @@ COB:0000073 rdfs:subClassOf owl:Thing .
 COB:0000074 a owl:ObjectProperty ;
     owl:equivalentProperty RO:0002333 .
 
-COB:0000075 a owl:Class ;
-    owl:equivalentClass GO:0032991 .
-
-COB:0000076 a owl:Class ;
-    owl:equivalentClass IAO:0000005 .
-
-COB:0000079 a owl:Class ;
-    owl:equivalentClass IAO:0000104 .
-
 COB:0000080 rdfs:subClassOf owl:Thing .
 
 COB:0000086 a owl:ObjectProperty ;
     owl:equivalentProperty STATO:0000102 .
-
-COB:0000101 a owl:Class ;
-    owl:equivalentClass IAO:0000310 .
-
-COB:0000102 a owl:Class ;
-    owl:equivalentClass IAO:0000027 .
-
-COB:0000103 a owl:Class ;
-    owl:equivalentClass GO:0005634 .
-
-COB:0000107 a owl:Class ;
-    owl:equivalentClass OBI:0000070 .
-
-COB:0000108 a owl:Class ;
-    owl:equivalentClass OBI:0200000 .
-
-COB:0000109 a owl:Class ;
-    owl:equivalentClass OBI:0000066 .
-
-COB:0000110 a owl:Class ;
-    owl:equivalentClass OBI:0000094 .
-
-COB:0000111 a owl:Class ;
-    owl:equivalentClass BFO:0000016 .
-
-COB:0000112 a owl:Class ;
-    owl:equivalentClass BFO:0000034 .
-
-COB:0000113 a owl:Class ;
-    owl:equivalentClass OBI:0000260 .
-
-COB:0000114 a owl:Class ;
-    owl:equivalentClass BFO:0000023 .
 
 COB:0000116 rdfs:subClassOf owl:Thing .
 
@@ -240,53 +167,113 @@ COB:0000512 a owl:ObjectProperty ;
 COB:0000513 a owl:ObjectProperty ;
     owl:equivalentProperty IAO:0000136 .
 
-GEO:000000370 rdfs:subClassOf COB:0000068 .
+DRON:0000005 a owl:Class ;
+    owl:equivalentClass COB:0000088 .
 
-OBI:0000202 rdfs:subClassOf COB:0000123 .
+ENVO:01000813 a owl:Class ;
+    owl:equivalentClass COB:0000068 .
 
-PO:0000003 rdfs:subClassOf COB:0000118 .
+ENVO:01001110 a owl:Class ;
+    owl:equivalentClass COB:0000067 .
 
-PO:0009002 rdfs:subClassOf COB:0000017 .
+ENVO:02500000 a owl:Class ;
+    owl:equivalentClass COB:0000065 .
 
-PO:0025117 rdfs:subClassOf COB:0000056 .
+GO:0003674 a owl:Class ;
+    owl:equivalentClass COB:0000038 .
 
-PO:0025606 rdfs:subClassOf COB:0000018 .
+GO:0005634 a owl:Class ;
+    owl:equivalentClass COB:0000103 .
 
-SO:0000110 rdfs:subClassOf COB:0000006 .
+GO:0008150 a owl:Class ;
+    owl:equivalentClass COB:0000037 .
 
-SO:0000400 rdfs:subClassOf COB:0000502 .
+GO:0032991 a owl:Class ;
+    owl:equivalentClass COB:0000075 .
 
-SO:0001060 rdfs:subClassOf COB:0000006 .
+IAO:0000005 a owl:Class ;
+    owl:equivalentClass COB:0000076 .
 
-SO:0001260 rdfs:subClassOf COB:0000006 .
+IAO:0000027 a owl:Class ;
+    owl:equivalentClass COB:0000102 .
 
-UBERON:0000466 rdfs:subClassOf COB:0000056 .
+IAO:0000030 a owl:Class ;
+    owl:equivalentClass COB:0000061 .
 
-UBERON:0000468 rdfs:subClassOf COB:0000118 .
+IAO:0000033 a owl:Class ;
+    owl:equivalentClass COB:0000069 .
 
-UBERON:0010000 rdfs:subClassOf COB:0000021 .
+IAO:0000104 a owl:Class ;
+    owl:equivalentClass COB:0000079 .
 
-XAO:0003012 rdfs:subClassOf COB:0000018 .
+IAO:0000310 a owl:Class ;
+    owl:equivalentClass COB:0000101 .
 
-ZFA:0009000 rdfs:subClassOf COB:0000018 .
+MOP:0000543 a owl:Class ;
+    owl:equivalentClass COB:0000066 .
 
-BFO:0000015 a owl:Class .
+NCBITaxon:1 a owl:Class ;
+    owl:equivalentClass COB:0000022 .
 
-BFO:0000016 a owl:Class .
+NCBITaxon:131567 a owl:Class ;
+    owl:equivalentClass COB:0000118 .
 
-BFO:0000017 a owl:Class .
+OBI:0000011 a owl:Class ;
+    owl:equivalentClass COB:0000035 .
 
-BFO:0000020 a owl:Class .
+OBI:0000047 a owl:Class ;
+    owl:equivalentClass COB:0000026 .
 
-BFO:0000023 a owl:Class .
+OBI:0000066 a owl:Class ;
+    owl:equivalentClass COB:0000109 .
 
-BFO:0000029 a owl:Class .
+OBI:0000070 a owl:Class ;
+    owl:equivalentClass COB:0000107 .
 
-BFO:0000034 a owl:Class .
+OBI:0000094 a owl:Class ;
+    owl:equivalentClass COB:0000110 .
 
-BFO:0000040 a owl:Class .
+OBI:0000245 a owl:Class ;
+    owl:equivalentClass COB:0000025 .
 
-BFO:0000041 a owl:Class .
+OBI:0000260 a owl:Class ;
+    owl:equivalentClass COB:0000113 .
+
+OBI:0001909 a owl:Class ;
+    owl:equivalentClass COB:0000058 .
+
+OBI:0100026 a owl:Class ;
+    owl:equivalentClass COB:0000022 .
+
+OBI:0200000 a owl:Class ;
+    owl:equivalentClass COB:0000108 .
+
+OGMS:0000014 a owl:Class ;
+    owl:equivalentClass COB:0000063 .
+
+OGMS:0000063 a owl:Class ;
+    owl:equivalentClass COB:0000064 .
+
+OGMS:0000073 a owl:Class ;
+    owl:equivalentClass COB:0000062 .
+
+PATO:0000001 a owl:Class ;
+    owl:equivalentClass COB:0000502 .
+
+PATO:0000125 a owl:Class ;
+    owl:equivalentClass COB:0000003 .
+
+PATO:0002193 a owl:Class ;
+    owl:equivalentClass COB:0000004 .
+
+PCO:0000000 a owl:Class ;
+    owl:equivalentClass COB:0000055 .
+
+PR:000000001 a owl:Class ;
+    owl:equivalentClass COB:0000015 .
+
+SEPIO:0000048 a owl:Class ;
+    owl:equivalentClass COB:0000123 .
 
 BFO:0000050 a owl:ObjectProperty .
 
@@ -298,90 +285,115 @@ BFO:0000066 a owl:ObjectProperty .
 
 BFO:0000067 a owl:ObjectProperty .
 
-CARO:0001008 a owl:Class .
+CHEBI:10545 a owl:Class ;
+    owl:equivalentClass COB:0000010,
+        COB:0000049 .
 
-CARO:0001010 a owl:Class .
+CHEBI:33250 a owl:Class ;
+    owl:equivalentClass COB:0000043 ;
+    skos:closeMatch COB:0000011 .
 
-CARO:0010004 a owl:Class .
+COB:0000003 a owl:Class .
 
-CHEBI:16541 a owl:Class .
+COB:0000004 a owl:Class .
 
-CHEBI:24636 a owl:Class .
+COB:0000006 a owl:Class .
 
-CHEBI:24867 a owl:Class .
+COB:0000007 a owl:Class .
 
-CHEBI:30222 a owl:Class .
+COB:0000008 a owl:Class .
 
-CHEBI:33252 a owl:Class .
+COB:0000009 a owl:Class .
 
-CHEBI:36342 a owl:Class .
+COB:0000010 a owl:Class .
 
-CL:0000000 a owl:Class .
+COB:0000012 a owl:Class .
 
-CL:0000003 a owl:Class .
+COB:0000017 a owl:Class .
 
-CL:0001034 a owl:Class .
+COB:0000018 a owl:Class .
 
-COB:0000013 skos:closeMatch CHEBI:23367,
-        CHEBI:25367 .
+COB:0000019 a owl:Class .
 
-COB:0000015 a owl:Class ;
-    owl:equivalentClass CHEBI:16541,
-        PR:000000001 .
+COB:0000021 a owl:Class .
 
-COB:0000088 a owl:Class ;
-    rdfs:seeAlso CHEBI:23888 ;
-    owl:equivalentClass DRON:0000005 .
+COB:0000025 a owl:Class .
 
-DRON:0000005 a owl:Class .
+COB:0000026 a owl:Class .
 
-ENVO:01000813 a owl:Class .
+COB:0000031 a owl:Class .
 
-ENVO:01001110 a owl:Class .
+COB:0000033 a owl:Class .
 
-ENVO:02500000 a owl:Class .
+COB:0000034 a owl:Class .
 
-GO:0003674 a owl:Class .
+COB:0000035 a owl:Class .
 
-GO:0005634 a owl:Class .
+COB:0000037 a owl:Class .
 
-GO:0008150 a owl:Class .
+COB:0000038 a owl:Class .
 
-GO:0032991 a owl:Class .
+COB:0000042 a owl:Class .
 
-IAO:0000005 a owl:Class .
+COB:0000043 a owl:Class .
 
-IAO:0000027 a owl:Class .
+COB:0000049 a owl:Class .
 
-IAO:0000030 a owl:Class .
+COB:0000055 a owl:Class .
 
-IAO:0000033 a owl:Class .
+COB:0000057 a owl:Class .
 
-IAO:0000104 a owl:Class .
+COB:0000058 a owl:Class .
+
+COB:0000061 a owl:Class .
+
+COB:0000062 a owl:Class .
+
+COB:0000063 a owl:Class .
+
+COB:0000064 a owl:Class .
+
+COB:0000065 a owl:Class .
+
+COB:0000066 a owl:Class .
+
+COB:0000067 a owl:Class .
+
+COB:0000068 a owl:Class .
+
+COB:0000069 a owl:Class .
+
+COB:0000075 a owl:Class .
+
+COB:0000076 a owl:Class .
+
+COB:0000079 a owl:Class .
+
+COB:0000101 a owl:Class .
+
+COB:0000102 a owl:Class .
+
+COB:0000103 a owl:Class .
+
+COB:0000107 a owl:Class .
+
+COB:0000108 a owl:Class .
+
+COB:0000109 a owl:Class .
+
+COB:0000110 a owl:Class .
+
+COB:0000111 a owl:Class .
+
+COB:0000112 a owl:Class .
+
+COB:0000113 a owl:Class .
+
+COB:0000114 a owl:Class .
+
+COB:0000123 a owl:Class .
 
 IAO:0000136 a owl:ObjectProperty .
-
-IAO:0000310 a owl:Class .
-
-MOP:0000543 a owl:Class .
-
-NCBITaxon:1 a owl:Class .
-
-NCBITaxon:131567 a owl:Class .
-
-OBI:0000011 a owl:Class .
-
-OBI:0000047 a owl:Class .
-
-OBI:0000066 a owl:Class .
-
-OBI:0000070 a owl:Class .
-
-OBI:0000094 a owl:Class .
-
-OBI:0000245 a owl:Class .
-
-OBI:0000260 a owl:Class .
 
 OBI:0000293 a owl:ObjectProperty .
 
@@ -390,28 +402,6 @@ OBI:0000295 a owl:ObjectProperty .
 OBI:0000299 a owl:ObjectProperty .
 
 OBI:0000312 a owl:ObjectProperty .
-
-OBI:0001909 a owl:Class .
-
-OBI:0100026 a owl:Class .
-
-OBI:0200000 a owl:Class .
-
-OGMS:0000014 a owl:Class .
-
-OGMS:0000063 a owl:Class .
-
-OGMS:0000073 a owl:Class .
-
-PATO:0000001 a owl:Class .
-
-PATO:0000125 a owl:Class .
-
-PATO:0002193 a owl:Class .
-
-PCO:0000000 a owl:Class .
-
-PR:000000001 a owl:Class .
 
 RO:0000052 a owl:ObjectProperty .
 
@@ -425,164 +415,42 @@ RO:0000058 a owl:ObjectProperty .
 
 RO:0002333 a owl:ObjectProperty .
 
-SEPIO:0000048 a owl:Class .
-
 STATO:0000102 a owl:ObjectProperty .
 
-COB:0000017 a owl:Class ;
-    owl:equivalentClass CL:0000000 .
+COB:0000088 a owl:Class ;
+    rdfs:seeAlso CHEBI:23888 .
 
-COB:0000021 a owl:Class ;
-    owl:equivalentClass CARO:0001008 .
+COB:0000015 a owl:Class .
 
-COB:0000022 a owl:Class ;
-    owl:equivalentClass CARO:0001010,
-        NCBITaxon:1,
-        OBI:0100026 .
+COB:0000118 a owl:Class .
 
-COB:0000068 a owl:Class ;
-    owl:equivalentClass ENVO:01000813 .
+COB:0000502 a owl:Class .
 
-COB:0000123 a owl:Class ;
-    owl:equivalentClass SEPIO:0000048 .
-
-CHEBI:10545 a owl:Class .
-
-CHEBI:33250 a owl:Class .
-
-COB:0000118 a owl:Class ;
-    owl:equivalentClass CARO:0010004,
-        NCBITaxon:131567 .
-
-COB:0000502 a owl:Class ;
-    owl:equivalentClass BFO:0000020,
-        PATO:0000001 .
-
-COB:0000006 a owl:Class ;
-    owl:equivalentClass BFO:0000040 .
-
-COB:0000018 a owl:Class ;
-    owl:equivalentClass CL:0000003 .
+COB:0000022 a owl:Class .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000088 ;
-    owl:annotatedTarget DRON:0000005 ;
+    owl:annotatedSource CHEBI:33252 ;
+    owl:annotatedTarget COB:0000012 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "drug product" ;
-    sssom:subject_label "drug product" .
+    sssom:object_label "atomic nucleus" ;
+    sssom:subject_label "atomic nucleus" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000025 ;
-    owl:annotatedTarget OBI:0000245 ;
+    owl:annotatedSource PATO:0000125 ;
+    owl:annotatedTarget COB:0000003 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "organization" ;
-    sssom:subject_label "organization" .
+    sssom:object_label "mass" ;
+    sssom:subject_label "mass" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000123 ;
-    owl:annotatedTarget SEPIO:0000048 ;
+    owl:annotatedSource BFO:0000041 ;
+    owl:annotatedTarget COB:0000031 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "agent role" ;
-    sssom:subject_label "agent role" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000110 ;
-    owl:annotatedTarget OBI:0000094 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "material processing" ;
-    sssom:subject_label "material processing" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource PO:0000003 ;
-    owl:annotatedTarget COB:0000118 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "cellular organism" ;
-    sssom:subject_label "whole plant" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource CHEBI:50906 ;
-    owl:annotatedTarget COB:0000502 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "characteristic" ;
-    sssom:subject_label "role" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000103 ;
-    owl:annotatedTarget GO:0005634 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "nucleus" ;
-    sssom:subject_label "cell nucleus" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000063 ;
-    owl:annotatedTarget OGMS:0000014 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "clinical finding" ;
-    sssom:subject_label "phenotypic finding" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000114 ;
-    owl:annotatedTarget BFO:0000023 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "role" ;
-    sssom:subject_label "role" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentProperty ;
-    owl:annotatedSource COB:0000086 ;
-    owl:annotatedTarget STATO:0000102 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "executes" ;
-    sssom:subject_label "executes" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource PO:0009002 ;
-    owl:annotatedTarget COB:0000017 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "cell" ;
-    sssom:subject_label "plant cell" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentProperty ;
-    owl:annotatedSource COB:0000047 ;
-    owl:annotatedTarget BFO:0000051 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "has part" ;
-    sssom:subject_label "has part" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000015 ;
-    owl:annotatedTarget PR:000000001 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "protein" ;
-    sssom:subject_label "protein" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000062 ;
-    owl:annotatedTarget OGMS:0000073 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "diagnosis" ;
-    sssom:subject_label "disease diagnosis" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000049 ;
-    owl:annotatedTarget CHEBI:10545 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "nucleic acid" ;
-    sssom:subject_label "nucleic acid polymer" .
+    sssom:object_label "immaterial entity" ;
+    sssom:subject_label "immaterial entity" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty rdfs:subClassOf ;
@@ -594,51 +462,59 @@ COB:0000018 a owl:Class ;
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000006 ;
-    owl:annotatedTarget BFO:0000040 ;
+    owl:annotatedSource PCO:0000000 ;
+    owl:annotatedTarget COB:0000055 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "collection of organisms" ;
+    sssom:subject_label "collection of organisms" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty skos:closeMatch ;
+    owl:annotatedSource CHEBI:25367 ;
+    owl:annotatedTarget COB:0000013 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "molecular entity" ;
+    sssom:subject_label "molecule" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentProperty ;
+    owl:annotatedSource COB:0000029 ;
+    owl:annotatedTarget BFO:0000054 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "realized in" ;
+    sssom:subject_label "realized in" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentProperty ;
+    owl:annotatedSource COB:0000086 ;
+    owl:annotatedTarget STATO:0000102 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "executes" ;
+    sssom:subject_label "executes" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource DRON:0000005 ;
+    owl:annotatedTarget COB:0000088 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "drug product" ;
+    sssom:subject_label "drug product" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource IAO:0000104 ;
+    owl:annotatedTarget COB:0000079 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "plan specification" ;
+    sssom:subject_label "plan specification" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource BFO:0000040 ;
+    owl:annotatedTarget COB:0000006 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
     sssom:object_label "material entity" ;
     sssom:subject_label "material entity" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000017 ;
-    owl:annotatedTarget CL:0000000 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "cell" ;
-    sssom:subject_label "cell" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000113 ;
-    owl:annotatedTarget OBI:0000260 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "plan" ;
-    sssom:subject_label "plan" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource PO:0025606 ;
-    owl:annotatedTarget COB:0000018 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "native cell" ;
-    sssom:subject_label "native plant cell" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource COB:0000116 ;
-    owl:annotatedTarget owl:Thing ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "owl:Thing" ;
-    sssom:subject_label "cellular membrane" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000010 ;
-    owl:annotatedTarget CHEBI:10545 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "electron" ;
-    sssom:subject_label "electron" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty rdfs:seeAlso ;
@@ -650,307 +526,59 @@ COB:0000018 a owl:Class ;
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000022 ;
-    owl:annotatedTarget OBI:0100026 ;
+    owl:annotatedSource BFO:0000015 ;
+    owl:annotatedTarget COB:0000034 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "organism" ;
-    sssom:subject_label "organism" .
+    sssom:object_label "process" ;
+    sssom:subject_label "process" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000102 ;
-    owl:annotatedTarget IAO:0000027 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "data item" ;
-    sssom:subject_label "data item" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000111 ;
-    owl:annotatedTarget BFO:0000016 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "disposition" ;
-    sssom:subject_label "disposition" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000043 ;
-    owl:annotatedTarget CHEBI:33250 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "atom" ;
-    sssom:subject_label "uncharged atom" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000057 ;
-    owl:annotatedTarget BFO:0000029 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "site" ;
-    sssom:subject_label "site" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty skos:closeMatch ;
-    owl:annotatedSource COB:0000013 ;
-    owl:annotatedTarget CHEBI:25367 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "molecule" ;
-    sssom:subject_label "molecular entity" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000079 ;
-    owl:annotatedTarget IAO:0000104 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "plan specification" ;
-    sssom:subject_label "plan specification" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource COB:0000073 ;
-    owl:annotatedTarget owl:Thing ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "owl:Thing" ;
-    sssom:subject_label "gene product" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000008 ;
-    owl:annotatedTarget CHEBI:24636 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "proton" ;
-    sssom:subject_label "proton" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000019 ;
-    owl:annotatedTarget CL:0001034 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "cell in vitro" ;
-    sssom:subject_label "cell in vitro" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource GEO:000000370 ;
-    owl:annotatedTarget COB:0000068 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "geophysical entity" ;
-    sssom:subject_label "geographical entity" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000061 ;
-    owl:annotatedTarget IAO:0000030 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "information content entity" ;
-    sssom:subject_label "information" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000003 ;
-    owl:annotatedTarget PATO:0000125 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "mass" ;
-    sssom:subject_label "mass" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000018 ;
-    owl:annotatedTarget CL:0000003 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "native cell" ;
-    sssom:subject_label "native cell" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentProperty ;
-    owl:annotatedSource COB:0000074 ;
-    owl:annotatedTarget RO:0002333 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "enabled by" ;
-    sssom:subject_label "enabled by" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000118 ;
-    owl:annotatedTarget CARO:0010004 ;
+    owl:annotatedSource NCBITaxon:131567 ;
+    owl:annotatedTarget COB:0000118 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
     sssom:object_label "cellular organism" ;
-    sssom:subject_label "cellular organism" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource OBI:0000202 ;
-    owl:annotatedTarget COB:0000123 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "agent role" ;
-    sssom:subject_label "investigation agent role" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentProperty ;
-    owl:annotatedSource COB:0000029 ;
-    owl:annotatedTarget BFO:0000054 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "realized in" ;
-    sssom:subject_label "realized in" .
+    sssom:subject_label "cellular organisms" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000031 ;
-    owl:annotatedTarget BFO:0000041 ;
+    owl:annotatedSource CARO:0001010 ;
+    owl:annotatedTarget COB:0000022 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "immaterial entity" ;
-    sssom:subject_label "immaterial entity" .
+    sssom:object_label "organism" ;
+    sssom:subject_label "organism or virus or viroid" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty rdfs:subPropertyOf ;
+    owl:annotatedSource COB:0000511 ;
+    owl:annotatedTarget owl:topObjectProperty ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "topObjectProperty" ;
+    sssom:subject_label "has quantity" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000112 ;
-    owl:annotatedTarget BFO:0000034 ;
+    owl:annotatedSource CHEBI:10545 ;
+    owl:annotatedTarget COB:0000010 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "electron" ;
+    sssom:subject_label "electron" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource BFO:0000034 ;
+    owl:annotatedTarget COB:0000112 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
     sssom:object_label "function" ;
     sssom:subject_label "function" .
 
 [] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentProperty ;
-    owl:annotatedSource COB:0000071 ;
-    owl:annotatedTarget BFO:0000066 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "occurs in" ;
-    sssom:subject_label "occurs in" .
-
-[] a owl:Axiom ;
     owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource UBERON:0010000 ;
-    owl:annotatedTarget COB:0000021 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "gross anatomical part" ;
-    sssom:subject_label "multicellular anatomical structure" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000026 ;
-    owl:annotatedTarget OBI:0000047 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "processed material" ;
-    sssom:subject_label "processed material entity" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource SO:0001260 ;
-    owl:annotatedTarget COB:0000006 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "material entity" ;
-    sssom:subject_label "sequence_collection" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000009 ;
-    owl:annotatedTarget CHEBI:30222 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "neutron" ;
-    sssom:subject_label "neutron" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource COB:0000020 ;
+    owl:annotatedSource COB:0000005 ;
     owl:annotatedTarget owl:Thing ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
     sssom:object_label "owl:Thing" ;
-    sssom:subject_label "subcellular structure" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000069 ;
-    owl:annotatedTarget IAO:0000033 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "directive information entity" ;
-    sssom:subject_label "directive information entity" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource COB:0000080 ;
-    owl:annotatedTarget owl:Thing ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "owl:Thing" ;
-    sssom:subject_label "complex of molecular entities" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource UBERON:0000468 ;
-    owl:annotatedTarget COB:0000118 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "cellular organism" ;
-    sssom:subject_label "multicellular organism" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000021 ;
-    owl:annotatedTarget CARO:0001008 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "gross anatomical part" ;
-    sssom:subject_label "gross anatomical part" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000067 ;
-    owl:annotatedTarget ENVO:01001110 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "ecosystem" ;
-    sssom:subject_label "ecosystem" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000033 ;
-    owl:annotatedTarget BFO:0000017 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "realizable entity" ;
-    sssom:subject_label "realizable" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentProperty ;
-    owl:annotatedSource COB:0000040 ;
-    owl:annotatedTarget OBI:0000299 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "has_specified_output" ;
-    sssom:subject_label "has specified output" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000075 ;
-    owl:annotatedTarget GO:0032991 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "protein-containing complex" ;
-    sssom:subject_label "protein-containing macromolecular complex" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000502 ;
-    owl:annotatedTarget PATO:0000001 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "quality" ;
-    sssom:subject_label "characteristic" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000065 ;
-    owl:annotatedTarget ENVO:02500000 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "environmental system process" ;
-    sssom:subject_label "environmental process" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentProperty ;
-    owl:annotatedSource COB:0000513 ;
-    owl:annotatedTarget IAO:0000136 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "is about" ;
-    sssom:subject_label "is about" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000055 ;
-    owl:annotatedTarget PCO:0000000 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "collection of organisms" ;
-    sssom:subject_label "collection of organisms" .
+    sssom:subject_label "elementary charge" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentProperty ;
@@ -962,47 +590,171 @@ COB:0000018 a owl:Class ;
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000066 ;
-    owl:annotatedTarget MOP:0000543 ;
+    owl:annotatedSource PATO:0000001 ;
+    owl:annotatedTarget COB:0000502 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "molecular process" ;
-    sssom:subject_label "physico-chemical process" .
+    sssom:object_label "characteristic" ;
+    sssom:subject_label "quality" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000015 ;
-    owl:annotatedTarget CHEBI:16541 ;
+    owl:annotatedSource OGMS:0000073 ;
+    owl:annotatedTarget COB:0000062 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "protein polypeptide chain" ;
-    sssom:subject_label "protein" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty skos:closeMatch ;
-    owl:annotatedSource COB:0000013 ;
-    owl:annotatedTarget CHEBI:23367 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "molecular entity" ;
-    sssom:subject_label "molecular entity" .
-
-[] a owl:Ontology ;
-    dc1:license "https://creativecommons.org/publicdomain/zero/1.0/"^^xsd:anyURI ;
-    sssom:mapping_set_id "http://purl.obolibrary.org/obo/cob/components/cob-to-external.tsv"^^xsd:anyURI .
+    sssom:object_label "disease diagnosis" ;
+    sssom:subject_label "diagnosis" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentProperty ;
-    owl:annotatedSource COB:0000070 ;
-    owl:annotatedTarget RO:0000057 ;
+    owl:annotatedSource COB:0000071 ;
+    owl:annotatedTarget BFO:0000066 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "has participant" ;
-    sssom:subject_label "has participant" .
+    sssom:object_label "occurs in" ;
+    sssom:subject_label "occurs in" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000108 ;
-    owl:annotatedTarget OBI:0200000 ;
+    owl:annotatedSource OGMS:0000063 ;
+    owl:annotatedTarget COB:0000064 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "data transformation" ;
-    sssom:subject_label "data transformation" .
+    sssom:object_label "disease course" ;
+    sssom:subject_label "disease course" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource OBI:0000066 ;
+    owl:annotatedTarget COB:0000109 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "investigation" ;
+    sssom:subject_label "investigation" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource BFO:0000020 ;
+    owl:annotatedTarget COB:0000502 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "characteristic" ;
+    sssom:subject_label "specifically dependent continuant" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource OBI:0000070 ;
+    owl:annotatedTarget COB:0000107 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "assay" ;
+    sssom:subject_label "assay" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty rdfs:subClassOf ;
+    owl:annotatedSource COB:0000116 ;
+    owl:annotatedTarget owl:Thing ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "owl:Thing" ;
+    sssom:subject_label "cellular membrane" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentProperty ;
+    owl:annotatedSource COB:0000513 ;
+    owl:annotatedTarget IAO:0000136 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "is about" ;
+    sssom:subject_label "is about" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentProperty ;
+    owl:annotatedSource COB:0000036 ;
+    owl:annotatedTarget BFO:0000067 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "contains process" ;
+    sssom:subject_label "contains process" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentProperty ;
+    owl:annotatedSource COB:0000002 ;
+    owl:annotatedTarget RO:0000058 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "is concretized as" ;
+    sssom:subject_label "is concretized as" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource OBI:0000260 ;
+    owl:annotatedTarget COB:0000113 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "plan" ;
+    sssom:subject_label "plan" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource IAO:0000310 ;
+    owl:annotatedTarget COB:0000101 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "document" ;
+    sssom:subject_label "document" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource CHEBI:24867 ;
+    owl:annotatedTarget COB:0000042 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "monoatomic ion" ;
+    sssom:subject_label "monoatomic ion" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource GO:0003674 ;
+    owl:annotatedTarget COB:0000038 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "gene product or complex activity" ;
+    sssom:subject_label "molecular function" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource CARO:0010004 ;
+    owl:annotatedTarget COB:0000118 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "cellular organism" ;
+    sssom:subject_label "cellular organism" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource NCBITaxon:1 ;
+    owl:annotatedTarget COB:0000022 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "organism" ;
+    sssom:subject_label "root" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource ENVO:02500000 ;
+    owl:annotatedTarget COB:0000065 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "environmental process" ;
+    sssom:subject_label "environmental system process" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentProperty ;
+    owl:annotatedSource COB:0000074 ;
+    owl:annotatedTarget RO:0002333 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "enabled by" ;
+    sssom:subject_label "enabled by" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource CL:0001034 ;
+    owl:annotatedTarget COB:0000019 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "cell in vitro" ;
+    sssom:subject_label "cell in vitro" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource CHEBI:33250 ;
+    owl:annotatedTarget COB:0000043 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "uncharged atom" ;
+    sssom:subject_label "atom" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentProperty ;
@@ -1014,123 +766,179 @@ COB:0000018 a owl:Class ;
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000004 ;
-    owl:annotatedTarget PATO:0002193 ;
+    owl:annotatedSource IAO:0000030 ;
+    owl:annotatedTarget COB:0000061 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "electric" ;
-    sssom:subject_label "charge" .
+    sssom:object_label "information" ;
+    sssom:subject_label "information content entity" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource GO:0005634 ;
+    owl:annotatedTarget COB:0000103 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "cell nucleus" ;
+    sssom:subject_label "nucleus" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource XAO:0003012 ;
-    owl:annotatedTarget COB:0000018 ;
+    owl:annotatedSource COB:0000073 ;
+    owl:annotatedTarget owl:Thing ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "native cell" ;
-    sssom:subject_label "xenopus cell" .
+    sssom:object_label "owl:Thing" ;
+    sssom:subject_label "gene product" .
 
 [] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000038 ;
-    owl:annotatedTarget GO:0003674 ;
+    owl:annotatedProperty skos:closeMatch ;
+    owl:annotatedSource CHEBI:33250 ;
+    owl:annotatedTarget COB:0000011 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "molecular function" ;
-    sssom:subject_label "gene product or complex activity" .
+    sssom:object_label "atom" ;
+    sssom:subject_label "atom" .
 
 [] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000502 ;
-    owl:annotatedTarget BFO:0000020 ;
+    owl:annotatedProperty skos:closeMatch ;
+    owl:annotatedSource CHEBI:23367 ;
+    owl:annotatedTarget COB:0000013 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "specifically dependent continuant" ;
-    sssom:subject_label "characteristic" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000034 ;
-    owl:annotatedTarget BFO:0000015 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "process" ;
-    sssom:subject_label "process" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subPropertyOf ;
-    owl:annotatedSource COB:0000511 ;
-    owl:annotatedTarget owl:topObjectProperty ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "topObjectProperty" ;
-    sssom:subject_label "has quantity" .
+    sssom:object_label "molecular entity" ;
+    sssom:subject_label "molecular entity" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource UBERON:0000466 ;
-    owl:annotatedTarget COB:0000056 ;
+    owl:annotatedSource COB:0000080 ;
+    owl:annotatedTarget owl:Thing ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "immaterial anatomical entity" ;
-    sssom:subject_label "immaterial anatomical entity" .
+    sssom:object_label "owl:Thing" ;
+    sssom:subject_label "complex of molecular entities" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentProperty ;
-    owl:annotatedSource COB:0000039 ;
-    owl:annotatedTarget OBI:0000293 ;
+    owl:annotatedSource COB:0000023 ;
+    owl:annotatedTarget RO:0000052 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "has_specified_input" ;
-    sssom:subject_label "has specified input" .
+    sssom:object_label "inheres in" ;
+    sssom:subject_label "characteristic of" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000012 ;
-    owl:annotatedTarget CHEBI:33252 ;
+    owl:annotatedSource PR:000000001 ;
+    owl:annotatedTarget COB:0000015 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "atomic nucleus" ;
-    sssom:subject_label "atomic nucleus" .
+    sssom:object_label "protein" ;
+    sssom:subject_label "protein" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000109 ;
-    owl:annotatedTarget OBI:0000066 ;
+    owl:annotatedSource MOP:0000543 ;
+    owl:annotatedTarget COB:0000066 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "investigation" ;
-    sssom:subject_label "investigation" .
+    sssom:object_label "physico-chemical process" ;
+    sssom:subject_label "molecular process" .
 
 [] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource ZFA:0009000 ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource SEPIO:0000048 ;
+    owl:annotatedTarget COB:0000123 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "agent role" ;
+    sssom:subject_label "agent role" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource CARO:0001008 ;
+    owl:annotatedTarget COB:0000021 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "gross anatomical part" ;
+    sssom:subject_label "gross anatomical part" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource CHEBI:10545 ;
+    owl:annotatedTarget COB:0000049 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "nucleic acid polymer" ;
+    sssom:subject_label "nucleic acid" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource CL:0000003 ;
     owl:annotatedTarget COB:0000018 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
     sssom:object_label "native cell" ;
-    sssom:subject_label "zebrafish cell" .
+    sssom:subject_label "native cell" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000107 ;
-    owl:annotatedTarget OBI:0000070 ;
+    owl:annotatedSource PATO:0002193 ;
+    owl:annotatedTarget COB:0000004 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "assay" ;
-    sssom:subject_label "assay" .
+    sssom:object_label "charge" ;
+    sssom:subject_label "electric" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource IAO:0000033 ;
+    owl:annotatedTarget COB:0000069 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "directive information entity" ;
+    sssom:subject_label "directive information entity" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource GO:0032991 ;
+    owl:annotatedTarget COB:0000075 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "protein-containing macromolecular complex" ;
+    sssom:subject_label "protein-containing complex" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource OBI:0000047 ;
+    owl:annotatedTarget COB:0000026 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "processed material entity" ;
+    sssom:subject_label "processed material" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentProperty ;
-    owl:annotatedSource COB:0000002 ;
-    owl:annotatedTarget RO:0000058 ;
+    owl:annotatedSource COB:0000070 ;
+    owl:annotatedTarget RO:0000057 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "is concretized as" ;
-    sssom:subject_label "is concretized as" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource SO:0000400 ;
-    owl:annotatedTarget COB:0000502 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "characteristic" ;
-    sssom:subject_label "sequence_attribute" .
+    sssom:object_label "has participant" ;
+    sssom:subject_label "has participant" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000037 ;
-    owl:annotatedTarget GO:0008150 ;
+    owl:annotatedSource CHEBI:36342 ;
+    owl:annotatedTarget COB:0000007 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "biological process" ;
-    sssom:subject_label "biological process" .
+    sssom:object_label "subatomic particle" ;
+    sssom:subject_label "subatomic particle" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource OBI:0001909 ;
+    owl:annotatedTarget COB:0000058 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "conclusion based on data" ;
+    sssom:subject_label "conclusion based on data" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource BFO:0000016 ;
+    owl:annotatedTarget COB:0000111 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "disposition" ;
+    sssom:subject_label "disposition" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentProperty ;
+    owl:annotatedSource COB:0000040 ;
+    owl:annotatedTarget OBI:0000299 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "has_specified_output" ;
+    sssom:subject_label "has specified output" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentProperty ;
@@ -1142,147 +950,123 @@ COB:0000018 a owl:Class ;
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000101 ;
-    owl:annotatedTarget IAO:0000310 ;
+    owl:annotatedSource OBI:0100026 ;
+    owl:annotatedTarget COB:0000022 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "document" ;
-    sssom:subject_label "document" .
+    sssom:object_label "organism" ;
+    sssom:subject_label "organism" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000076 ;
-    owl:annotatedTarget IAO:0000005 ;
+    owl:annotatedSource BFO:0000017 ;
+    owl:annotatedTarget COB:0000033 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "realizable" ;
+    sssom:subject_label "realizable entity" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource OBI:0000245 ;
+    owl:annotatedTarget COB:0000025 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "organization" ;
+    sssom:subject_label "organization" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource CL:0000000 ;
+    owl:annotatedTarget COB:0000017 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "cell" ;
+    sssom:subject_label "cell" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource IAO:0000027 ;
+    owl:annotatedTarget COB:0000102 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "data item" ;
+    sssom:subject_label "data item" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource CHEBI:30222 ;
+    owl:annotatedTarget COB:0000009 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "neutron" ;
+    sssom:subject_label "neutron" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentProperty ;
+    owl:annotatedSource COB:0000039 ;
+    owl:annotatedTarget OBI:0000293 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "has_specified_input" ;
+    sssom:subject_label "has specified input" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource CHEBI:16541 ;
+    owl:annotatedTarget COB:0000015 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "protein" ;
+    sssom:subject_label "protein polypeptide chain" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource OGMS:0000014 ;
+    owl:annotatedTarget COB:0000063 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "phenotypic finding" ;
+    sssom:subject_label "clinical finding" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource CHEBI:24636 ;
+    owl:annotatedTarget COB:0000008 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "proton" ;
+    sssom:subject_label "proton" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource OBI:0200000 ;
+    owl:annotatedTarget COB:0000108 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "data transformation" ;
+    sssom:subject_label "data transformation" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource IAO:0000005 ;
+    owl:annotatedTarget COB:0000076 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
     sssom:object_label "objective specification" ;
     sssom:subject_label "objective specification" .
 
 [] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource BFO:0000029 ;
+    owl:annotatedTarget COB:0000057 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "site" ;
+    sssom:subject_label "site" .
+
+[] a owl:Axiom ;
     owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource COB:0000005 ;
+    owl:annotatedSource COB:0000020 ;
     owl:annotatedTarget owl:Thing ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
     sssom:object_label "owl:Thing" ;
-    sssom:subject_label "elementary charge" .
+    sssom:subject_label "subcellular structure" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000022 ;
-    owl:annotatedTarget CARO:0001010 ;
+    owl:annotatedSource GO:0008150 ;
+    owl:annotatedTarget COB:0000037 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "organism or virus or viroid" ;
-    sssom:subject_label "organism" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentProperty ;
-    owl:annotatedSource COB:0000023 ;
-    owl:annotatedTarget RO:0000052 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "inheres in" ;
-    sssom:subject_label "characteristic of" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource SO:0000110 ;
-    owl:annotatedTarget COB:0000006 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "material entity" ;
-    sssom:subject_label "sequence_feature" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentProperty ;
-    owl:annotatedSource COB:0000027 ;
-    owl:annotatedTarget OBI:0000295 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "is_specified_input_of" ;
-    sssom:subject_label "is specified input of" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000068 ;
-    owl:annotatedTarget ENVO:01000813 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "astronomical body part" ;
-    sssom:subject_label "geophysical entity" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000042 ;
-    owl:annotatedTarget CHEBI:24867 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "monoatomic ion" ;
-    sssom:subject_label "monoatomic ion" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource SO:0001060 ;
-    owl:annotatedTarget COB:0000006 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "material entity" ;
-    sssom:subject_label "sequence_variant" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subClassOf ;
-    owl:annotatedSource PO:0025117 ;
-    owl:annotatedTarget COB:0000056 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "immaterial anatomical entity" ;
-    sssom:subject_label "plant anatomical space" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000058 ;
-    owl:annotatedTarget OBI:0001909 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "conclusion based on data" ;
-    sssom:subject_label "conclusion based on data" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000035 ;
-    owl:annotatedTarget OBI:0000011 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "planned process" ;
-    sssom:subject_label "planned process" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentProperty ;
-    owl:annotatedSource COB:0000036 ;
-    owl:annotatedTarget BFO:0000067 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "contains process" ;
-    sssom:subject_label "contains process" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000022 ;
-    owl:annotatedTarget NCBITaxon:1 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "root" ;
-    sssom:subject_label "organism" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000118 ;
-    owl:annotatedTarget NCBITaxon:131567 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "cellular organisms" ;
-    sssom:subject_label "cellular organism" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty rdfs:subPropertyOf ;
-    owl:annotatedSource COB:0000016 ;
-    owl:annotatedTarget owl:topObjectProperty ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "topObjectProperty" ;
-    sssom:subject_label "executed by" .
-
-[] a owl:Axiom ;
-    owl:annotatedProperty skos:closeMatch ;
-    owl:annotatedSource COB:0000011 ;
-    owl:annotatedTarget CHEBI:33250 ;
-    sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "atom" ;
-    sssom:subject_label "atom" .
+    sssom:object_label "biological process" ;
+    sssom:subject_label "biological process" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentProperty ;
@@ -1293,19 +1077,67 @@ COB:0000018 a owl:Class ;
     sssom:subject_label "is specified output of" .
 
 [] a owl:Axiom ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000007 ;
-    owl:annotatedTarget CHEBI:36342 ;
+    owl:annotatedProperty rdfs:subPropertyOf ;
+    owl:annotatedSource COB:0000016 ;
+    owl:annotatedTarget owl:topObjectProperty ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "subatomic particle" ;
-    sssom:subject_label "subatomic particle" .
+    sssom:object_label "topObjectProperty" ;
+    sssom:subject_label "executed by" .
 
 [] a owl:Axiom ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource COB:0000064 ;
-    owl:annotatedTarget OGMS:0000063 ;
+    owl:annotatedSource OBI:0000094 ;
+    owl:annotatedTarget COB:0000110 ;
     sssom:mapping_justification semapv:ManualMappingCuration ;
-    sssom:object_label "disease course" ;
-    sssom:subject_label "disease course" .
+    sssom:object_label "material processing" ;
+    sssom:subject_label "material processing" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource OBI:0000011 ;
+    owl:annotatedTarget COB:0000035 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "planned process" ;
+    sssom:subject_label "planned process" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource BFO:0000023 ;
+    owl:annotatedTarget COB:0000114 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "role" ;
+    sssom:subject_label "role" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentProperty ;
+    owl:annotatedSource COB:0000047 ;
+    owl:annotatedTarget BFO:0000051 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "has part" ;
+    sssom:subject_label "has part" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource ENVO:01000813 ;
+    owl:annotatedTarget COB:0000068 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "geophysical entity" ;
+    sssom:subject_label "astronomical body part" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource ENVO:01001110 ;
+    owl:annotatedTarget COB:0000067 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "ecosystem" ;
+    sssom:subject_label "ecosystem" .
+
+[] a owl:Axiom ;
+    owl:annotatedProperty owl:equivalentProperty ;
+    owl:annotatedSource COB:0000027 ;
+    owl:annotatedTarget OBI:0000295 ;
+    sssom:mapping_justification semapv:ManualMappingCuration ;
+    sssom:object_label "is_specified_input_of" ;
+    sssom:subject_label "is specified input of" .
 
 

--- a/tests/validate_data/cob-to-external.tsv.rdf
+++ b/tests/validate_data/cob-to-external.tsv.rdf
@@ -5,7 +5,6 @@
 @prefix COB: <http://purl.obolibrary.org/obo/COB_> .
 @prefix DRON: <http://purl.obolibrary.org/obo/DRON_> .
 @prefix ENVO: <http://purl.obolibrary.org/obo/ENVO_> .
-@prefix GEO: <http://purl.obolibrary.org/obo/GEO_> .
 @prefix GO: <http://purl.obolibrary.org/obo/GO_> .
 @prefix IAO: <http://purl.obolibrary.org/obo/IAO_> .
 @prefix MOP: <http://purl.obolibrary.org/obo/MOP_> .
@@ -14,124 +13,68 @@
 @prefix OGMS: <http://purl.obolibrary.org/obo/OGMS_> .
 @prefix PATO: <http://purl.obolibrary.org/obo/PATO_> .
 @prefix PCO: <http://purl.obolibrary.org/obo/PCO_> .
-@prefix PO: <http://purl.obolibrary.org/obo/PO_> .
 @prefix PR: <http://purl.obolibrary.org/obo/PR_> .
 @prefix RO: <http://purl.obolibrary.org/obo/RO_> .
 @prefix SEPIO: <http://purl.obolibrary.org/obo/SEPIO_> .
-@prefix SO: <http://purl.obolibrary.org/obo/SO_> .
 @prefix STATO: <http://purl.obolibrary.org/obo/STATO_> .
-@prefix UBERON: <http://purl.obolibrary.org/obo/UBERON_> .
-@prefix XAO: <http://purl.obolibrary.org/obo/XAO_> .
-@prefix ZFA: <http://purl.obolibrary.org/obo/ZFA_> .
-@prefix dc1: <http://purl.org/dc/terms/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix semapv: <https://w3id.org/semapv/vocab/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix sssom: <https://w3id.org/sssom/> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-[] a sssom:MappingSet ;
-    dc1:license "https://creativecommons.org/publicdomain/zero/1.0/"^^xsd:anyURI ;
-    sssom:mapping_set_id "http://purl.obolibrary.org/obo/cob/components/cob-to-external.tsv"^^xsd:anyURI ;
+<http://purl.obolibrary.org/obo/cob/components/cob-to-external.tsv> a sssom:MappingSet ;
+    dcterms:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
     sssom:mappings [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000113 ;
-            owl:annotatedTarget OBI:0000260 ;
+            owl:annotatedSource COB:0000112 ;
+            owl:annotatedTarget BFO:0000034 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "plan" ;
-            sssom:subject_label "plan" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty rdfs:subClassOf ;
-            owl:annotatedSource COB:0000032 ;
-            owl:annotatedTarget owl:Thing ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "owl:Thing" ;
-            sssom:subject_label "geographical location" ],
+            sssom:object_label "function" ;
+            sssom:subject_label "function" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000037 ;
-            owl:annotatedTarget GO:0008150 ;
+            owl:annotatedSource COB:0000103 ;
+            owl:annotatedTarget GO:0005634 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "biological process" ;
-            sssom:subject_label "biological process" ],
+            sssom:object_label "nucleus" ;
+            sssom:subject_label "cell nucleus" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000109 ;
-            owl:annotatedTarget OBI:0000066 ;
+            owl:annotatedSource COB:0000118 ;
+            owl:annotatedTarget CARO:0010004 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "investigation" ;
-            sssom:subject_label "investigation" ],
+            sssom:object_label "cellular organism" ;
+            sssom:subject_label "cellular organism" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000114 ;
-            owl:annotatedTarget BFO:0000023 ;
+            owl:annotatedSource COB:0000019 ;
+            owl:annotatedTarget CL:0001034 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "role" ;
-            sssom:subject_label "role" ],
+            sssom:object_label "cell in vitro" ;
+            sssom:subject_label "cell in vitro" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000018 ;
-            owl:annotatedTarget CL:0000003 ;
+            owl:annotatedSource COB:0000057 ;
+            owl:annotatedTarget BFO:0000029 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "native cell" ;
-            sssom:subject_label "native cell" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty sssom:superClassOf ;
-            owl:annotatedSource COB:0000056 ;
-            owl:annotatedTarget UBERON:0000466 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "immaterial anatomical entity" ;
-            sssom:subject_label "immaterial anatomical entity" ],
+            sssom:object_label "site" ;
+            sssom:subject_label "site" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000010 ;
-            owl:annotatedTarget CHEBI:10545 ;
+            owl:annotatedSource COB:0000065 ;
+            owl:annotatedTarget ENVO:02500000 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "electron" ;
-            sssom:subject_label "electron" ],
+            sssom:object_label "environmental system process" ;
+            sssom:subject_label "environmental process" ],
         [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000069 ;
-            owl:annotatedTarget IAO:0000033 ;
+            owl:annotatedProperty rdfs:seeAlso ;
+            owl:annotatedSource COB:0000088 ;
+            owl:annotatedTarget CHEBI:23888 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "directive information entity" ;
-            sssom:subject_label "directive information entity" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000063 ;
-            owl:annotatedTarget OGMS:0000014 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "clinical finding" ;
-            sssom:subject_label "phenotypic finding" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty rdfs:subPropertyOf ;
-            owl:annotatedSource COB:0000511 ;
-            owl:annotatedTarget owl:topObjectProperty ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "topObjectProperty" ;
-            sssom:subject_label "has quantity" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000033 ;
-            owl:annotatedTarget BFO:0000017 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "realizable entity" ;
-            sssom:subject_label "realizable" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000031 ;
-            owl:annotatedTarget BFO:0000041 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "immaterial entity" ;
-            sssom:subject_label "immaterial entity" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty sssom:superClassOf ;
-            owl:annotatedSource COB:0000502 ;
-            owl:annotatedTarget SO:0000400 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "sequence_attribute" ;
-            sssom:subject_label "characteristic" ],
+            sssom:object_label "drug" ;
+            sssom:subject_label "drug product" ],
         [ a owl:Axiom ;
             owl:annotatedProperty skos:closeMatch ;
             owl:annotatedSource COB:0000013 ;
@@ -140,40 +83,19 @@
             sssom:object_label "molecular entity" ;
             sssom:subject_label "molecular entity" ],
         [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentProperty ;
-            owl:annotatedSource COB:0000039 ;
-            owl:annotatedTarget OBI:0000293 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "has_specified_input" ;
-            sssom:subject_label "has specified input" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty skos:closeMatch ;
-            owl:annotatedSource COB:0000011 ;
-            owl:annotatedTarget CHEBI:33250 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "atom" ;
-            sssom:subject_label "atom" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentProperty ;
-            owl:annotatedSource COB:0000028 ;
-            owl:annotatedTarget OBI:0000312 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "is_specified_output_of" ;
-            sssom:subject_label "is specified output of" ],
-        [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000043 ;
-            owl:annotatedTarget CHEBI:33250 ;
+            owl:annotatedSource COB:0000022 ;
+            owl:annotatedTarget OBI:0100026 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "atom" ;
-            sssom:subject_label "uncharged atom" ],
+            sssom:object_label "organism" ;
+            sssom:subject_label "organism" ],
         [ a owl:Axiom ;
-            owl:annotatedProperty rdfs:subClassOf ;
-            owl:annotatedSource COB:0000073 ;
-            owl:annotatedTarget owl:Thing ;
+            owl:annotatedProperty owl:equivalentProperty ;
+            owl:annotatedSource COB:0000036 ;
+            owl:annotatedTarget BFO:0000067 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "owl:Thing" ;
-            sssom:subject_label "gene product" ],
+            sssom:object_label "contains process" ;
+            sssom:subject_label "contains process" ],
         [ a owl:Axiom ;
             owl:annotatedProperty rdfs:subPropertyOf ;
             owl:annotatedSource COB:0000016 ;
@@ -181,6 +103,20 @@
             sssom:mapping_justification semapv:ManualMappingCuration ;
             sssom:object_label "topObjectProperty" ;
             sssom:subject_label "executed by" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty rdfs:subClassOf ;
+            owl:annotatedSource COB:0000005 ;
+            owl:annotatedTarget owl:Thing ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "owl:Thing" ;
+            sssom:subject_label "elementary charge" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty rdfs:subClassOf ;
+            owl:annotatedSource COB:0000073 ;
+            owl:annotatedTarget owl:Thing ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "owl:Thing" ;
+            sssom:subject_label "gene product" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
             owl:annotatedSource COB:0000123 ;
@@ -190,25 +126,11 @@
             sssom:subject_label "agent role" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentProperty ;
-            owl:annotatedSource COB:0000029 ;
-            owl:annotatedTarget BFO:0000054 ;
+            owl:annotatedSource COB:0000023 ;
+            owl:annotatedTarget RO:0000052 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "realized in" ;
-            sssom:subject_label "realized in" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000049 ;
-            owl:annotatedTarget CHEBI:10545 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "nucleic acid" ;
-            sssom:subject_label "nucleic acid polymer" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000107 ;
-            owl:annotatedTarget OBI:0000070 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "assay" ;
-            sssom:subject_label "assay" ],
+            sssom:object_label "inheres in" ;
+            sssom:subject_label "characteristic of" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
             owl:annotatedSource COB:0000076 ;
@@ -218,81 +140,32 @@
             sssom:subject_label "objective specification" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000111 ;
-            owl:annotatedTarget BFO:0000016 ;
+            owl:annotatedSource COB:0000031 ;
+            owl:annotatedTarget BFO:0000041 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "disposition" ;
-            sssom:subject_label "disposition" ],
+            sssom:object_label "immaterial entity" ;
+            sssom:subject_label "immaterial entity" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentProperty ;
+            owl:annotatedSource COB:0000071 ;
+            owl:annotatedTarget BFO:0000066 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "occurs in" ;
+            sssom:subject_label "occurs in" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000038 ;
-            owl:annotatedTarget GO:0003674 ;
+            owl:annotatedSource COB:0000114 ;
+            owl:annotatedTarget BFO:0000023 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "molecular function" ;
-            sssom:subject_label "gene product or complex activity" ],
+            sssom:object_label "role" ;
+            sssom:subject_label "role" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000034 ;
-            owl:annotatedTarget BFO:0000015 ;
+            owl:annotatedSource COB:0000007 ;
+            owl:annotatedTarget CHEBI:36342 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "process" ;
-            sssom:subject_label "process" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentProperty ;
-            owl:annotatedSource COB:0000512 ;
-            owl:annotatedTarget RO:0000053 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "bearer of" ;
-            sssom:subject_label "has characteristic" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentProperty ;
-            owl:annotatedSource COB:0000027 ;
-            owl:annotatedTarget OBI:0000295 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "is_specified_input_of" ;
-            sssom:subject_label "is specified input of" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000067 ;
-            owl:annotatedTarget ENVO:01001110 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "ecosystem" ;
-            sssom:subject_label "ecosystem" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty rdfs:subClassOf ;
-            owl:annotatedSource COB:0000080 ;
-            owl:annotatedTarget owl:Thing ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "owl:Thing" ;
-            sssom:subject_label "complex of molecular entities" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentProperty ;
-            owl:annotatedSource COB:0000070 ;
-            owl:annotatedTarget RO:0000057 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "has participant" ;
-            sssom:subject_label "has participant" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty sssom:superClassOf ;
-            owl:annotatedSource COB:0000006 ;
-            owl:annotatedTarget SO:0001060 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "sequence_variant" ;
-            sssom:subject_label "material entity" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty sssom:superClassOf ;
-            owl:annotatedSource COB:0000118 ;
-            owl:annotatedTarget UBERON:0000468 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "multicellular organism" ;
-            sssom:subject_label "cellular organism" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentProperty ;
-            owl:annotatedSource COB:0000002 ;
-            owl:annotatedTarget RO:0000058 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "is concretized as" ;
-            sssom:subject_label "is concretized as" ],
+            sssom:object_label "subatomic particle" ;
+            sssom:subject_label "subatomic particle" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
             owl:annotatedSource COB:0000003 ;
@@ -302,32 +175,193 @@
             sssom:subject_label "mass" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000022 ;
-            owl:annotatedTarget CARO:0001010 ;
+            owl:annotatedSource COB:0000075 ;
+            owl:annotatedTarget GO:0032991 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "organism or virus or viroid" ;
-            sssom:subject_label "organism" ],
+            sssom:object_label "protein-containing complex" ;
+            sssom:subject_label "protein-containing macromolecular complex" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000042 ;
+            owl:annotatedTarget CHEBI:24867 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "monoatomic ion" ;
+            sssom:subject_label "monoatomic ion" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000025 ;
+            owl:annotatedTarget OBI:0000245 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "organization" ;
+            sssom:subject_label "organization" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty rdfs:subClassOf ;
+            owl:annotatedSource COB:0000080 ;
+            owl:annotatedTarget owl:Thing ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "owl:Thing" ;
+            sssom:subject_label "complex of molecular entities" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentProperty ;
-            owl:annotatedSource COB:0000040 ;
-            owl:annotatedTarget OBI:0000299 ;
+            owl:annotatedSource COB:0000029 ;
+            owl:annotatedTarget BFO:0000054 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "has_specified_output" ;
-            sssom:subject_label "has specified output" ],
+            sssom:object_label "realized in" ;
+            sssom:subject_label "realized in" ],
         [ a owl:Axiom ;
-            owl:annotatedProperty sssom:superClassOf ;
-            owl:annotatedSource COB:0000021 ;
-            owl:annotatedTarget UBERON:0010000 ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000061 ;
+            owl:annotatedTarget IAO:0000030 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "multicellular anatomical structure" ;
+            sssom:object_label "information content entity" ;
+            sssom:subject_label "information" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000109 ;
+            owl:annotatedTarget OBI:0000066 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "investigation" ;
+            sssom:subject_label "investigation" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000101 ;
+            owl:annotatedTarget IAO:0000310 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "document" ;
+            sssom:subject_label "document" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000113 ;
+            owl:annotatedTarget OBI:0000260 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "plan" ;
+            sssom:subject_label "plan" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentProperty ;
+            owl:annotatedSource COB:0000002 ;
+            owl:annotatedTarget RO:0000058 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "is concretized as" ;
+            sssom:subject_label "is concretized as" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000062 ;
+            owl:annotatedTarget OGMS:0000073 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "diagnosis" ;
+            sssom:subject_label "disease diagnosis" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty skos:closeMatch ;
+            owl:annotatedSource COB:0000011 ;
+            owl:annotatedTarget CHEBI:33250 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "atom" ;
+            sssom:subject_label "atom" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000069 ;
+            owl:annotatedTarget IAO:0000033 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "directive information entity" ;
+            sssom:subject_label "directive information entity" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty rdfs:subClassOf ;
+            owl:annotatedSource COB:0000032 ;
+            owl:annotatedTarget owl:Thing ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "owl:Thing" ;
+            sssom:subject_label "geographical location" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000022 ;
+            owl:annotatedTarget NCBITaxon:1 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "root" ;
+            sssom:subject_label "organism" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000058 ;
+            owl:annotatedTarget OBI:0001909 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "conclusion based on data" ;
+            sssom:subject_label "conclusion based on data" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000067 ;
+            owl:annotatedTarget ENVO:01001110 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "ecosystem" ;
+            sssom:subject_label "ecosystem" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentProperty ;
+            owl:annotatedSource COB:0000074 ;
+            owl:annotatedTarget RO:0002333 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "enabled by" ;
+            sssom:subject_label "enabled by" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000502 ;
+            owl:annotatedTarget PATO:0000001 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "quality" ;
+            sssom:subject_label "characteristic" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentProperty ;
+            owl:annotatedSource COB:0000070 ;
+            owl:annotatedTarget RO:0000057 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "has participant" ;
+            sssom:subject_label "has participant" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000008 ;
+            owl:annotatedTarget CHEBI:24636 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "proton" ;
+            sssom:subject_label "proton" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000107 ;
+            owl:annotatedTarget OBI:0000070 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "assay" ;
+            sssom:subject_label "assay" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000043 ;
+            owl:annotatedTarget CHEBI:33250 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "atom" ;
+            sssom:subject_label "uncharged atom" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000026 ;
+            owl:annotatedTarget OBI:0000047 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "processed material" ;
+            sssom:subject_label "processed material entity" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty rdfs:subPropertyOf ;
+            owl:annotatedSource COB:0000511 ;
+            owl:annotatedTarget owl:topObjectProperty ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "topObjectProperty" ;
+            sssom:subject_label "has quantity" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000021 ;
+            owl:annotatedTarget CARO:0001008 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "gross anatomical part" ;
             sssom:subject_label "gross anatomical part" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000057 ;
-            owl:annotatedTarget BFO:0000029 ;
+            owl:annotatedSource COB:0000035 ;
+            owl:annotatedTarget OBI:0000011 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "site" ;
-            sssom:subject_label "site" ],
+            sssom:object_label "planned process" ;
+            sssom:subject_label "planned process" ],
         [ a owl:Axiom ;
             owl:annotatedProperty skos:closeMatch ;
             owl:annotatedSource COB:0000013 ;
@@ -337,46 +371,18 @@
             sssom:subject_label "molecular entity" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000118 ;
-            owl:annotatedTarget NCBITaxon:131567 ;
+            owl:annotatedSource COB:0000111 ;
+            owl:annotatedTarget BFO:0000016 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "cellular organisms" ;
-            sssom:subject_label "cellular organism" ],
+            sssom:object_label "disposition" ;
+            sssom:subject_label "disposition" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000012 ;
-            owl:annotatedTarget CHEBI:33252 ;
+            owl:annotatedSource COB:0000088 ;
+            owl:annotatedTarget DRON:0000005 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "atomic nucleus" ;
-            sssom:subject_label "atomic nucleus" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty sssom:superClassOf ;
-            owl:annotatedSource COB:0000018 ;
-            owl:annotatedTarget XAO:0003012 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "xenopus cell" ;
-            sssom:subject_label "native cell" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000004 ;
-            owl:annotatedTarget PATO:0002193 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "electric" ;
-            sssom:subject_label "charge" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000017 ;
-            owl:annotatedTarget CL:0000000 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "cell" ;
-            sssom:subject_label "cell" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentProperty ;
-            owl:annotatedSource COB:0000024 ;
-            owl:annotatedTarget RO:0000056 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "participates in" ;
-            sssom:subject_label "participates in" ],
+            sssom:object_label "drug product" ;
+            sssom:subject_label "drug product" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentProperty ;
             owl:annotatedSource COB:0000086 ;
@@ -386,67 +392,32 @@
             sssom:subject_label "executes" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000065 ;
-            owl:annotatedTarget ENVO:02500000 ;
+            owl:annotatedSource COB:0000034 ;
+            owl:annotatedTarget BFO:0000015 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "environmental system process" ;
-            sssom:subject_label "environmental process" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty sssom:superClassOf ;
-            owl:annotatedSource COB:0000017 ;
-            owl:annotatedTarget PO:0009002 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "plant cell" ;
-            sssom:subject_label "cell" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty sssom:superClassOf ;
-            owl:annotatedSource COB:0000006 ;
-            owl:annotatedTarget SO:0000110 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "sequence_feature" ;
-            sssom:subject_label "material entity" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentProperty ;
-            owl:annotatedSource COB:0000036 ;
-            owl:annotatedTarget BFO:0000067 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "contains process" ;
-            sssom:subject_label "contains process" ],
+            sssom:object_label "process" ;
+            sssom:subject_label "process" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000021 ;
-            owl:annotatedTarget CARO:0001008 ;
+            owl:annotatedSource COB:0000022 ;
+            owl:annotatedTarget CARO:0001010 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "gross anatomical part" ;
-            sssom:subject_label "gross anatomical part" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty sssom:superClassOf ;
-            owl:annotatedSource COB:0000068 ;
-            owl:annotatedTarget GEO:000000370 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "geographical entity" ;
-            sssom:subject_label "geophysical entity" ],
+            sssom:object_label "organism or virus or viroid" ;
+            sssom:subject_label "organism" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000035 ;
-            owl:annotatedTarget OBI:0000011 ;
+            owl:annotatedSource COB:0000066 ;
+            owl:annotatedTarget MOP:0000543 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "planned process" ;
-            sssom:subject_label "planned process" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty rdfs:subClassOf ;
-            owl:annotatedSource COB:0000020 ;
-            owl:annotatedTarget owl:Thing ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "owl:Thing" ;
-            sssom:subject_label "subcellular structure" ],
+            sssom:object_label "molecular process" ;
+            sssom:subject_label "physico-chemical process" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000062 ;
-            owl:annotatedTarget OGMS:0000073 ;
+            owl:annotatedSource COB:0000102 ;
+            owl:annotatedTarget IAO:0000027 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "diagnosis" ;
-            sssom:subject_label "disease diagnosis" ],
+            sssom:object_label "data item" ;
+            sssom:subject_label "data item" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
             owl:annotatedSource COB:0000068 ;
@@ -456,18 +427,11 @@
             sssom:subject_label "geophysical entity" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000058 ;
-            owl:annotatedTarget OBI:0001909 ;
+            owl:annotatedSource COB:0000502 ;
+            owl:annotatedTarget BFO:0000020 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "conclusion based on data" ;
-            sssom:subject_label "conclusion based on data" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentProperty ;
-            owl:annotatedSource COB:0000047 ;
-            owl:annotatedTarget BFO:0000051 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "has part" ;
-            sssom:subject_label "has part" ],
+            sssom:object_label "specifically dependent continuant" ;
+            sssom:subject_label "characteristic" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
             owl:annotatedSource COB:0000009 ;
@@ -477,6 +441,20 @@
             sssom:subject_label "neutron" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000010 ;
+            owl:annotatedTarget CHEBI:10545 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "electron" ;
+            sssom:subject_label "electron" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentProperty ;
+            owl:annotatedSource COB:0000047 ;
+            owl:annotatedTarget BFO:0000051 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "has part" ;
+            sssom:subject_label "has part" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
             owl:annotatedSource COB:0000015 ;
             owl:annotatedTarget PR:000000001 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
@@ -484,11 +462,32 @@
             sssom:subject_label "protein" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000064 ;
-            owl:annotatedTarget OGMS:0000063 ;
+            owl:annotatedSource COB:0000004 ;
+            owl:annotatedTarget PATO:0002193 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "disease course" ;
-            sssom:subject_label "disease course" ],
+            sssom:object_label "electric" ;
+            sssom:subject_label "charge" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentProperty ;
+            owl:annotatedSource COB:0000024 ;
+            owl:annotatedTarget RO:0000056 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "participates in" ;
+            sssom:subject_label "participates in" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty rdfs:subClassOf ;
+            owl:annotatedSource COB:0000020 ;
+            owl:annotatedTarget owl:Thing ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "owl:Thing" ;
+            sssom:subject_label "subcellular structure" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentProperty ;
+            owl:annotatedSource COB:0000028 ;
+            owl:annotatedTarget OBI:0000312 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "is_specified_output_of" ;
+            sssom:subject_label "is specified output of" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentProperty ;
             owl:annotatedSource COB:0000513 ;
@@ -504,145 +503,12 @@
             sssom:object_label "material entity" ;
             sssom:subject_label "material entity" ],
         [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000110 ;
-            owl:annotatedTarget OBI:0000094 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "material processing" ;
-            sssom:subject_label "material processing" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000502 ;
-            owl:annotatedTarget PATO:0000001 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "quality" ;
-            sssom:subject_label "characteristic" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000055 ;
-            owl:annotatedTarget PCO:0000000 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "collection of organisms" ;
-            sssom:subject_label "collection of organisms" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000022 ;
-            owl:annotatedTarget OBI:0100026 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "organism" ;
-            sssom:subject_label "organism" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000026 ;
-            owl:annotatedTarget OBI:0000047 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "processed material" ;
-            sssom:subject_label "processed material entity" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000118 ;
-            owl:annotatedTarget CARO:0010004 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "cellular organism" ;
-            sssom:subject_label "cellular organism" ],
-        [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentProperty ;
-            owl:annotatedSource COB:0000072 ;
-            owl:annotatedTarget BFO:0000050 ;
+            owl:annotatedSource COB:0000039 ;
+            owl:annotatedTarget OBI:0000293 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "part of" ;
-            sssom:subject_label "part of" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000025 ;
-            owl:annotatedTarget OBI:0000245 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "organization" ;
-            sssom:subject_label "organization" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentProperty ;
-            owl:annotatedSource COB:0000074 ;
-            owl:annotatedTarget RO:0002333 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "enabled by" ;
-            sssom:subject_label "enabled by" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000022 ;
-            owl:annotatedTarget NCBITaxon:1 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "root" ;
-            sssom:subject_label "organism" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty sssom:superClassOf ;
-            owl:annotatedSource COB:0000056 ;
-            owl:annotatedTarget PO:0025117 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "plant anatomical space" ;
-            sssom:subject_label "immaterial anatomical entity" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000112 ;
-            owl:annotatedTarget BFO:0000034 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "function" ;
-            sssom:subject_label "function" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000079 ;
-            owl:annotatedTarget IAO:0000104 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "plan specification" ;
-            sssom:subject_label "plan specification" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000088 ;
-            owl:annotatedTarget DRON:0000005 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "drug product" ;
-            sssom:subject_label "drug product" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000019 ;
-            owl:annotatedTarget CL:0001034 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "cell in vitro" ;
-            sssom:subject_label "cell in vitro" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000061 ;
-            owl:annotatedTarget IAO:0000030 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "information content entity" ;
-            sssom:subject_label "information" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000102 ;
-            owl:annotatedTarget IAO:0000027 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "data item" ;
-            sssom:subject_label "data item" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000008 ;
-            owl:annotatedTarget CHEBI:24636 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "proton" ;
-            sssom:subject_label "proton" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty rdfs:subClassOf ;
-            owl:annotatedSource COB:0000005 ;
-            owl:annotatedTarget owl:Thing ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "owl:Thing" ;
-            sssom:subject_label "elementary charge" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000007 ;
-            owl:annotatedTarget CHEBI:36342 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "subatomic particle" ;
-            sssom:subject_label "subatomic particle" ],
+            sssom:object_label "has_specified_input" ;
+            sssom:subject_label "has specified input" ],
         [ a owl:Axiom ;
             owl:annotatedProperty rdfs:subClassOf ;
             owl:annotatedSource COB:0000116 ;
@@ -652,18 +518,25 @@
             sssom:subject_label "cellular membrane" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000103 ;
-            owl:annotatedTarget GO:0005634 ;
+            owl:annotatedSource COB:0000049 ;
+            owl:annotatedTarget CHEBI:10545 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "nucleus" ;
-            sssom:subject_label "cell nucleus" ],
+            sssom:object_label "nucleic acid" ;
+            sssom:subject_label "nucleic acid polymer" ],
         [ a owl:Axiom ;
-            owl:annotatedProperty sssom:superClassOf ;
-            owl:annotatedSource COB:0000118 ;
-            owl:annotatedTarget PO:0000003 ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000110 ;
+            owl:annotatedTarget OBI:0000094 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "whole plant" ;
-            sssom:subject_label "cellular organism" ],
+            sssom:object_label "material processing" ;
+            sssom:subject_label "material processing" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000017 ;
+            owl:annotatedTarget CL:0000000 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "cell" ;
+            sssom:subject_label "cell" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
             owl:annotatedSource COB:0000108 ;
@@ -672,6 +545,69 @@
             sssom:object_label "data transformation" ;
             sssom:subject_label "data transformation" ],
         [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentProperty ;
+            owl:annotatedSource COB:0000512 ;
+            owl:annotatedTarget RO:0000053 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "bearer of" ;
+            sssom:subject_label "has characteristic" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000063 ;
+            owl:annotatedTarget OGMS:0000014 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "clinical finding" ;
+            sssom:subject_label "phenotypic finding" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000064 ;
+            owl:annotatedTarget OGMS:0000063 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "disease course" ;
+            sssom:subject_label "disease course" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000018 ;
+            owl:annotatedTarget CL:0000003 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "native cell" ;
+            sssom:subject_label "native cell" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentProperty ;
+            owl:annotatedSource COB:0000072 ;
+            owl:annotatedTarget BFO:0000050 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "part of" ;
+            sssom:subject_label "part of" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000118 ;
+            owl:annotatedTarget NCBITaxon:131567 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "cellular organisms" ;
+            sssom:subject_label "cellular organism" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentProperty ;
+            owl:annotatedSource COB:0000040 ;
+            owl:annotatedTarget OBI:0000299 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "has_specified_output" ;
+            sssom:subject_label "has specified output" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000037 ;
+            owl:annotatedTarget GO:0008150 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "biological process" ;
+            sssom:subject_label "biological process" ],
+        [ a owl:Axiom ;
+            owl:annotatedProperty owl:equivalentClass ;
+            owl:annotatedSource COB:0000079 ;
+            owl:annotatedTarget IAO:0000104 ;
+            sssom:mapping_justification semapv:ManualMappingCuration ;
+            sssom:object_label "plan specification" ;
+            sssom:subject_label "plan specification" ],
+        [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
             owl:annotatedSource COB:0000015 ;
             owl:annotatedTarget CHEBI:16541 ;
@@ -679,95 +615,39 @@
             sssom:object_label "protein polypeptide chain" ;
             sssom:subject_label "protein" ],
         [ a owl:Axiom ;
-            owl:annotatedProperty sssom:superClassOf ;
-            owl:annotatedSource COB:0000123 ;
-            owl:annotatedTarget OBI:0000202 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "investigation agent role" ;
-            sssom:subject_label "agent role" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty sssom:superClassOf ;
-            owl:annotatedSource COB:0000006 ;
-            owl:annotatedTarget SO:0001260 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "sequence_collection" ;
-            sssom:subject_label "material entity" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty sssom:superClassOf ;
-            owl:annotatedSource COB:0000018 ;
-            owl:annotatedTarget ZFA:0009000 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "zebrafish cell" ;
-            sssom:subject_label "native cell" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty sssom:superClassOf ;
-            owl:annotatedSource COB:0000018 ;
-            owl:annotatedTarget PO:0025606 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "native plant cell" ;
-            sssom:subject_label "native cell" ],
-        [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentProperty ;
-            owl:annotatedSource COB:0000071 ;
-            owl:annotatedTarget BFO:0000066 ;
+            owl:annotatedSource COB:0000027 ;
+            owl:annotatedTarget OBI:0000295 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "occurs in" ;
-            sssom:subject_label "occurs in" ],
+            sssom:object_label "is_specified_input_of" ;
+            sssom:subject_label "is specified input of" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000042 ;
-            owl:annotatedTarget CHEBI:24867 ;
+            owl:annotatedSource COB:0000012 ;
+            owl:annotatedTarget CHEBI:33252 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "monoatomic ion" ;
-            sssom:subject_label "monoatomic ion" ],
+            sssom:object_label "atomic nucleus" ;
+            sssom:subject_label "atomic nucleus" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000066 ;
-            owl:annotatedTarget MOP:0000543 ;
+            owl:annotatedSource COB:0000055 ;
+            owl:annotatedTarget PCO:0000000 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "molecular process" ;
-            sssom:subject_label "physico-chemical process" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty sssom:superClassOf ;
-            owl:annotatedSource COB:0000502 ;
-            owl:annotatedTarget CHEBI:50906 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "role" ;
-            sssom:subject_label "characteristic" ],
+            sssom:object_label "collection of organisms" ;
+            sssom:subject_label "collection of organisms" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000502 ;
-            owl:annotatedTarget BFO:0000020 ;
+            owl:annotatedSource COB:0000033 ;
+            owl:annotatedTarget BFO:0000017 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "specifically dependent continuant" ;
-            sssom:subject_label "characteristic" ],
+            sssom:object_label "realizable entity" ;
+            sssom:subject_label "realizable" ],
         [ a owl:Axiom ;
             owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000101 ;
-            owl:annotatedTarget IAO:0000310 ;
+            owl:annotatedSource COB:0000038 ;
+            owl:annotatedTarget GO:0003674 ;
             sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "document" ;
-            sssom:subject_label "document" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentClass ;
-            owl:annotatedSource COB:0000075 ;
-            owl:annotatedTarget GO:0032991 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "protein-containing complex" ;
-            sssom:subject_label "protein-containing macromolecular complex" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty owl:equivalentProperty ;
-            owl:annotatedSource COB:0000023 ;
-            owl:annotatedTarget RO:0000052 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "inheres in" ;
-            sssom:subject_label "characteristic of" ],
-        [ a owl:Axiom ;
-            owl:annotatedProperty rdfs:seeAlso ;
-            owl:annotatedSource COB:0000088 ;
-            owl:annotatedTarget CHEBI:23888 ;
-            sssom:mapping_justification semapv:ManualMappingCuration ;
-            sssom:object_label "drug" ;
-            sssom:subject_label "drug product" ] .
+            sssom:object_label "molecular function" ;
+            sssom:subject_label "gene product or complex activity" ] .
 
 

--- a/tests/validate_data/cob-to-external.tsv.tsv
+++ b/tests/validate_data/cob-to-external.tsv.tsv
@@ -38,9 +38,6 @@ COB:0000003	mass	owl:equivalentClass	PATO:0000125	mass	semapv:ManualMappingCurat
 COB:0000004	charge	owl:equivalentClass	PATO:0002193	electric	semapv:ManualMappingCuration
 COB:0000005	elementary charge	rdfs:subClassOf	owl:Thing	owl:Thing	semapv:ManualMappingCuration
 COB:0000006	material entity	owl:equivalentClass	BFO:0000040	material entity	semapv:ManualMappingCuration
-COB:0000006	material entity	sssom:superClassOf	SO:0000110	sequence_feature	semapv:ManualMappingCuration
-COB:0000006	material entity	sssom:superClassOf	SO:0001060	sequence_variant	semapv:ManualMappingCuration
-COB:0000006	material entity	sssom:superClassOf	SO:0001260	sequence_collection	semapv:ManualMappingCuration
 COB:0000007	subatomic particle	owl:equivalentClass	CHEBI:36342	subatomic particle	semapv:ManualMappingCuration
 COB:0000008	proton	owl:equivalentClass	CHEBI:24636	proton	semapv:ManualMappingCuration
 COB:0000009	neutron	owl:equivalentClass	CHEBI:30222	neutron	semapv:ManualMappingCuration
@@ -53,15 +50,10 @@ COB:0000015	protein	owl:equivalentClass	CHEBI:16541	protein polypeptide chain	se
 COB:0000015	protein	owl:equivalentClass	PR:000000001	protein	semapv:ManualMappingCuration
 COB:0000016	executed by	rdfs:subPropertyOf	owl:topObjectProperty	topObjectProperty	semapv:ManualMappingCuration
 COB:0000017	cell	owl:equivalentClass	CL:0000000	cell	semapv:ManualMappingCuration
-COB:0000017	cell	sssom:superClassOf	PO:0009002	plant cell	semapv:ManualMappingCuration
 COB:0000018	native cell	owl:equivalentClass	CL:0000003	native cell	semapv:ManualMappingCuration
-COB:0000018	native cell	sssom:superClassOf	PO:0025606	native plant cell	semapv:ManualMappingCuration
-COB:0000018	native cell	sssom:superClassOf	XAO:0003012	xenopus cell	semapv:ManualMappingCuration
-COB:0000018	native cell	sssom:superClassOf	ZFA:0009000	zebrafish cell	semapv:ManualMappingCuration
 COB:0000019	cell in vitro	owl:equivalentClass	CL:0001034	cell in vitro	semapv:ManualMappingCuration
 COB:0000020	subcellular structure	rdfs:subClassOf	owl:Thing	owl:Thing	semapv:ManualMappingCuration
 COB:0000021	gross anatomical part	owl:equivalentClass	CARO:0001008	gross anatomical part	semapv:ManualMappingCuration
-COB:0000021	gross anatomical part	sssom:superClassOf	UBERON:0010000	multicellular anatomical structure	semapv:ManualMappingCuration
 COB:0000022	organism	owl:equivalentClass	CARO:0001010	organism or virus or viroid	semapv:ManualMappingCuration
 COB:0000022	organism	owl:equivalentClass	NCBITaxon:1	root	semapv:ManualMappingCuration
 COB:0000022	organism	owl:equivalentClass	OBI:0100026	organism	semapv:ManualMappingCuration
@@ -87,8 +79,6 @@ COB:0000043	uncharged atom	owl:equivalentClass	CHEBI:33250	atom	semapv:ManualMap
 COB:0000047	has part	owl:equivalentProperty	BFO:0000051	has part	semapv:ManualMappingCuration
 COB:0000049	nucleic acid polymer	owl:equivalentClass	CHEBI:10545	nucleic acid	semapv:ManualMappingCuration
 COB:0000055	collection of organisms	owl:equivalentClass	PCO:0000000	collection of organisms	semapv:ManualMappingCuration
-COB:0000056	immaterial anatomical entity	sssom:superClassOf	PO:0025117	plant anatomical space	semapv:ManualMappingCuration
-COB:0000056	immaterial anatomical entity	sssom:superClassOf	UBERON:0000466	immaterial anatomical entity	semapv:ManualMappingCuration
 COB:0000057	site	owl:equivalentClass	BFO:0000029	site	semapv:ManualMappingCuration
 COB:0000058	conclusion based on data	owl:equivalentClass	OBI:0001909	conclusion based on data	semapv:ManualMappingCuration
 COB:0000061	information	owl:equivalentClass	IAO:0000030	information content entity	semapv:ManualMappingCuration
@@ -99,7 +89,6 @@ COB:0000065	environmental process	owl:equivalentClass	ENVO:02500000	environmenta
 COB:0000066	physico-chemical process	owl:equivalentClass	MOP:0000543	molecular process	semapv:ManualMappingCuration
 COB:0000067	ecosystem	owl:equivalentClass	ENVO:01001110	ecosystem	semapv:ManualMappingCuration
 COB:0000068	geophysical entity	owl:equivalentClass	ENVO:01000813	astronomical body part	semapv:ManualMappingCuration
-COB:0000068	geophysical entity	sssom:superClassOf	GEO:000000370	geographical entity	semapv:ManualMappingCuration
 COB:0000069	directive information entity	owl:equivalentClass	IAO:0000033	directive information entity	semapv:ManualMappingCuration
 COB:0000070	has participant	owl:equivalentProperty	RO:0000057	has participant	semapv:ManualMappingCuration
 COB:0000071	occurs in	owl:equivalentProperty	BFO:0000066	occurs in	semapv:ManualMappingCuration
@@ -127,15 +116,9 @@ COB:0000114	role	owl:equivalentClass	BFO:0000023	role	semapv:ManualMappingCurati
 COB:0000116	cellular membrane	rdfs:subClassOf	owl:Thing	owl:Thing	semapv:ManualMappingCuration
 COB:0000118	cellular organism	owl:equivalentClass	CARO:0010004	cellular organism	semapv:ManualMappingCuration
 COB:0000118	cellular organism	owl:equivalentClass	NCBITaxon:131567	cellular organisms	semapv:ManualMappingCuration
-COB:0000118	cellular organism	sssom:superClassOf	PO:0000003	whole plant	semapv:ManualMappingCuration
-COB:0000118	cellular organism	sssom:superClassOf	UBERON:0000468	multicellular organism	semapv:ManualMappingCuration
 COB:0000123	agent role	owl:equivalentClass	SEPIO:0000048	agent role	semapv:ManualMappingCuration
-COB:0000123	agent role	sssom:superClassOf	OBI:0000202	investigation agent role	semapv:ManualMappingCuration
 COB:0000502	characteristic	owl:equivalentClass	BFO:0000020	specifically dependent continuant	semapv:ManualMappingCuration
 COB:0000502	characteristic	owl:equivalentClass	PATO:0000001	quality	semapv:ManualMappingCuration
-COB:0000502	characteristic	sssom:superClassOf	CHEBI:50906	role	semapv:ManualMappingCuration
-COB:0000502	characteristic	sssom:superClassOf	SO:0000400	sequence_attribute	semapv:ManualMappingCuration
 COB:0000511	has quantity	rdfs:subPropertyOf	owl:topObjectProperty	topObjectProperty	semapv:ManualMappingCuration
 COB:0000512	has characteristic	owl:equivalentProperty	RO:0000053	bearer of	semapv:ManualMappingCuration
 COB:0000513	is about	owl:equivalentProperty	IAO:0000136	is about	semapv:ManualMappingCuration
-


### PR DESCRIPTION
The `rdfs:subClassOf` predicate has no standard inverse predicate, but for a while SSSOM-Py has been treating it as being the inverse of a completely made-up `sssom:superClassOf` predicate, which has never been documented anywhere.

This used to be needed specifically for the COB ontology, but this is no longer the case and this predicate should now disappear. It is completely unknown outside of SSSOM-Py.

Closes https://github.com/mapping-commons/sssom/issues/559