### PR TITLE
cli: Accept `-h` as a short option for `--help`.

### DIFF
--- a/src/sssom/cli.py
+++ b/src/sssom/cli.py
@@ -119,7 +119,7 @@ condense_option = click.option(
 )
 
 
-@click.group()
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option("-v", "--verbose", count=True)
 @click.option("-q", "--quiet")
 @click.version_option(__version__)


### PR DESCRIPTION
Most command-line tools accepts `-h` as a short alias for `--help`. However by default Click only accepts the long option, and must be explicitly configured to accept the short option. This PR does exactly that.

This is to avoid the following sequence:

```sh
$ sssom -h
Usage: sssom [OPTIONS] COMMAND [ARGS]...
Try 'sssom --help' for help.

Error: No such option: -h

$ sssom --help
Usage: sssom [OPTIONS] COMMAND [ARGS]...

  Run the SSSOM CLI.

Options:
  -v, --verbose
  -q, --quiet TEXT
  --version         Show the version and exit.
  --help            Show this message and exit.

Commands:
  annotate            Annotate metadata of a mapping set.
  cliquesummary       Calculate summaries for each clique in a SSSOM file.
  [...]
```